### PR TITLE
DEV-1827 Loosen initial required args checks

### DIFF
--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/ClinicalAlgoConfig.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/clinical/ClinicalAlgoConfig.java
@@ -152,7 +152,8 @@ public interface ClinicalAlgoConfig {
     static ClinicalAlgoConfig createConfig(@NotNull CommandLine cmd) throws ParseException {
         boolean doProcessWideClinicalData = cmd.hasOption(DO_PROCESS_WIDE_CLINICAL_DATA);
         ImmutableClinicalAlgoConfig.Builder builder = ImmutableClinicalAlgoConfig.builder()
-                .runsDirectory(nonOptionalDir(cmd, RUNS_DIRECTORY))
+                .runsDirectory(cmd.getOptionValue(RUNS_DIRECTORY))
+                .runsJson(cmd.getOptionValue(RUNS_JSON))
                 .pipelineVersionFile(nonOptionalValue(cmd, PIPELINE_VERSION_FILE))
                 .cpctEcrfFile(nonOptionalFile(cmd, CPCT_ECRF_FILE))
                 .cpctFormStatusCsv(nonOptionalFile(cmd, CPCT_FORM_STATUS_CSV))


### PR DESCRIPTION
The change that was made previously to allow a JSON file containing the
runs (instead of a runs directory) could only be unit tested. However
when run in-app there was a check against the runs directory that was
still breaking the in-GCP clinical loader.

This change loosens the argument checking to allow the SampleLoader
class to do all the checking. It knows about both arguments and will
require one and only one of the runs JSON/runs directory to be given.