### PR TITLE
DEV-2408 Remove static date from ReportResources

### DIFF
--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/commands/CommandOptionTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/commands/CommandOptionTest.kt
@@ -9,7 +9,7 @@ import java.io.IOException
 
 class CommandOptionTest : StringSpec() {
 
-    private val COMMAND = "cd"
+    private val COMMAND = "more"
     private val MISSING_COMMAND = "this_should_be_missing"
     private val CMD_OPTION = "cmd"
 

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/PatientReport.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/PatientReport.java
@@ -70,4 +70,7 @@ public interface PatientReport {
 
     @NotNull
     List<PeachGenotype> peachGenotypes();
+
+    @NotNull
+    String reportDate();
 }

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/PatientReporterApplication.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/PatientReporterApplication.java
@@ -2,12 +2,14 @@ package com.hartwig.hmftools.patientreporter;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.hartwig.hmftools.common.clinical.PatientPrimaryTumor;
 import com.hartwig.hmftools.common.clinical.PatientPrimaryTumorFile;
 import com.hartwig.hmftools.common.lims.Lims;
 import com.hartwig.hmftools.common.lims.LimsFactory;
+import com.hartwig.hmftools.common.utils.DataUtil;
 import com.hartwig.hmftools.patientreporter.algo.AnalysedPatientReport;
 import com.hartwig.hmftools.patientreporter.algo.AnalysedPatientReporter;
 import com.hartwig.hmftools.patientreporter.algo.AnalysedReportData;
@@ -50,14 +52,17 @@ public class PatientReporterApplication {
             throw new IllegalArgumentException("Unexpected error, check inputs");
         }
 
-        new PatientReporterApplication(config).run();
+        new PatientReporterApplication(config, DataUtil.formatDate(LocalDate.now())).run();
     }
 
     @NotNull
     private final PatientReporterConfig config;
+    @NotNull
+    private final String reportDate;
 
