### PR TITLE
GRIPSS: support tumor-only?

### DIFF
--- a/gripss/src/main/kotlin/com/hartwig/hmftools/gripss/GripssApplication.kt
+++ b/gripss/src/main/kotlin/com/hartwig/hmftools/gripss/GripssApplication.kt
@@ -73,9 +73,12 @@ class GripssApplication(private val config: GripssConfig) : AutoCloseable, Runna
         logger.info("Config ${config.filterConfig}")
         val contigComparator = ContigComparator(dictionary)
 
-        val sampleNames =  inputHeader.genotypeSamples!!
-        val sampleOrdinals = sampleOrdinals(sampleNames);
-        logger.info("Using ${sampleNames[sampleOrdinals.first]} as reference, ${sampleNames[sampleOrdinals.second]} as tumor")
+        val sampleNames = inputHeader.genotypeSamples!!
+        val sampleOrdinals = sampleOrdinals(sampleNames)
+        if (sampleNames.size == 2) {
+            logger.info("Using ${sampleNames[sampleOrdinals.first]} as reference, " +
+                    "${sampleNames[sampleOrdinals.second]} as tumor")
+        }
 
         logger.info("Reading hotspot file: ${config.pairedHotspotFile}")
         val hotspotStore = LocationStore(contigComparator, listOf(), Breakpoint.fromBedpeFile(config.pairedHotspotFile, contigComparator))
@@ -135,6 +138,10 @@ class GripssApplication(private val config: GripssConfig) : AutoCloseable, Runna
     }
 
     private fun sampleOrdinals(sampleNames: List<String>): Pair<Int, Int> {
+        if (sampleNames.size == 1) {  // Tumor-only
+            return Pair(-1, 0)
+        }
+
         val normalOrdinal = if (config.reference.isEmpty()) 0 else sampleNames.indexOf(config.reference)
         if (normalOrdinal < 0) {
             throw IllegalArgumentException("Unable to locate sample ${config.reference} in supplied VCF")

--- a/gripss/src/main/kotlin/com/hartwig/hmftools/gripss/StructuralVariantContext.kt
+++ b/gripss/src/main/kotlin/com/hartwig/hmftools/gripss/StructuralVariantContext.kt
@@ -27,7 +27,7 @@ class StructuralVariantContext(val context: VariantContext, private val normalOr
     }
 
     private val remoteConfidenceInterval = context.remoteConfidenceInterval()
-    private val normalGenotype = context.getGenotype(normalOrdinal)
+    private val normalGenotype = if (normalOrdinal != -1) context.getGenotype(normalOrdinal) else null
     private val tumorGenotype = context.getGenotype(tumorOrdinal)
 
     val contig = context.contig!!
@@ -313,15 +313,21 @@ class StructuralVariantContext(val context: VariantContext, private val normalOr
     }
 
     fun shortSplitReadNormalFilter(): Boolean {
+        if (normalGenotype == null) {
+            return false
+        }
+
         return isShort && normalGenotype.splitRead() > 0
     }
 
     fun discordantPairSupportFilter(): Boolean {
         return !isSingle && !isShort
-                && normalGenotype.readPairs() == 0
-                && normalGenotype.assemblyReadPairs() == 0
                 && tumorGenotype.readPairs() == 0
                 && tumorGenotype.assemblyReadPairs() == 0
+                && (normalGenotype == null ||
+                    normalGenotype.readPairs() == 0
+                    && normalGenotype.assemblyReadPairs() == 0
+                )
     }
 
     fun impreciseFilter(): Boolean {
@@ -345,6 +351,10 @@ class StructuralVariantContext(val context: VariantContext, private val normalOr
     }
 
     fun normalCoverageFilter(minNormalCoverage: Int): Boolean {
+        if (normalGenotype == null) {
+            return false
+        }
+
         val supportingFragments = normalGenotype.fragmentSupport(isSingle)
         val ref = normalGenotype.refSupportRead()
         val refPair = normalGenotype.refSupportReadPair()
@@ -353,6 +363,10 @@ class StructuralVariantContext(val context: VariantContext, private val normalOr
     }
 
     fun normalSupportAbsoluteFilter(maxNormalAbsoluteSupport: Int): Boolean {
+        if (normalGenotype == null) {
+            return false
+        }
+
         val normalSupport = normalGenotype.fragmentSupport(isSingle)
         return normalSupport > maxNormalAbsoluteSupport
     }
@@ -362,6 +376,10 @@ class StructuralVariantContext(val context: VariantContext, private val normalOr
     }
 
     fun normalSupportRelativeFilter(maxNormalRelativeSupport: Double, comparator: ContigComparator): Boolean {
+        if (normalGenotype == null) {
+            return false
+        }
+
         if (isSingle && context.hasViralSequenceAlignment(comparator)) {
             return false
         }


### PR DESCRIPTION
I know your pipeline is designed for tumor/normal paired variant calling; but sometimes we have tumor-only cases and I still find GRIDSS useful. So I slightly modified GRIPSS to work for tumor-only VCFs. 

Feel free to reject the PR if you didn't plan to support this case or if you wanted to implement it better (I'm not even sure if my way is correct!). Just wanted to bring this use case to you.

By the way, really appreciate the usage of Kotlin!

Vlad
