### PR TITLE
DEV-2235 Generate JSON for API alongside report

### DIFF
--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/PatientReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/PatientReporterApplication.java
@@ -92,7 +92,7 @@ public class PatientReporterApplication {
 
             writeReportDataToJson(report);
 
-            new ReportingDb(config.reportingDbTsv()).appendAnalysedReport(report);
+            new ReportingDb(config.reportingDbTsv()).appendAnalysedReport(report, config.outputDirData());
         }
     }
 

--- a/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/reportingdb/ReportingDbTest.java
+++ b/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/reportingdb/ReportingDbTest.java
@@ -1,14 +1,24 @@
 package com.hartwig.hmftools.patientreporter.reportingdb;
 
+import static java.lang.String.join;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 import com.google.common.io.Resources;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import com.hartwig.hmftools.common.lims.cohort.LimsCohortConfig;
 import com.hartwig.hmftools.common.lims.cohort.LimsCohortTestFactory;
 import com.hartwig.hmftools.common.reportingdb.ReportingDatabase;
@@ -69,10 +79,41 @@ public class ReportingDbTest {
                     new ExampleAnalysisConfig.Builder().sampleId("CPCT01_SUCCESS").limsCohortConfig(cohortConfig).build();
 
             ReportingDb reportingDb = new ReportingDb(reportingDbTsv.getPath());
-            reportingDb.appendAnalysedReport(ExampleAnalysisTestFactory.createAnalysisWithAllTablesFilledIn(config));
+            reportingDb.appendAnalysedReport(ExampleAnalysisTestFactory.createAnalysisWithAllTablesFilledIn(config), "/tmp");
             reportingDb.appendQCFailReport(ExampleAnalysisTestFactory.createQCFailReport("CPCT01_FAIL",
                     QCFailReason.INSUFFICIENT_TCP_SHALLOW_WGS,
                     cohortConfig));
         }
+    }
+
+    @Test
+    public void shouldWriteApiUpdateJson() throws IOException {
+        File reportingDbTsv = File.createTempFile("reporting-db-test", ".tsv");
+
+        BufferedWriter writer = new BufferedWriter(new FileWriter(reportingDbTsv, true));
+        writer.write("tumorBarcode\tsampleId\tcohort\treportDate\treportType\tpurity\thasReliableQuality\thasReliablePurity\n");
+        writer.close();
+        LimsCohortConfig cohortConfig = LimsCohortTestFactory.createCPCTCohortConfig();
+
+        ExampleAnalysisConfig config =
+                new ExampleAnalysisConfig.Builder().sampleId("CPCT01_SUCCESS").limsCohortConfig(cohortConfig).build();
+
+        ReportingDb reportingDb = new ReportingDb(reportingDbTsv.getPath());
+
+        File expectedOutput = new File("/tmp/CPCT01_SUCCESS_FR12345678_api-update.json");
+        Files.deleteIfExists(expectedOutput.toPath());
+        assertFalse(expectedOutput.exists());
+        reportingDb.appendAnalysedReport(ExampleAnalysisTestFactory.createAnalysisWithAllTablesFilledIn(config), "/tmp");
+        assertTrue(expectedOutput.exists());
+
+        Map<String, Object> output = new GsonBuilder().serializeNulls().serializeSpecialFloatingPointValues().create()
+                .fromJson(join("\n", Files.readAllLines(expectedOutput.toPath())), new TypeToken<Map<String, Object>>(){}.getType());
+        assertEquals(output.get("has_reliable_quality"), true);
+        assertEquals(output.get("has_reliable_purity"), true);
+        assertEquals(output.get("purity"), 1.0);
+        assertEquals(output.get("cohort"), "CPCT");
+        assertEquals(output.get("report_type"), "dna_analysis_report");
+        assertEquals(output.get("barcode"), "FR12345678");
+        assertEquals(output.get("report_date"), LocalDateTime.now().format(DateTimeFormatter.ofPattern("d-MMM-y")));
     }
 }


### PR DESCRIPTION
Unless explicitly asked to only generate the PDF, also generate a JSON file
containing essentially the same information that will have been added to the
reporting DB TSV.

This file can be picked up by whichever process called the patient-reporter,
augmented to include the report source as required by the report endpoint and
shipped to the API.