### PR TITLE
DEV-2333 Add unique keys for large genomic db tables

### DIFF
--- a/patient-db/src/main/resources/generate_database.sql
+++ b/patient-db/src/main/resources/generate_database.sql
@@ -526,8 +526,8 @@ DROP TABLE IF EXISTS somaticVariant;
 CREATE TABLE somaticVariant
 (   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     modified DATETIME NOT NULL,
-    sampleId varchar(255) NOT NULL,
-    chromosome varchar(255) NOT NULL,
+    sampleId varchar(20) NOT NULL,
+    chromosome varchar(20) NOT NULL,
     position int not null,
     filter varchar(255) NOT NULL,
     type varchar(255) NOT NULL,
@@ -570,6 +570,7 @@ CREATE TABLE somaticVariant
     qual double precision not null,
     reported BOOLEAN NOT NULL,
     PRIMARY KEY (id),
+    UNIQUE KEY (sampleId, chromosome, position, ref, alt),
     INDEX(sampleId),
     INDEX(filter),
     INDEX(type),
@@ -726,6 +727,7 @@ CREATE TABLE copyNumber
     minStart int not null,
     maxStart int not null,
     PRIMARY KEY (id),
+    UNIQUE KEY (sampleId, chromosome, start, end),
     INDEX(sampleId)
 );
 
@@ -868,6 +870,7 @@ CREATE TABLE structuralVariant
     startAnchoringSupportDistance int,
     endAnchoringSupportDistance int,
     PRIMARY KEY (id),
+    UNIQUE KEY (sampleId, startChromosome, startPosition, startOrientation, endChromosome, endPosition, endOrientation, event),
     INDEX(sampleId, svId)
 );
 

--- a/patient-db/src/main/resources/generate_database.sql
+++ b/patient-db/src/main/resources/generate_database.sql
@@ -526,8 +526,8 @@ DROP TABLE IF EXISTS somaticVariant;
 CREATE TABLE somaticVariant
 (   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     modified DATETIME NOT NULL,
-    sampleId varchar(20) NOT NULL,
-    chromosome varchar(20) NOT NULL,
+    sampleId varchar(31) NOT NULL,
+    chromosome varchar(31) NOT NULL,
     position int not null,
     filter varchar(255) NOT NULL,
     type varchar(255) NOT NULL,

--- a/patient-db/src/main/resources/generate_database.sql
+++ b/patient-db/src/main/resources/generate_database.sql
@@ -754,6 +754,7 @@ CREATE TABLE geneCopyNumber
     minRegionMethod varchar(255) NOT NULL,
     minMinorAlleleCopyNumber DOUBLE PRECISION not null,
     PRIMARY KEY (id),
+    UNIQUE KEY (sampleId, chromosome, gene, transcriptId),
     INDEX(sampleId, gene),
     INDEX(gene)
 );

--- a/patient-db/src/main/resources/patches/patientdb/patientdb3.62_to_3.63_migration.sql
+++ b/patient-db/src/main/resources/patches/patientdb/patientdb3.62_to_3.63_migration.sql
@@ -12,6 +12,22 @@ ALTER TABLE baseline
 ALTER TABLE baseline
     ADD COLUMN outsideEU BOOLEAN AFTER inHMFDatabase;
 
+ALTER TABLE copyNumber
+	ADD UNIQUE KEY (sampleId, chromosome, start, end);
+
+ALTER TABLE geneCopyNumber
+	ADD UNIQUE KEY (sampleId, chromosome, gene, transcriptId);
+
+ALTER TABLE somaticVariant
+	MODIFY COLUMN sampleId VARCHAR(31);
+ALTER TABLE somaticVariant
+	MODIFY COLUMN chromosome VARCHAR(31);
+ALTER TABLE somaticVariant
+	ADD UNIQUE KEY (sampleId, chromosome, position, ref, alt);
+
+ALTER TABLE structuralVariant
+	ADD UNIQUE KEY (sampleId, startChromosome, startPosition, startOrientation, endChromosome, endPosition, endOrientation, event)
+
 ALTER TABLE virusAnnotation
     ADD COLUMN percentageCovered double NOT NULL AFTER interpretation;
 


### PR DESCRIPTION
SomaticVariant, geneCopyNumber, copyNumber and structuralVariant. A couple column size reductions also
necessary such that the index will fit into the max for mysql.

Applied in both a patch and generate_database.sql.