-    private PatientReporterApplication(@NotNull final PatientReporterConfig config) {
+    private PatientReporterApplication(@NotNull final PatientReporterConfig config, @NotNull final String reportDate) {
         this.config = config;
+        this.reportDate = reportDate;
     }
 
     private void run() throws IOException {
@@ -74,7 +79,7 @@ public class PatientReporterApplication {
 
     private void generateAnalysedReport(@NotNull SampleMetadata sampleMetadata) throws IOException {
         AnalysedReportData reportData = buildAnalysedReportData(config);
-        AnalysedPatientReporter reporter = new AnalysedPatientReporter(reportData);
+        AnalysedPatientReporter reporter = new AnalysedPatientReporter(reportData, reportDate);
 
         AnalysedPatientReport report = reporter.run(sampleMetadata, config);
 
@@ -93,7 +98,7 @@ public class PatientReporterApplication {
     }
 
     private void generateQCFail(@NotNull SampleMetadata sampleMetadata) throws IOException {
-        QCFailReporter reporter = new QCFailReporter(buildBaseReportData(config));
+        QCFailReporter reporter = new QCFailReporter(buildBaseReportData(config), reportDate);
         QCFailReport report = reporter.run(config.qcFailReason(),
                 sampleMetadata,
                 config.purplePurityTsv(),

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReport.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReport.java
@@ -62,4 +62,8 @@ public abstract class AnalysedPatientReport implements PatientReport {
     @Override
     @NotNull
     public abstract String logoCompanyPath();
+
+    @Override
+    @NotNull
+    public abstract String reportDate();
 }

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReporter.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class AnalysedPatientReporter {
 
@@ -41,9 +40,12 @@ public class AnalysedPatientReporter {
 
     @NotNull
     private final AnalysedReportData reportData;
+    @NotNull
+    private final String reportDate;
 
-    public AnalysedPatientReporter(@NotNull final AnalysedReportData reportData) {
+    public AnalysedPatientReporter(@NotNull final AnalysedReportData reportData, @NotNull final String reportDate) {
         this.reportData = reportData;
+        this.reportDate = reportDate;
     }
 
     @NotNull
@@ -108,6 +110,7 @@ public class AnalysedPatientReporter {
                 .logoCompanyPath(reportData.logoCompanyPath())
                 .udiDi(reportData.udiDi())
                 .peachGenotypes(peachGenotypesOverrule)
+                .reportDate(reportDate)
                 .build();
 
         printReportState(report);

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/ReportResources.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/ReportResources.java
@@ -33,7 +33,6 @@ public final class ReportResources {
 
     static final String METADATA_TITLE = "HMF Sequencing Report v" + PatientReporterApplication.VERSION;
     static final String METADATA_AUTHOR = HARTWIG_NAME;
-    public static final String REPORT_DATE = DataUtil.formatDate(LocalDate.now());
 
     static final float PAGE_MARGIN_TOP = 150; // Top margin also excludes the chapter title, which is rendered in the header
     public static final float PAGE_MARGIN_LEFT = 55.5f;

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/chapters/analysed/DetailsAndDisclaimerChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/chapters/analysed/DetailsAndDisclaimerChapter.java
@@ -80,7 +80,7 @@ public class DetailsAndDisclaimerChapter implements ReportChapter {
         div.add(createContentParagraphTwice("The results in this report have been obtained between ",
                 DataUtil.formatNullableString(earliestArrivalDate),
                 " and ",
-                ReportResources.REPORT_DATE));
+                patientReport.reportDate()));
 
         div.add(createContentParagraphTwice("This experiment is performed on the tumor sample which arrived on ",
                 DataUtil.formatDate(sampleReport.tumorArrivalDate()),

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/chapters/failed/QCFailDisclaimerChapter.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/chapters/failed/QCFailDisclaimerChapter.java
@@ -138,7 +138,7 @@ public class QCFailDisclaimerChapter implements ReportChapter {
         return createContentParagraphTwice("The results in this report have been obtained between ",
                 earliestArrivalDate != null ? earliestArrivalDate : DataUtil.NA_STRING,
                 " and ",
-                ReportResources.REPORT_DATE);
+                failReport.reportDate());
     }
 
     @NotNull

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/components/SidePanel.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/cfreport/components/SidePanel.java
@@ -36,7 +36,7 @@ public final class SidePanel {
         Canvas cv = new Canvas(canvas, page.getDocument(), page.getPageSize());
 
         cv.add(createSidePanelDiv(++sideTextIndex, "HMF sample id", sampleReport.tumorSampleId()));
-        cv.add(createSidePanelDiv(++sideTextIndex, "Report date", ReportResources.REPORT_DATE));
+        cv.add(createSidePanelDiv(++sideTextIndex, "Report date", patientReport.reportDate()));
 
         LimsCohortConfig cohort = sampleReport.cohort();
 

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/qcfail/QCFailReport.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/qcfail/QCFailReport.java
@@ -58,5 +58,9 @@ public abstract class QCFailReport implements PatientReport {
     @NotNull
     @Override
     public abstract List<PeachGenotype> peachGenotypes();
+
+    @NotNull
+    @Override
+    public abstract String reportDate();
 }
 

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/qcfail/QCFailReporter.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/qcfail/QCFailReporter.java
@@ -40,9 +40,11 @@ public class QCFailReporter {
 
     @NotNull
     private final QCFailReportData reportData;
+    private final String reportDate;
 
-    public QCFailReporter(@NotNull final QCFailReportData reportData) {
+    public QCFailReporter(@NotNull final QCFailReportData reportData, @NotNull final String reportDate) {
         this.reportData = reportData;
+        this.reportDate = reportDate;
     }
 
     @NotNull
@@ -109,6 +111,7 @@ public class QCFailReporter {
                 .udiDi(reportData.udiDi())
                 .peachGenotypes(peachGenotypesOverrule)
                 .purpleQC(purpleQc)
+                .reportDate(reportDate)
                 .build();
     }
 

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/reportingdb/ReportingDb.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/reportingdb/ReportingDb.java
@@ -12,8 +12,6 @@ import java.util.Map;
 
 import com.google.gson.GsonBuilder;
 import com.hartwig.hmftools.common.lims.cohort.LimsCohortConfig;
-import com.hartwig.hmftools.common.lims.reportingdb.ReportingDatabase;
-import com.hartwig.hmftools.common.lims.reportingdb.ReportingEntry;
 import com.hartwig.hmftools.patientreporter.SampleReport;
 import com.hartwig.hmftools.patientreporter.algo.AnalysedPatientReport;
 import com.hartwig.hmftools.patientreporter.algo.GenomicAnalysis;
@@ -27,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
 public class ReportingDb {
 
     private static final Logger LOGGER = LogManager.getLogger(ReportingDb.class);
-
     private static final String NA_STRING = "N/A";
 
     public ReportingDb() {
@@ -39,7 +36,7 @@ public class ReportingDb {
             LimsCohortConfig cohort = report.sampleReport().cohort();
 
             String tumorBarcode = report.sampleReport().tumorSampleBarcode();
-            String reportDate = ReportResources.REPORT_DATE;
+
             GenomicAnalysis analysis = report.genomicAnalysis();
 
             String purity = new DecimalFormat("0.00").format(analysis.impliedPurity());
@@ -54,7 +51,7 @@ public class ReportingDb {
                         sampleId,
                         cohort,
                         "report_without_conclusion",
-                        reportDate,
+                        report.reportDate(),
                         purity,
                         hasReliableQuality,
                         hasReliablePurity);
@@ -76,7 +73,7 @@ public class ReportingDb {
                         sampleId,
                         cohort,
                         reportType,
-                        reportDate,
+                        report.reportDate(),
                         purity,
                         hasReliableQuality,
                         hasReliablePurity);
@@ -111,11 +108,10 @@ public class ReportingDb {
             String sampleId = report.sampleReport().tumorSampleId();
             LimsCohortConfig cohort = report.sampleReport().cohort();
             String tumorBarcode = report.sampleReport().tumorSampleBarcode();
-            String reportDate = ReportResources.REPORT_DATE;
 
             String reportType = report.isCorrectedReport() ? report.reason().identifier() + "_corrected" : report.reason().identifier();
 
-            writeApiUpdateJson(outputDirectory, tumorBarcode, sampleId, cohort, reportType, reportDate, NA_STRING, null, null);
+            writeApiUpdateJson(outputDirectory, tumorBarcode, sampleId, cohort, reportType, report.reportDate(), NA_STRING, null, null);
 
         }
     }

--- a/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/ExampleAnalysisTestFactory.java
+++ b/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/ExampleAnalysisTestFactory.java
@@ -43,6 +43,7 @@ import com.hartwig.hmftools.common.sv.linx.FusionLikelihoodType;
 import com.hartwig.hmftools.common.sv.linx.FusionPhasedType;
 import com.hartwig.hmftools.common.sv.linx.ImmutableLinxFusion;
 import com.hartwig.hmftools.common.sv.linx.LinxFusion;
+import com.hartwig.hmftools.common.utils.DataUtil;
 import com.hartwig.hmftools.common.variant.CodingEffect;
 import com.hartwig.hmftools.common.variant.Hotspot;
 import com.hartwig.hmftools.common.variant.ImmutableReportableVariant;
@@ -89,6 +90,7 @@ public final class ExampleAnalysisTestFactory {
         double microsatelliteIndelsPerMb = 0.12;
         double chordHrdValue = 0D;
         ChordStatus chordStatus = ChordStatus.HR_PROFICIENT;
+        String reportDate = DataUtil.formatDate(LocalDate.now());
 
         ReportData reportData = PatientReporterTestFactory.loadTestReportData();
 
@@ -176,6 +178,7 @@ public final class ExampleAnalysisTestFactory {
                 .logoCompanyPath(reportData.logoCompanyPath())
                 .pipelineVersion(pipelineVersion)
                 .peachGenotypes(peachGenotypes)
+                .reportDate(reportDate)
                 .build();
     }
 

--- a/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReporterTest.java
+++ b/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/algo/AnalysedPatientReporterTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.time.LocalDate;
 
+import com.hartwig.hmftools.common.utils.DataUtil;
 import com.hartwig.hmftools.patientreporter.ImmutableSampleMetadata;
 import com.hartwig.hmftools.patientreporter.PatientReporterConfig;
 import com.hartwig.hmftools.patientreporter.PatientReporterTestFactory;
@@ -22,7 +24,8 @@ public class AnalysedPatientReporterTest {
 
     @Test
     public void canRunOnRunDirectory() throws IOException {
-        AnalysedPatientReporter reporter = new AnalysedPatientReporter(PatientReporterTestFactory.loadTestAnalysedReportData());
+        AnalysedPatientReporter reporter = new AnalysedPatientReporter(PatientReporterTestFactory.loadTestAnalysedReportData(),
+                DataUtil.formatDate(LocalDate.now()));
         PatientReporterConfig config = PatientReporterTestFactory.createTestReporterConfig();
 
         SampleMetadata sampleMetadata = ImmutableSampleMetadata.builder()

--- a/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/cfreport/CFReportWriterTest.java
+++ b/patient-reporter/src/test/java/com/hartwig/hmftools/patientreporter/cfreport/CFReportWriterTest.java
@@ -19,6 +19,7 @@ import com.hartwig.hmftools.common.lims.hospital.ImmutableHospitalContactData;
 import com.hartwig.hmftools.common.peach.ImmutablePeachGenotype;
 import com.hartwig.hmftools.common.peach.PeachGenotype;
 import com.hartwig.hmftools.common.purple.PurpleQCStatus;
+import com.hartwig.hmftools.common.utils.DataUtil;
 import com.hartwig.hmftools.patientreporter.ExampleAnalysisConfig;
 import com.hartwig.hmftools.patientreporter.ExampleAnalysisTestFactory;
 import com.hartwig.hmftools.patientreporter.ImmutableSampleMetadata;
@@ -386,6 +387,7 @@ public class CFReportWriterTest {
                 .udiDi(UDI_DI)
                 .peachGenotypes(createTestPeachGenotypes())
                 .purpleQC(Sets.newHashSet(purpleQCStatus))
+                .reportDate(DataUtil.formatDate(LocalDate.now()))
                 .build();
 
         String filename = testReportFilePath(patientReport);


### PR DESCRIPTION
This static field is being used as a global variable for the generation date
of the patient report. It's causing a bug in the GCP-based reporting because
in that situation the process remains running for quite a long time and the
static date drifts from the current date.

Eliminate this global variable in favour of a parameter to the reports that
is injected at the top level. Since it's no longer static the value of this
can be set each time the `.main()` method is called by the controlling
process.

Also in an only tangentially related change I've modified the test for
`CommandOption.kt` as this does not work on Linux, the `cd` command it was
using for a command that should exist does not actually exist as a
standalone executable on Linux. `more` should be available as a binary on
Windows, Linux and Mac.