### PR TITLE
DEV-1853 Create list of runcontexts from json when specified

### DIFF
--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/ClinicalAlgoConfig.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/ClinicalAlgoConfig.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 public interface ClinicalAlgoConfig {
 
     String RUNS_DIRECTORY = "runs_dir";
+    String RUNS_JSON = "runs_json";
     String PIPELINE_VERSION_FILE = "pipeline_version_file";
 
     String CPCT_ECRF_FILE = "cpct_ecrf";
@@ -50,6 +51,7 @@ public interface ClinicalAlgoConfig {
         options.addOption(RUNS_DIRECTORY,
                 true,
                 "Path towards the folder containing patient runs that are considered part of HMF database.");
+        options.addOption(RUNS_JSON, true, "Path towards a JSON file containing patient runs that are considered part of HMF database.");
         options.addOption(PIPELINE_VERSION_FILE, true, "Path towards the pipeline version");
 
         options.addOption(CPCT_ECRF_FILE, true, "Path towards the CPCT ecrf file.");
@@ -83,10 +85,13 @@ public interface ClinicalAlgoConfig {
         return options;
     }
 
-    @NotNull
+    @Nullable
     String runsDirectory();
 
-    @NotNull
+    @Nullable
+    String runsJson();
+
+    @Nullable
     String pipelineVersionFile();
 
     @NotNull

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/SampleLoader.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/SampleLoader.java
@@ -55,21 +55,18 @@ public class SampleLoader {
     @NotNull
     private List<RunContext> extractRunContextsFromDirectoryOrJson(final @NotNull ClinicalAlgoConfig config, final String runsDirectory,
             final String runsJson) throws IOException {
-        List<RunContext> runContexts;
-        if (runsDirectory != null) {
+        if (runsDirectory != null && runsJson == null) {
             String pipelineVersionFile = config.pipelineVersionFile();
             if (pipelineVersionFile != null) {
                 LOGGER.info("   Loading sequence runs from {}", runsDirectory);
-                runContexts = loadRunContextsFromDirectory(runsDirectory, pipelineVersionFile);
+                return loadRunContextsFromDirectory(runsDirectory, pipelineVersionFile);
             } else {
                 throw new IllegalArgumentException("Cannot load from a runs directory if no pipeline version file given");
             }
-        } else if (runsJson != null) {
-            runContexts = loadRunContextsFromJson(runsJson);
-        } else {
-            throw new IllegalStateException("Either a runs directory or runs json must be specified");
+        } else if (runsJson != null && runsDirectory == null) {
+            return loadRunContextsFromJson(runsJson);
         }
-        return runContexts;
+        throw new IllegalStateException("Either a runs directory or runs json must be specified, and not both");
     }
 
     @NotNull

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/SampleLoader.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/SampleLoader.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SampleLoader {
 
@@ -53,8 +54,8 @@ public class SampleLoader {
     }
 
     @NotNull
-    private List<RunContext> extractRunContextsFromDirectoryOrJson(final @NotNull ClinicalAlgoConfig config, final String runsDirectory,
-            final String runsJson) throws IOException {
+    private List<RunContext> extractRunContextsFromDirectoryOrJson(@NotNull ClinicalAlgoConfig config, @Nullable String runsDirectory,
+            @Nullable String runsJson) throws IOException {
         if (runsDirectory != null && runsJson == null) {
             String pipelineVersionFile = config.pipelineVersionFile();
             if (pipelineVersionFile != null) {

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/context/ProductionRunContextFactory.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/context/ProductionRunContextFactory.java
@@ -20,5 +20,4 @@ public final class ProductionRunContextFactory {
         }
         return runContextFromMetaData;
     }
-
 }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/context/ProductionRunContextFactory.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/context/ProductionRunContextFactory.java
@@ -20,4 +20,5 @@ public final class ProductionRunContextFactory {
         }
         return runContextFromMetaData;
     }
+
 }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReader.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReader.java
@@ -14,6 +14,7 @@ import com.google.gson.GsonBuilder;
 import com.hartwig.hmftools.common.runcontext.RunContext;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class RunsJsonReader {
 
@@ -34,30 +35,35 @@ public class RunsJsonReader {
     }
 
     @SuppressWarnings("UnstableApiUsage")
+    @NotNull
     private static Type listOfRunContext() {
         return new TypeToken<ArrayList<JsonRunContext>>() {
         }.getType();
     }
 
     static class JsonRunContext implements RunContext {
+        @Nullable
         private String setName;
+        @Nullable
         private String refSample;
+        @Nullable
         private String tumorSample;
+        @Nullable
         private String tumorBarcodeSample;
 
-        public void setSetName(final String setName) {
+        public void setSetName(@NotNull String setName) {
             this.setName = setName;
         }
 
-        public void setRefSample(final String refSample) {
+        public void setRefSample(@NotNull String refSample) {
             this.refSample = refSample;
         }
 
-        public void setTumorSample(final String tumorSample) {
+        public void setTumorSample(@NotNull String tumorSample) {
             this.tumorSample = tumorSample;
         }
 
-        public void setTumorBarcodeSample(final String tumorBarcodeSample) {
+        public void setTumorBarcodeSample(@NotNull String tumorBarcodeSample) {
             this.tumorBarcodeSample = tumorBarcodeSample;
         }
 
@@ -70,25 +76,33 @@ public class RunsJsonReader {
         @NotNull
         @Override
         public String setName() {
-            return setName;
+            return throwWhenNull(setName, "setName");
         }
 
         @NotNull
         @Override
         public String refSample() {
-            return refSample;
+            return throwWhenNull(refSample, "refSample");
         }
 
         @NotNull
         @Override
         public String tumorSample() {
-            return tumorSample;
+            return throwWhenNull(tumorSample, "tumorSample");
         }
 
         @NotNull
         @Override
         public String tumorBarcodeSample() {
-            return tumorBarcodeSample;
+            return throwWhenNull(tumorBarcodeSample, "tumorBarcodeSample");
+        }
+
+        @NotNull
+        static String throwWhenNull(@Nullable String nullable, @NotNull String field) {
+            if (nullable == null) {
+                throw new IllegalStateException(String.format("Field [%s] was null in the input JSON", field));
+            }
+            return nullable;
         }
     }
 }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReader.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReader.java
@@ -1,0 +1,94 @@
+package com.hartwig.hmftools.patientdb.clinical.readers;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.hartwig.hmftools.common.runcontext.RunContext;
+
+import org.jetbrains.annotations.NotNull;
+
+public class RunsJsonReader {
+
+    private static final Gson GSON = new GsonBuilder().create();
+
+    @NotNull
+    public static List<RunContext> extractRunContexts(@NotNull final File jsonFile) {
+        try {
+            List<RunContext> runContexts = GSON.fromJson(new FileReader(jsonFile), listOfRunContext());
+            if (runContexts != null) {
+                return runContexts;
+            } else {
+                throw new IllegalArgumentException(String.format("File [%s] did not contain run contexts", jsonFile.getPath()));
+            }
+        } catch (FileNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private static Type listOfRunContext() {
+        return new TypeToken<ArrayList<JsonRunContext>>() {
+        }.getType();
+    }
+
+    static class JsonRunContext implements RunContext {
+        private String setName;
+        private String refSample;
+        private String tumorSample;
+        private String tumorBarcodeSample;
+
+        public void setSetName(final String setName) {
+            this.setName = setName;
+        }
+
+        public void setRefSample(final String refSample) {
+            this.refSample = refSample;
+        }
+
+        public void setTumorSample(final String tumorSample) {
+            this.tumorSample = tumorSample;
+        }
+
+        public void setTumorBarcodeSample(final String tumorBarcodeSample) {
+            this.tumorBarcodeSample = tumorBarcodeSample;
+        }
+
+        @NotNull
+        @Override
+        public String runDirectory() {
+            return "json_file";
+        }
+
+        @NotNull
+        @Override
+        public String setName() {
+            return setName;
+        }
+
+        @NotNull
+        @Override
+        public String refSample() {
+            return refSample;
+        }
+
+        @NotNull
+        @Override
+        public String tumorSample() {
+            return tumorSample;
+        }
+
+        @NotNull
+        @Override
+        public String tumorBarcodeSample() {
+            return tumorBarcodeSample;
+        }
+    }
+}

--- a/patient-db/src/test/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReaderTest.java
+++ b/patient-db/src/test/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReaderTest.java
@@ -1,0 +1,44 @@
+package com.hartwig.hmftools.patientdb.clinical.readers;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.List;
+
+import com.google.common.io.Resources;
+import com.hartwig.hmftools.common.runcontext.RunContext;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+public class RunsJsonReaderTest {
+
+    @SuppressWarnings("UnstableApiUsage")
+    private static final String JSON_DIR = Resources.getResource("context" + File.separator + "RunJson").getPath();
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIllegalArgumentIfFileDoesntExist() {
+        RunsJsonReader.extractRunContexts(new File("/does/not/exist"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIllegalArgumentOnEmptyFile() {
+        RunsJsonReader.extractRunContexts(testJson("empty.json"));
+    }
+
+    @Test
+    public void throwsIllegalArgumentOnUnparseableFile() {
+        RunsJsonReader.extractRunContexts(testJson("missing_fields.json"));
+    }
+
+    @Test
+    public void readsRunContextsFromJsonFile() {
+        List<RunContext> runContexts = RunsJsonReader.extractRunContexts(testJson("two_somatic.json"));
+        assertEquals(2, runContexts.size());
+    }
+
+    @NotNull
+    private File testJson(final String filename) {
+        return new File(JSON_DIR + File.separator + filename);
+    }
+}

--- a/patient-db/src/test/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReaderTest.java
+++ b/patient-db/src/test/java/com/hartwig/hmftools/patientdb/clinical/readers/RunsJsonReaderTest.java
@@ -27,11 +27,6 @@ public class RunsJsonReaderTest {
     }
 
     @Test
-    public void throwsIllegalArgumentOnUnparseableFile() {
-        RunsJsonReader.extractRunContexts(testJson("missing_fields.json"));
-    }
-
-    @Test
     public void readsRunContextsFromJsonFile() {
         List<RunContext> runContexts = RunsJsonReader.extractRunContexts(testJson("two_somatic.json"));
         assertEquals(2, runContexts.size());

--- a/patient-db/src/test/resources/context/RunJson/two_somatic.json
+++ b/patient-db/src/test/resources/context/RunJson/two_somatic.json
@@ -1,0 +1,14 @@
+[
+  {
+    "setName": "set1",
+    "tumorSample": "tumor1",
+    "tumorBarcode": "tumor1_barcode",
+    "refSample": "ref1"
+  },
+  {
+    "setName": "set2",
+    "tumorSample": "tumor2",
+    "tumorBarcode": "tumor2_barcode",
+    "refSample": "ref2"
+  }
+]


### PR DESCRIPTION
Adds a simple json deserializer which takes a local file and creates a list of run
contexts. Will be used when the run_dir argument is null and the run_json argument is
specified.