### PR TITLE
DEV-2199 Use exact (not major.minor) pipeline ver

### DIFF
--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/runcontext/MetaDataResolver.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/runcontext/MetaDataResolver.java
@@ -180,7 +180,7 @@ public final class MetaDataResolver {
     }
 
     @Nullable
-    private static String readPipelineVersion(@NotNull File pipelineVersionFile) throws IOException {
+    public static String readPipelineVersion(@NotNull File pipelineVersionFile) throws IOException {
         List<String> lines = Files.readAllLines(pipelineVersionFile.toPath());
         if (lines.isEmpty()) {
             throw new IOException("Pipeline version file seems empty on " + pipelineVersionFile.getPath());

--- a/patient-reporter/pom.xml
+++ b/patient-reporter/pom.xml
@@ -97,5 +97,39 @@
             </plugin>
         </plugins>
     </build>
-
+    <profiles>
+        <profile>
+            <id>shade</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactSet>
+                                        <excludes>
+                                            <exclude>org.apache.lucene:*</exclude>
+                                        </excludes>
+                                    </artifactSet>
+                                    <relocations>
+                                        <relocation>
+                                            <pattern>com.google</pattern>
+                                            <shadedPattern>hmf.shaded.com.google</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReporter.java
@@ -52,7 +52,7 @@ public class AnalysedPatientReporter {
 
         String clinicalSummary = reportData.summaryModel().findSummaryForSample(sampleMetadata.tumorSampleId(), sampleReport.cohort());
 
-        String pipelineVersion = MetaDataResolver.majorDotMinorVersion(new File(config.pipelineVersionFile()));
+        String pipelineVersion = MetaDataResolver.readPipelineVersion(new File(config.pipelineVersionFile()));
         checkPipelineVersion(pipelineVersion, config.expectedPipelineVersion(), config.overridePipelineVersion());
 
         GenomicAnalyzer genomicAnalyzer = new GenomicAnalyzer(reportData.germlineReportingModel(),


### PR DESCRIPTION
This is to accommodate the patient-reporter that runs in GCP as in that
environment there will be a three-part version string rather than the
major.minor we've had when running directly on datastore.

Also backport the shading for the patient-reporter JAR that is required
when including it as a dependency in the GCP wrapped version, and which
is already in the master branch.