### PR TITLE
GRIPPS: Fix NullPointerException when -output_vcf is a file name in CWD

### DIFF
--- a/gripss/src/main/kotlin/com/hartwig/hmftools/gripss/GripssConfig.kt
+++ b/gripss/src/main/kotlin/com/hartwig/hmftools/gripss/GripssConfig.kt
@@ -59,7 +59,7 @@ data class GripssConfig(
             val reference = cmd.getOptionValue(REFERENCE, Strings.EMPTY)
             val tumor = cmd.getOptionValue(TUMOR, Strings.EMPTY)
 
-            val outputDir = File(outputVcf).parentFile
+            val outputDir = File(outputVcf).absoluteFile.parentFile
             if (!outputDir.exists() && !outputDir.mkdirs()) {
                 throw IOException("Unable to write to directory ${outputDir.absolutePath}")
             }


### PR DESCRIPTION
GRIPPS's failing when the input VCF is a relative file path in CWD, e.g. `-output_vcf gridss.somatic.vcf.gz`, because `File("gridss.somatic.vcf.gz").parentFile` is null.

Adding an extra `absoluteFile` fixes the issue.

Vlad