### PR TITLE
Get hmftools working with java 11

### DIFF
--- a/amber/pom.xml
+++ b/amber/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>value</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.hartwig</groupId>
-            <artifactId>patient-db</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/ckb-importer/pom.xml
+++ b/ckb-importer/pom.xml
@@ -107,7 +107,7 @@
                     </jdbc>
                     <generator>
                         <database>
-                            <name>org.jooq.util.mysql.MySQLDatabase</name>
+                            <name>org.jooq.meta.mysql.MySQLDatabase</name>
                             <includes>.*</includes>
                             <inputSchema>ckb_test</inputSchema>
                         </database>

--- a/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/CkbDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/CkbDAO.java
@@ -86,8 +86,8 @@ public final class CkbDAO {
     public void write(@NotNull CkbEntry ckbEntry) {
         int id = context.insertInto(CKBENTRY, CKBENTRY.CKBPROFILEID, CKBENTRY.CREATEDATE, CKBENTRY.UPDATEDATE, CKBENTRY.PROFILENAME)
                 .values(ckbEntry.profileId(),
-                        Util.sqlDate(ckbEntry.createDate()),
-                        Util.sqlDate(ckbEntry.updateDate()),
+                        ckbEntry.createDate(),
+                        ckbEntry.updateDate(),
                         ckbEntry.profileName())
                 .returning(CKBENTRY.ID)
                 .fetchOne()

--- a/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/ClinicalTrialDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/ClinicalTrialDAO.java
@@ -60,7 +60,7 @@ class ClinicalTrialDAO {
                 CLINICALTRIAL.SPONSORS,
                 CLINICALTRIAL.VARIANTREQUIREMENT)
                 .values(ckbEntryId,
-                        Util.sqlDate(clinicalTrial.updateDate()),
+                        clinicalTrial.updateDate(),
                         clinicalTrial.nctId(),
                         clinicalTrial.title(),
                         clinicalTrial.phase(),

--- a/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/IndicationDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/IndicationDAO.java
@@ -37,7 +37,7 @@ class IndicationDAO {
                         indication.source(),
                         indication.definition(),
                         indication.currentPreferredTerm(),
-                        Util.sqlDate(indication.lastUpdateDateFromDO()),
+                        indication.lastUpdateDateFromDO(),
                         indication.termId())
                 .returning(INDICATION.ID)
                 .fetchOne()

--- a/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/TherapyDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/TherapyDAO.java
@@ -52,8 +52,8 @@ class TherapyDAO {
                 THERAPY.THERAPYNAME,
                 THERAPY.DESCRIPTION)
                 .values(therapy.id(),
-                        Util.sqlDate(therapy.createDate()),
-                        Util.sqlDate(therapy.updateDate()),
+                        therapy.createDate(),
+                        therapy.updateDate(),
                         therapy.therapyName(),
                         therapy.description())
                 .returning(THERAPY.ID)
@@ -103,7 +103,7 @@ class TherapyDAO {
                 DRUG.DESCRIPTION)
                 .values(therapyId,
                         drug.id(),
-                        Util.sqlDate(drug.createDate()),
+                        drug.createDate(),
                         drug.drugName(),
                         drug.tradeName(),
                         drug.casRegistryNum(),
@@ -115,7 +115,7 @@ class TherapyDAO {
 
         for (DrugClass drugClass : drug.drugClasses()) {
             context.insertInto(DRUGCLASS, DRUGCLASS.DRUGID, DRUGCLASS.CKBDRUGCLASSID, DRUGCLASS.CREATEDATE, DRUGCLASS.DRUGCLASS_)
-                    .values(id, drugClass.id(), Util.sqlDate(drugClass.createDate()), drugClass.drugClass())
+                    .values(id, drugClass.id(), drugClass.createDate(), drugClass.drugClass())
                     .execute();
         }
 

--- a/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/Util.java
+++ b/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/Util.java
@@ -1,17 +1,8 @@
 package com.hartwig.hmftools.ckb.dao;
 
-import java.time.LocalDate;
-
-import org.jetbrains.annotations.Nullable;
-
 final class Util {
 
     private Util() {
-    }
-
-    @Nullable
-    public static java.sql.Date sqlDate(@Nullable LocalDate date) {
-        return date != null ? java.sql.Date.valueOf(date) : null;
     }
 
     public static byte toByte(boolean value) {

--- a/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/VariantDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/hmftools/ckb/dao/VariantDAO.java
@@ -58,8 +58,8 @@ class VariantDAO {
                 VARIANT.DESCRIPTION)
                 .values(ckbEntryId,
                         variant.id(),
-                        Util.sqlDate(variant.createDate()),
-                        Util.sqlDate(variant.updateDate()),
+                        variant.createDate(),
+                        variant.updateDate(),
                         variant.fullName(),
                         variant.variant(),
                         variant.impact(),
@@ -107,8 +107,8 @@ class VariantDAO {
                 GENE.DESCRIPTION)
                 .values(variantId,
                         gene.id(),
-                        Util.sqlDate(gene.createDate()),
-                        Util.sqlDate(gene.updateDate()),
+                        gene.createDate(),
+                        gene.updateDate(),
                         gene.geneSymbol(),
                         gene.geneRole(),
                         gene.entrezId(),

--- a/cobalt/pom.xml
+++ b/cobalt/pom.xml
@@ -18,11 +18,6 @@
             <groupId>com.hartwig</groupId>
             <artifactId>hmf-common</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/compar/pom.xml
+++ b/compar/pom.xml
@@ -26,21 +26,6 @@
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/gene-utils/pom.xml
+++ b/gene-utils/pom.xml
@@ -18,27 +18,10 @@
             <groupId>com.hartwig</groupId>
             <artifactId>hmf-common</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.hartwig</groupId>
-            <artifactId>patient-db</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
         </dependency>
 
         <dependency>

--- a/gene-utils/src/main/java/com/hartwig/hmftools/geneutils/ensembl/EnsemblDAO.java
+++ b/gene-utils/src/main/java/com/hartwig/hmftools/geneutils/ensembl/EnsemblDAO.java
@@ -164,6 +164,7 @@ public class EnsemblDAO
             final String jdbcUrl = "jdbc:" + databaseUrl;
 
             System.setProperty("org.jooq.no-logo", "true");
+            System.setProperty("org.jooq.no-tips", "true");
             Connection conn = DriverManager.getConnection(jdbcUrl, userName, password);
             String catalog = conn.getCatalog();
 

--- a/gripss/pom.xml
+++ b/gripss/pom.xml
@@ -18,23 +18,6 @@
             <groupId>com.hartwig</groupId>
             <artifactId>hmf-common</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/gripss/src/main/java/com/hartwig/hmftools/gripss/PonCache.java
+++ b/gripss/src/main/java/com/hartwig/hmftools/gripss/PonCache.java
@@ -4,7 +4,6 @@ import static java.lang.Integer.max;
 import static java.lang.Math.abs;
 import static java.lang.Math.min;
 
-import static com.hartwig.hmftools.common.utils.sv.BaseRegion.positionsOverlap;
 import static com.hartwig.hmftools.common.utils.sv.StartEndIterator.SE_END;
 import static com.hartwig.hmftools.common.utils.sv.StartEndIterator.SE_PAIR;
 import static com.hartwig.hmftools.common.utils.sv.StartEndIterator.SE_START;
@@ -28,8 +27,6 @@ import com.hartwig.hmftools.gripss.common.SvData;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-
-import jdk.nashorn.internal.runtime.regexp.RegExp;
 
 public class PonCache
 {

--- a/gripss/src/main/java/com/hartwig/hmftools/gripss/common/VcfUtils.java
+++ b/gripss/src/main/java/com/hartwig/hmftools/gripss/common/VcfUtils.java
@@ -123,13 +123,13 @@ public class VcfUtils
     public static int getGenotypeAttributeAsInt(final Genotype genotype, final String attribute, int defaultVaue)
     {
         Object value = genotype.getExtendedAttribute(attribute);
-        return value == null ? defaultVaue : Integer.valueOf(value.toString());
+        return value == null ? defaultVaue : Integer.parseInt(value.toString());
     }
 
     public static double getGenotypeAttributeAsDouble(final Genotype genotype, final String attribute, double defaultVaue)
     {
         Object value = genotype.getExtendedAttribute(attribute);
-        return value == null ? defaultVaue : Double.valueOf(value.toString());
+        return value == null ? defaultVaue : Double.parseDouble(value.toString());
     }
 
     public static final Interval confidenceInterval(final VariantContext variantContext, final String attribute)

--- a/gripss/src/main/java/com/hartwig/hmftools/gripss/links/TransitiveLinkFinder.java
+++ b/gripss/src/main/java/com/hartwig/hmftools/gripss/links/TransitiveLinkFinder.java
@@ -51,9 +51,9 @@ public class TransitiveLinkFinder
 
         String tranksLinkPrefix = String.format("%s_%s_",TRANS_LINK_PREFIX, breakend.VcfId);
 
-        ArrayDeque assemblyTransLinks = new ArrayDeque<TransitiveLink>();
-        ArrayDeque transLinks = new ArrayDeque<TransitiveLink>();
-        ArrayDeque matchedTransLinks = new ArrayDeque<TransitiveLink>();
+        var assemblyTransLinks = new ArrayDeque<TransitiveLink>();
+        var transLinks = new ArrayDeque<TransitiveLink>();
+        var matchedTransLinks = new ArrayDeque<TransitiveLink>();
 
         for(Breakend alternative : alternatives)
         {
@@ -78,7 +78,7 @@ public class TransitiveLinkFinder
     private static final int MAX_ITERATIONS = 500   ; // logically not required but in as a safety measure
 
     private List<Link> findLinks(
-            final Breakend target, final ArrayDeque assemblyTransLinks, final ArrayDeque transLinks, final ArrayDeque matchedTransLinks)
+            final Breakend target, final ArrayDeque<TransitiveLink> assemblyTransLinks, final ArrayDeque<TransitiveLink> transLinks, final ArrayDeque<TransitiveLink> matchedTransLinks)
     {
         ++mRecursiveInterations;
 

--- a/health-checker/pom.xml
+++ b/health-checker/pom.xml
@@ -25,12 +25,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.hartwig</groupId>
-            <artifactId>hmf-common</artifactId>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/hmf-common/pom.xml
+++ b/hmf-common/pom.xml
@@ -46,10 +46,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.immutables</groupId>

--- a/hmf-common/pom.xml
+++ b/hmf-common/pom.xml
@@ -63,11 +63,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/PurpleCommon.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/PurpleCommon.java
@@ -1,5 +1,11 @@
 package com.hartwig.hmftools.common.purple;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+import org.jetbrains.annotations.NotNull;
+
 public final class PurpleCommon
 {
     public static final String PURPLE_SOMATIC_VCF_SUFFIX = ".purple.somatic.vcf.gz";
@@ -7,4 +13,8 @@ public final class PurpleCommon
     public static final String PURPLE_SV_VCF_SUFFIX = ".purple.sv.vcf.gz";
 
     public static final String DELIMITER = "\t";
+
+    public static DecimalFormat decimalFormat(@NotNull String format) {
+        return new DecimalFormat(format,  DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+    }
 }

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/copynumber/PurpleCopyNumberFile.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/copynumber/PurpleCopyNumberFile.java
@@ -12,14 +12,14 @@ import java.util.StringJoiner;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import com.hartwig.hmftools.common.purple.gene.ImmutableGeneCopyNumber;
+import com.hartwig.hmftools.common.purple.PurpleCommon;
 import com.hartwig.hmftools.common.purple.segment.SegmentSupport;
 
 import org.jetbrains.annotations.NotNull;
 
 public final class PurpleCopyNumberFile
 {
-    private static final DecimalFormat FORMAT = new DecimalFormat("0.0000");
+    private static final DecimalFormat FORMAT = PurpleCommon.decimalFormat("0.0000");
     private static final String DELIMITER = "\t";
 
     private static final String SOMATIC_EXTENSION = ".purple.cnv.somatic.tsv";

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/purity/FittedPurityRangeFile.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/purity/FittedPurityRangeFile.java
@@ -13,13 +13,14 @@ import java.util.StringJoiner;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import com.hartwig.hmftools.common.purple.PurpleCommon;
 
 import org.jetbrains.annotations.NotNull;
 
 public final class FittedPurityRangeFile {
 
-    private static final DecimalFormat FORMAT = new DecimalFormat("0.0000");
-    private static final int MAX_RECORDS = 10000;
+    private static final DecimalFormat FORMAT = PurpleCommon.decimalFormat("0.0000");
+
     private static final String DELIMITER = "\t";
     private static final String COMMENT = "#";
 

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/purity/PurityContextFile.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/purity/PurityContextFile.java
@@ -10,6 +10,7 @@ import java.util.StringJoiner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.common.purple.Gender;
+import com.hartwig.hmftools.common.purple.PurpleCommon;
 import com.hartwig.hmftools.common.purple.PurpleQC;
 import com.hartwig.hmftools.common.variant.msi.MicrosatelliteStatus;
 import com.hartwig.hmftools.common.variant.tml.TumorMutationalStatus;
@@ -18,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 public final class PurityContextFile {
 
-    private static final DecimalFormat FORMAT = new DecimalFormat("0.0000");
+    private static final DecimalFormat FORMAT = PurpleCommon.decimalFormat("0.0000");
     private static final String DELIMITER = "\t";
 
     private static final String EXTENSION = ".purple.purity.tsv";

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/purity/PurpleQCFile.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/purple/purity/PurpleQCFile.java
@@ -9,15 +9,17 @@ import java.util.List;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.common.genome.chromosome.GermlineAberration;
-import com.hartwig.hmftools.common.purple.ImmutablePurpleQC;
 import com.hartwig.hmftools.common.purple.Gender;
+import com.hartwig.hmftools.common.purple.ImmutablePurpleQC;
+import com.hartwig.hmftools.common.purple.PurpleCommon;
 import com.hartwig.hmftools.common.purple.PurpleQC;
 
 import org.jetbrains.annotations.NotNull;
 
- public final class PurpleQCFile {
+public final class PurpleQCFile {
 
-    private static final DecimalFormat FORMATTER = new DecimalFormat("0.0000");
+    private static final DecimalFormat FORMAT = PurpleCommon.decimalFormat("0.0000");
+
     private static final String DELIMITER = "\t";
     private static final String EXTENSION = ".purple.qc";
 
@@ -85,7 +87,7 @@ import org.jetbrains.annotations.NotNull;
         result.add("Method" + DELIMITER + check.method());
         result.add("CopyNumberSegments" + DELIMITER + check.copyNumberSegments());
         result.add("UnsupportedCopyNumberSegments" + DELIMITER + check.unsupportedCopyNumberSegments());
-        result.add("Purity" + DELIMITER + FORMATTER.format(check.purity()));
+        result.add("Purity" + DELIMITER + FORMAT.format(check.purity()));
         result.add("AmberGender" + DELIMITER + check.amberGender());
         result.add("CobaltGender" + DELIMITER + check.cobaltGender());
         result.add("DeletedGenes" + DELIMITER + check.deletedGenes());

--- a/hmf-id-generator/pom.xml
+++ b/hmf-id-generator/pom.xml
@@ -47,10 +47,19 @@
             <artifactId>selenium-java</artifactId>
         </dependency>
 
-
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-junit5-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/hmf-id-generator/src/main/kotlin/com/hartwig/hmftools/extensions/cli/options/validators/primitives/EnumValidator.kt
+++ b/hmf-id-generator/src/main/kotlin/com/hartwig/hmftools/extensions/cli/options/validators/primitives/EnumValidator.kt
@@ -8,8 +8,8 @@ data class EnumValidator<T : Enum<T>>(private val enumClass: Class<T>) : OptionV
 
     override fun validate(option: HmfOption, cmd: CommandLine): String? {
         if (!cmd.hasOption(option.name)) return null
-        val optionValue = cmd.getOptionValue(option.name).toLowerCase()
-        val valueSet = enumClass.enumConstants.map { it.name.toLowerCase() }.toSet()
+        val optionValue = cmd.getOptionValue(option.name).lowercase()
+        val valueSet = enumClass.enumConstants.map { it.name.lowercase() }.toSet()
         if (!valueSet.contains(optionValue)) return "-${option.name}: $optionValue is not a valid choice."
         return null
     }

--- a/hmf-id-generator/src/main/kotlin/com/hartwig/hmftools/idgenerator/HmfSample.kt
+++ b/hmf-id-generator/src/main/kotlin/com/hartwig/hmftools/idgenerator/HmfSample.kt
@@ -14,7 +14,7 @@ data class HmfSample(val patientId: Int, val sampleId: Int, val deleted: Boolean
         operator fun invoke(amberAnonymous: AmberAnonymous): HmfSample {
             val hmfSampleId = amberAnonymous.hmfSampleId()
 
-            val sampleId = hmfSampleId[hmfSampleId.length - 1].toInt() - 64
+            val sampleId = hmfSampleId[hmfSampleId.length - 1].code - 64
             val patientId = hmfSampleId.substring(prefix.length, hmfSampleId.length - 1).toInt()
 
             return HmfSample(patientId, sampleId, amberAnonymous.deleted(), amberAnonymous.sampleId())

--- a/hmf-id-generator/src/main/kotlin/com/hartwig/hmftools/idgenerator/PatientAnonymizer.kt
+++ b/hmf-id-generator/src/main/kotlin/com/hartwig/hmftools/idgenerator/PatientAnonymizer.kt
@@ -6,15 +6,15 @@ class PatientAnonymizer {
 
     fun anonymize(amberPatients: List<AmberPatient>, existingSamples: List<HmfSample>): List<HmfSample> {
         val newSamples = mutableListOf<HmfSample>()
-        var maxPatientId = existingSamples.map { x -> x.patientId }.max() ?: 0
+        var maxPatientId = existingSamples.map { x -> x.patientId }.maxOrNull() ?: 0
 
         val amberPatientIds = amberPatients.map { x -> x.patientId() }.toSet()
         for (amberPatientId in amberPatientIds) {
             val allPatientSamples = amberPatients.filter { it.patientId() == amberPatientId }.map { it.sample() }
             val existingPatientSamples = existingSamples.filter { x -> allPatientSamples.contains(x.sample) }
 
-            val hmfPatientId = (existingPatientSamples.map { x -> x.patientId }.max() ?: ++maxPatientId)
-            var maxSampleIdForPatient = existingPatientSamples.map { x -> x.sampleId }.max() ?: 0
+            val hmfPatientId = (existingPatientSamples.map { x -> x.patientId }.maxOrNull() ?: ++maxPatientId)
+            var maxSampleIdForPatient = existingPatientSamples.map { x -> x.sampleId }.maxOrNull() ?: 0
 
             for (sample in allPatientSamples) {
                 if (existingPatientSamples.none { x -> x.sample == sample }) {

--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/commands/CommandOptionTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/commands/CommandOptionTest.kt
@@ -2,9 +2,9 @@ package com.hartwig.hmftools.extensions.cli.options.commands
 
 import com.hartwig.hmftools.extensions.cli.createCommandLine
 import com.hartwig.hmftools.extensions.cli.options.HmfOptions
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import java.io.IOException
 
 class CommandOptionTest : StringSpec() {

--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/enums/EnumOptionTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/enums/EnumOptionTest.kt
@@ -2,9 +2,9 @@ package com.hartwig.hmftools.extensions.cli.options.enums
 
 import com.hartwig.hmftools.extensions.cli.createCommandLine
 import com.hartwig.hmftools.extensions.cli.options.HmfOptions
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import java.io.IOException
 
 class EnumOptionTest : StringSpec() {

--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/enums/RequiredEnumOptionTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/enums/RequiredEnumOptionTest.kt
@@ -2,9 +2,9 @@ package com.hartwig.hmftools.extensions.cli.options.enums
 
 import com.hartwig.hmftools.extensions.cli.createCommandLine
 import com.hartwig.hmftools.extensions.cli.options.HmfOptions
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import java.io.IOException
 
 class RequiredEnumOptionTest : StringSpec() {

--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/filesystem/InputDirOptionTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/filesystem/InputDirOptionTest.kt
@@ -3,9 +3,9 @@ package com.hartwig.hmftools.extensions.cli.options.filesystem
 import com.google.common.io.Resources
 import com.hartwig.hmftools.extensions.cli.createCommandLine
 import com.hartwig.hmftools.extensions.cli.options.HmfOptions
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import java.io.IOException
 
 class InputDirOptionTest : StringSpec() {

--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/filesystem/InputFileOptionTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/filesystem/InputFileOptionTest.kt
@@ -3,9 +3,9 @@ package com.hartwig.hmftools.extensions.cli.options.filesystem
 import com.google.common.io.Resources
 import com.hartwig.hmftools.extensions.cli.createCommandLine
 import com.hartwig.hmftools.extensions.cli.options.HmfOptions
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import java.io.IOException
 
 class InputFileOptionTest : StringSpec() {

--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/filesystem/RequiredInputFileOptionTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/cli/options/filesystem/RequiredInputFileOptionTest.kt
@@ -3,9 +3,9 @@ package com.hartwig.hmftools.extensions.cli.options.filesystem
 import com.google.common.io.Resources
 import com.hartwig.hmftools.extensions.cli.createCommandLine
 import com.hartwig.hmftools.extensions.cli.options.HmfOptions
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import java.io.IOException
 
 class RequiredInputFileOptionTest : StringSpec() {

--- a/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/csv/CsvExtensionsTest.kt
+++ b/hmf-id-generator/src/test/kotlin/com/hartwig/hmftools/extensions/csv/CsvExtensionsTest.kt
@@ -1,9 +1,9 @@
 package com.hartwig.hmftools.extensions.csv
 
 import com.google.common.io.Resources
-import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldThrow
-import io.kotlintest.specs.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import java.io.File
 
 class CsvExtensionsTest : StringSpec() {

--- a/isofox/pom.xml
+++ b/isofox/pom.xml
@@ -22,23 +22,6 @@
             <groupId>com.hartwig</groupId>
             <artifactId>patient-db</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/isofox/src/main/java/com/hartwig/hmftools/isofox/expression/ExpressionReadTracker.java
+++ b/isofox/src/main/java/com/hartwig/hmftools/isofox/expression/ExpressionReadTracker.java
@@ -116,7 +116,7 @@ public class ExpressionReadTracker
         final List<String> unsplicedGeneIds = mGenes.findGenesCoveringRange(enrichedRegion[SE_START], enrichedRegion[SE_END], true)
                 .stream().map(x -> x.GeneData.GeneId).collect(Collectors.toList());
 
-        final List<Integer> transIds = mGenes.getEnrichedTranscripts().stream().map(x -> new Integer(x.TransId)).collect(Collectors.toList());
+        final List<Integer> transIds = mGenes.getEnrichedTranscripts().stream().map(x -> Integer.valueOf(x.TransId)).collect(Collectors.toList());
         CategoryCountsData catCounts = getCategoryCountsData(transIds, unsplicedGeneIds);
 
         // compute and cache GC data

--- a/lilac/pom.xml
+++ b/lilac/pom.xml
@@ -23,14 +23,6 @@
             <artifactId>patient-db</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>

--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/coverage/ComplexCoverageCalculator.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/coverage/ComplexCoverageCalculator.java
@@ -46,7 +46,7 @@ public class ComplexCoverageCalculator
         ExecutorService executorService = Executors.newFixedThreadPool(mThreadCount, namedThreadFactory);
 
         List<CoverageCalcTask> coverageCalcTasks = Lists.newArrayList();
-        List<FutureTask> taskList = new ArrayList<FutureTask>();
+        List<FutureTask<Long>> taskList = new ArrayList<>();
 
         List<HlaComplex>[] complexLists = new List[mThreadCount];
 
@@ -71,7 +71,7 @@ public class ComplexCoverageCalculator
             CoverageCalcTask coverageTask = new CoverageCalcTask(threadIndex++, complexList, fragAlleleMatrix, mTopScoreThreshold);
             coverageCalcTasks.add(coverageTask);
 
-            FutureTask futureTask = new FutureTask(coverageTask);
+            FutureTask<Long> futureTask = new FutureTask<>(coverageTask);
 
             taskList.add(futureTask);
             executorService.execute(futureTask);
@@ -79,7 +79,7 @@ public class ComplexCoverageCalculator
 
         try
         {
-            for (FutureTask futureTask : taskList)
+            for (FutureTask<Long> futureTask : taskList)
             {
                 futureTask.get();
             }

--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/coverage/CoverageCalcTask.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/coverage/CoverageCalcTask.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Callable;
 
 import com.google.common.collect.Lists;
 
-public class CoverageCalcTask implements Callable
+public class CoverageCalcTask implements Callable<Long>
 {
     private final int mId;
     private final List<HlaComplex> mComplexes;

--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/evidence/ExtendEvidence.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/evidence/ExtendEvidence.java
@@ -132,7 +132,7 @@ public final class ExtendEvidence
             return merge(current, current, right);
         }
 
-        return new Pair(current, Sets.newHashSet());
+        return Pair.create(current, Sets.newHashSet());
     }
 
     private final int minTotalFragments(List<Integer> indices)
@@ -164,11 +164,11 @@ public final class ExtendEvidence
 
                 if (combined.totalEvidence() >= minTotalFragments)
                 {
-                    return new Pair(combined, Sets.newHashSet(left, right));
+                    return Pair.create(combined, Sets.newHashSet(left, right));
                 }
             }
         }
 
-        return new Pair(current, Sets.newHashSet());
+        return Pair.create(current, Sets.newHashSet());
     }
 }

--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/fragment/NucleotideGeneEnrichment.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/fragment/NucleotideGeneEnrichment.java
@@ -71,13 +71,13 @@ public class NucleotideGeneEnrichment
 
         Set<String> genes = fragment.getGenes();
 
-        if(!genes.contains(HLA_A) && matchToGene(fragment, HLA_A, new Pair(HLA_B, mAbMinBoundary), new Pair(HLA_C, mAcMinBoundary)))
+        if(!genes.contains(HLA_A) && matchToGene(fragment, HLA_A, Pair.create(HLA_B, mAbMinBoundary), Pair.create(HLA_C, mAcMinBoundary)))
             genes.add(HLA_A);
 
-        if(!genes.contains(HLA_B) && matchToGene(fragment, HLA_B, new Pair(HLA_A, mAbMinBoundary), new Pair(HLA_C, mBcMinBoundary)))
+        if(!genes.contains(HLA_B) && matchToGene(fragment, HLA_B, Pair.create(HLA_A, mAbMinBoundary), Pair.create(HLA_C, mBcMinBoundary)))
             genes.add(HLA_B);
 
-        if(!genes.contains(HLA_C) && matchToGene(fragment, HLA_C, new Pair(HLA_A, mAcMinBoundary), new Pair(HLA_B, mBcMinBoundary)))
+        if(!genes.contains(HLA_C) && matchToGene(fragment, HLA_C, Pair.create(HLA_A, mAcMinBoundary), Pair.create(HLA_B, mBcMinBoundary)))
             genes.add(HLA_C);
 
         return fragment;

--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/hla/HlaAlleleCache.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/hla/HlaAlleleCache.java
@@ -83,7 +83,7 @@ public class HlaAlleleCache
                 .filter(x -> x.getKey().equals(groupAllele)).findFirst().orElse(null);
 
         if(entry != null)
-            return new Pair(entry.getKey(), entry.getValue());
+            return Pair.create(entry.getKey(), entry.getValue());
 
         Map<HlaAllele,List<HlaAllele>> groupMap = Maps.newHashMap();
 
@@ -91,7 +91,7 @@ public class HlaAlleleCache
                 allele.Gene, allele.AlleleGroup, "", "", "", null, null);
 
         mAlleleMap.put(newGroup, groupMap);
-        return new Pair(newGroup, groupMap);
+        return Pair.create(newGroup, groupMap);
     }
 
     private static Pair<HlaAllele,List<HlaAllele>> getOrCreateFourDigitList(
@@ -103,7 +103,7 @@ public class HlaAlleleCache
                 .filter(x -> x.getKey().equals(fourDigitAllele)).findFirst().orElse(null);
 
         if(entry != null)
-            return new Pair(entry.getKey(), entry.getValue());
+            return Pair.create(entry.getKey(), entry.getValue());
 
         List<HlaAllele> alleleList = Lists.newArrayList();
 
@@ -111,7 +111,7 @@ public class HlaAlleleCache
                 allele.Gene, allele.AlleleGroup, allele.Protein, "", "", null, groupAllele);
 
         groupMap.put(newFourDigit, alleleList);
-        return new Pair(newFourDigit, alleleList);
+        return Pair.create(newFourDigit, alleleList);
     }
 
     public void rebuildProteinAlleles(final List<HlaAllele> list)

--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/qc/HaplotypeQC.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/qc/HaplotypeQC.java
@@ -150,7 +150,7 @@ public class HaplotypeQC
         for(Map.Entry<String,Integer> entry : unmatched.entrySet())
         {
             Haplotype haplotype = Haplotype.create(
-                    evidence.getAminoAcidLoci(), new Pair(entry.getKey(), entry.getValue()), aminoAcidCount);
+                    evidence.getAminoAcidLoci(), Pair.create(entry.getKey(), entry.getValue()), aminoAcidCount);
 
             haplotypes.add(haplotype);
         }

--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/seq/SequenceCount.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/seq/SequenceCount.java
@@ -301,7 +301,7 @@ public final class SequenceCount
                         ++index;
                     }
 
-                    sortedCounts.add(index, new Pair(entry.getKey(), entry.getValue()));
+                    sortedCounts.add(index, Pair.create(entry.getKey(), entry.getValue()));
                 }
 
                 for(int j = 0; j <= min(5, sortedCounts.size() - 1); ++j)

--- a/lilac/src/test/java/com/hartwig/hmftools/lilac/evidence/PhasedEvidenceTest.java
+++ b/lilac/src/test/java/com/hartwig/hmftools/lilac/evidence/PhasedEvidenceTest.java
@@ -23,7 +23,7 @@ public class PhasedEvidenceTest
         Map<String,Integer> evidence = Maps.newHashMap();
         evidence.put("CAT", 4);
         evidence.put("ATC", 5);
-        PhasedEvidence victim = new PhasedEvidence(Lists.newArrayList(new Integer(0), new Integer(1), new Integer(3)), evidence);
+        PhasedEvidence victim = new PhasedEvidence(Lists.newArrayList(Integer.valueOf(0), Integer.valueOf(1), Integer.valueOf(3)), evidence);
         HlaSequenceLoci catCandidate = createSequenceLoci(new HlaSequence(HlaAllele.fromString("A*01:01"), "CART"));
         HlaSequenceLoci atcCandidate = createSequenceLoci(new HlaSequence(HlaAllele.fromString("A*01:02"), "ATRC"));
         HlaSequenceLoci wildAtcCandidate = createSequenceLoci(new HlaSequence(HlaAllele.fromString("A*01:03"), "*TRC"));

--- a/lilac/src/test/java/com/hartwig/hmftools/lilac/fragment/FragmentsTest.java
+++ b/lilac/src/test/java/com/hartwig/hmftools/lilac/fragment/FragmentsTest.java
@@ -52,7 +52,7 @@ public class FragmentsTest
         assertTrue(frag1.validate());
         assertEquals(2, mergedFrag.getGenes().size());
         assertEquals(1, mergedFrag.getNucleotideLoci().size());
-        assertEquals(new Integer(1), mergedFrag.getNucleotideLoci().get(0));
+        assertEquals(Integer.valueOf(1), mergedFrag.getNucleotideLoci().get(0));
         assertEquals(1, mergedFrag.getNucleotideQuality().size());
         assertEquals(1, mergedFrag.getNucleotides().size());
 
@@ -66,8 +66,8 @@ public class FragmentsTest
         assertTrue(frag1.validate());
         assertEquals(2, mergedFrag.getGenes().size());
         assertEquals(4, mergedFrag.getNucleotideLoci().size());
-        assertEquals(new Integer(0), mergedFrag.getNucleotideLoci().get(0));
-        assertEquals(new Integer(1), mergedFrag.getNucleotideLoci().get(1));
+        assertEquals(Integer.valueOf(0), mergedFrag.getNucleotideLoci().get(0));
+        assertEquals(Integer.valueOf(1), mergedFrag.getNucleotideLoci().get(1));
         assertEquals(4, mergedFrag.getNucleotideQuality().size());
         assertEquals(4, mergedFrag.getNucleotides().size());
 
@@ -81,10 +81,10 @@ public class FragmentsTest
         assertTrue(frag1.validate());
         assertEquals(3, mergedFrag.getGenes().size());
         assertEquals(6, mergedFrag.getNucleotideLoci().size());
-        assertEquals(new Integer(0), mergedFrag.getNucleotideLoci().get(0));
-        assertEquals(new Integer(3), mergedFrag.getNucleotideLoci().get(3));
-        assertEquals(new Integer(4), mergedFrag.getNucleotideLoci().get(4));
-        assertEquals(new Integer(5), mergedFrag.getNucleotideLoci().get(5));
+        assertEquals(Integer.valueOf(0), mergedFrag.getNucleotideLoci().get(0));
+        assertEquals(Integer.valueOf(3), mergedFrag.getNucleotideLoci().get(3));
+        assertEquals(Integer.valueOf(4), mergedFrag.getNucleotideLoci().get(4));
+        assertEquals(Integer.valueOf(5), mergedFrag.getNucleotideLoci().get(5));
         assertEquals(6, mergedFrag.getNucleotideQuality().size());
         assertEquals(6, mergedFrag.getNucleotides().size());
     }

--- a/linx/pom.xml
+++ b/linx/pom.xml
@@ -23,18 +23,6 @@
             <artifactId>patient-db</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>

--- a/linx/src/main/java/com/hartwig/hmftools/linx/analysis/ClusterAnalyser.java
+++ b/linx/src/main/java/com/hartwig/hmftools/linx/analysis/ClusterAnalyser.java
@@ -212,7 +212,7 @@ public class ClusterAnalyser {
 
         // take note of DM clusters so they can be rechecked after any final cluster merging
         final List<Integer> dmClusterIds = mClusters.stream().filter(x -> x.hasAnnotation(CLUSTER_ANNOT_DM))
-                .map(x -> new Integer(x.id())).collect(Collectors.toList());
+                .map(x -> Integer.valueOf(x.id())).collect(Collectors.toList());
 
         // re-check foldbacks amongst newly formed chains and then DM status
         if(FoldbackFinder.markFoldbacks(mState.getChrBreakendMap(), true))

--- a/linx/src/main/java/com/hartwig/hmftools/linx/visualiser/circos/CircosDataWriter.java
+++ b/linx/src/main/java/com/hartwig/hmftools/linx/visualiser/circos/CircosDataWriter.java
@@ -6,8 +6,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -27,16 +29,16 @@ import com.hartwig.hmftools.linx.visualiser.data.AdjustedPositions;
 import com.hartwig.hmftools.linx.visualiser.data.Connector;
 import com.hartwig.hmftools.linx.visualiser.data.CopyNumberAlteration;
 import com.hartwig.hmftools.linx.visualiser.data.Gene;
+import com.hartwig.hmftools.linx.visualiser.data.Segment;
 import com.hartwig.hmftools.linx.visualiser.data.VisSvData;
 import com.hartwig.hmftools.linx.visualiser.data.VisLinks;
-import com.hartwig.hmftools.linx.visualiser.data.Segment;
 import com.hartwig.hmftools.linx.visualiser.file.VisGeneExon;
 
 import org.jetbrains.annotations.NotNull;
 
 public class CircosDataWriter
 {
-    private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("#.###");
+    private static final DecimalFormat RATIO_FORMAT = new DecimalFormat("#.###", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
     private static final DecimalFormat POSITION_FORMAT = new DecimalFormat("#,###");
     private static final String SINGLE_BLUE = "(107,174,214)";
     private static final String SINGLE_RED = "(214,144,107)";
@@ -633,10 +635,10 @@ public class CircosDataWriter
 
         if (value < 99_950)
         {
-            return String.format("%.1fk", value / 1_000d);
+            return String.format(Locale.ENGLISH, "%.1fk", value / 1_000d);
         }
 
-        return String.format("%.1fm", value / 1_000_000d);
+        return String.format(Locale.ENGLISH, "%.1fm", value / 1_000_000d);
     }
 
 }

--- a/neo/pom.xml
+++ b/neo/pom.xml
@@ -23,14 +23,6 @@
             <artifactId>patient-db</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>

--- a/neo/src/test/java/com/hartwig/hmftools/neo/epitope/NeoEpitopeTest.java
+++ b/neo/src/test/java/com/hartwig/hmftools/neo/epitope/NeoEpitopeTest.java
@@ -53,8 +53,8 @@ public class NeoEpitopeTest
         // tests: SNP, delete, insertion
 
         int[] exonStarts = {0, 20, 40, 60, 80, 100};
-        Integer codingStart = new Integer(25);
-        Integer codingEnd = new Integer(85);
+        Integer codingStart = Integer.valueOf(25);
+        Integer codingEnd = Integer.valueOf(85);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -236,8 +236,8 @@ public class NeoEpitopeTest
         // tests: SNP, delete, insertion
 
         int[] exonStarts = {0, 20, 40, 60, 80, 100};
-        Integer codingStart = new Integer(25);
-        Integer codingEnd = new Integer(85);
+        Integer codingStart = Integer.valueOf(25);
+        Integer codingEnd = Integer.valueOf(85);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -407,8 +407,8 @@ public class NeoEpitopeTest
         refGenome.RefGenomeMap.put(CHR_1, chr1Bases);
 
         int[] exonStarts = { 0, 20, 40, 60, 80, 100 };
-        Integer codingStart = new Integer(25);
-        Integer codingEnd = new Integer(85);
+        Integer codingStart = Integer.valueOf(25);
+        Integer codingEnd = Integer.valueOf(85);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -709,8 +709,8 @@ public class NeoEpitopeTest
         refGenome.RefGenomeMap.put(CHR_1, chr1Bases);
 
         int[] exonStarts = { 0, 20, 40, 60, 80, 100 };
-        Integer codingStart = new Integer(25);
-        Integer codingEnd = new Integer(85);
+        Integer codingStart = Integer.valueOf(25);
+        Integer codingEnd = Integer.valueOf(85);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -874,8 +874,8 @@ public class NeoEpitopeTest
         refGenome.RefGenomeMap.put(CHR_1, chr1Bases);
 
         int[] exonStarts = { 0, 20, 40, 60, 80, 100 };
-        Integer codingStart = new Integer(25);
-        Integer codingEnd = new Integer(66);
+        Integer codingStart = Integer.valueOf(25);
+        Integer codingEnd = Integer.valueOf(66);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -923,8 +923,8 @@ public class NeoEpitopeTest
         // tests: intronic vs exonic, with and without insertions
 
         int[] exonStarts = { 0, 20, 40, 60, 80, 100 };
-        Integer codingStart = new Integer(25);
-        Integer codingEnd = new Integer(85);
+        Integer codingStart = Integer.valueOf(25);
+        Integer codingEnd = Integer.valueOf(85);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");

--- a/neo/src/test/java/com/hartwig/hmftools/neo/epitope/NeoEpitopeUtilsTest.java
+++ b/neo/src/test/java/com/hartwig/hmftools/neo/epitope/NeoEpitopeUtilsTest.java
@@ -56,8 +56,8 @@ public class NeoEpitopeUtilsTest
         // tests: repeated for each strand
 
         int[] exonStarts = {0, 20, 40, 60, 80, 100};
-        Integer codingStart = new Integer(25);
-        Integer codingEnd = new Integer(85);
+        Integer codingStart = Integer.valueOf(25);
+        Integer codingEnd = Integer.valueOf(85);
 
         TranscriptData transDataUp = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -168,8 +168,8 @@ public class NeoEpitopeUtilsTest
         // non-coding - get all bases
 
         int[] exonStarts = { 100, 120, 140, 160, 180, 200, 220, 240, 260 };
-        Integer codingStart = new Integer(125);
-        Integer codingEnd = new Integer(245);
+        Integer codingStart = Integer.valueOf(125);
+        Integer codingEnd = Integer.valueOf(245);
 
         TranscriptData transData = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");

--- a/paddle/pom.xml
+++ b/paddle/pom.xml
@@ -36,16 +36,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.kotest</groupId>
-            <artifactId>kotest-runner-junit5-jvm</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.kotest</groupId>
-            <artifactId>kotest-assertions-core-jvm</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/paddle/pom.xml
+++ b/paddle/pom.xml
@@ -32,8 +32,18 @@
         </dependency>
 
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-junit5-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/patient-db/pom.xml
+++ b/patient-db/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
         </dependency>

--- a/patient-db/pom.xml
+++ b/patient-db/pom.xml
@@ -127,7 +127,7 @@
                     </jdbc>
                     <generator>
                         <database>
-                            <name>org.jooq.util.mysql.MySQLDatabase</name>
+                            <name>org.jooq.meta.mysql.MySQLDatabase</name>
                             <includes>.*</includes>
                             <inputSchema>hmfpatients_test</inputSchema>
                         </database>

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/ClinicalDAO.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/ClinicalDAO.java
@@ -102,9 +102,9 @@ class ClinicalDAO {
                 .values(sample.sampleId(),
                         patientId,
                         sample.setName(),
-                        DatabaseUtil.sqlDate(sample.arrivalDate()),
-                        DatabaseUtil.sqlDate(sample.samplingDate()),
-                        DatabaseUtil.sqlDate(sample.reportedDate()),
+                        sample.arrivalDate(),
+                        sample.samplingDate(),
+                        sample.reportedDate(),
                         sample.dnaNanograms(),
                         sample.limsPrimaryTumor(),
                         sample.pathologyTumorPercentage())
@@ -148,8 +148,8 @@ class ClinicalDAO {
                         BASELINE.PRETREATMENTSTYPE,
                         BASELINE.PRETREATMENTSMECHANISM)
                 .values(patientId,
-                        DatabaseUtil.sqlDate(patient.registrationDate()),
-                        DatabaseUtil.sqlDate(patient.informedConsentDate()),
+                        patient.registrationDate(),
+                        patient.informedConsentDate(),
                         patient.pifVersion(),
                         toByte(patient.inDatabase()),
                         toByte(patient.outsideEU()),
@@ -162,7 +162,7 @@ class ClinicalDAO {
                         patient.curatedPrimaryTumor().subType(),
                         patient.curatedPrimaryTumor().extraDetails(),
                         (byte) (patient.curatedPrimaryTumor().isOverridden() ? 1 : 0),
-                        DatabaseUtil.sqlDate(patient.deathDate()),
+                        patient.deathDate(),
                         preTreatmentData.treatmentGiven(),
                         preTreatmentData.radiotherapyGiven(),
                         preTreatmentData.treatmentName(),
@@ -227,8 +227,8 @@ class ClinicalDAO {
                             PRETREATMENTDRUG.MECHANISM,
                             PRETREATMENTDRUG.BESTRESPONSE)
                     .values(patientId,
-                            DatabaseUtil.sqlDate(drug.startDate()),
-                            DatabaseUtil.sqlDate(drug.endDate()),
+                            drug.startDate(),
+                            drug.endDate(),
                             curatedTreatment.name(),
                             curatedTreatment.type(),
                             curatedTreatment.mechanism(),
@@ -260,7 +260,7 @@ class ClinicalDAO {
                         biopsy.curatedType(),
                         biopsy.site(),
                         biopsy.location(),
-                        DatabaseUtil.sqlDate(biopsy.date()))
+                        biopsy.date())
                 .execute();
         writeFormStatus(biopsy.id(), BIOPSY.getName(), "biopsy", biopsy.formStatus());
     }
@@ -282,8 +282,8 @@ class ClinicalDAO {
                         patientId,
                         treatment.treatmentGiven(),
                         treatment.radiotherapyGiven(),
-                        DatabaseUtil.sqlDate(treatment.startDate()),
-                        DatabaseUtil.sqlDate(treatment.endDate()),
+                        treatment.startDate(),
+                        treatment.endDate(),
                         treatment.treatmentName(),
                         treatment.consolidatedType(),
                         treatment.consolidatedMechanism())
@@ -304,8 +304,8 @@ class ClinicalDAO {
                             DRUG.MECHANISM)
                     .values(treatmentId,
                             patientId,
-                            DatabaseUtil.sqlDate(drug.startDate()),
-                            DatabaseUtil.sqlDate(drug.endDate()),
+                            drug.startDate(),
+                            drug.endDate(),
                             curatedTreatment.name(),
                             curatedTreatment.type(),
                             curatedTreatment.mechanism())
@@ -326,7 +326,7 @@ class ClinicalDAO {
                         TREATMENTRESPONSE.BONEONLYDISEASE)
                 .values(treatmentResponse.treatmentId(),
                         patientId,
-                        DatabaseUtil.sqlDate(treatmentResponse.date()),
+                        treatmentResponse.date(),
                         treatmentResponse.response(),
                         treatmentResponse.measurementDone(),
                         treatmentResponse.boneOnlyDisease())
@@ -345,7 +345,7 @@ class ClinicalDAO {
                         TUMORMARKER.MEASUREMENT,
                         TUMORMARKER.UNIT)
                 .values(patientId,
-                        DatabaseUtil.sqlDate(tumorMarker.date()),
+                        tumorMarker.date(),
                         tumorMarker.marker(),
                         tumorMarker.measurement(),
                         tumorMarker.unit())
@@ -365,7 +365,7 @@ class ClinicalDAO {
                         RANOMEASUREMENT.NOTARGETLESIONRESPONSE,
                         RANOMEASUREMENT.OVERALLRESPONSE)
                 .values(patientId,
-                        DatabaseUtil.sqlDate(RanoMeasurement.responseDate()),
+                        RanoMeasurement.responseDate(),
                         RanoMeasurement.therapyGiven(),
                         RanoMeasurement.targetLesionResponse(),
                         RanoMeasurement.noTargetLesionResponse(),

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/CuppaDAO.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/CuppaDAO.java
@@ -1,7 +1,6 @@
 package com.hartwig.hmftools.patientdb.dao;
 
-import java.sql.Timestamp;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static com.hartwig.hmftools.patientdb.database.hmfpatients.Tables.CUPPA;
 
@@ -21,7 +20,7 @@ public class CuppaDAO {
 
     void writeCuppa(@NotNull String sample, @NotNull MolecularTissueOrginData molecularTissueOrginData) {
         deleteCuppaForSample(sample);
-        Timestamp timestamp = new Timestamp(new Date().getTime());
+        LocalDateTime timestamp = LocalDateTime.now();
 
         context.insertInto(CUPPA, CUPPA.MODIFIED, CUPPA.SAMPLEID, CUPPA.CUPPATUMORLOCATION, CUPPA.CUPPAPREDICTION)
                 .values(timestamp, sample, molecularTissueOrginData.predictedOrigin(), molecularTissueOrginData.predictionLikelihood())

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/DatabaseAccess.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/DatabaseAccess.java
@@ -1,7 +1,5 @@
 package com.hartwig.hmftools.patientdb.dao;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.EnumSet;
 import java.util.List;
@@ -59,6 +57,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jooq.CloseableDSLContext;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.conf.MappedSchema;
@@ -82,7 +81,7 @@ public class DatabaseAccess implements AutoCloseable {
     public static final String DB_DEFAULT_ARGS = "?serverTimezone=UTC&useSSL=false";
 
     @NotNull
-    private final DSLContext context;
+    private final CloseableDSLContext context;
     @NotNull
     private final EcrfDAO ecrfDAO;
     @NotNull
@@ -139,10 +138,8 @@ public class DatabaseAccess implements AutoCloseable {
     public DatabaseAccess(@NotNull final String userName, @NotNull final String password, @NotNull final String url) throws SQLException {
         // Disable annoying jooq self-ad message
         System.setProperty("org.jooq.no-logo", "true");
-        Connection conn = DriverManager.getConnection(url, userName, password);
-        String catalog = conn.getCatalog();
-        LOGGER.debug("Connecting to database {}", catalog);
-        this.context = DSL.using(conn, SQLDialect.MYSQL, settings(catalog));
+        LOGGER.debug("Connecting to database {} @ {}", userName, url);
+        this.context = DSL.using(url, userName, password);
 
         this.ecrfDAO = new EcrfDAO(context);
         this.clinicalDAO = new ClinicalDAO(context);

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/DatabaseUtil.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/DatabaseUtil.java
@@ -1,7 +1,5 @@
 package com.hartwig.hmftools.patientdb.dao;
 
-import java.time.LocalDate;
-
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,11 +11,6 @@ final public class DatabaseUtil {
     }
 
     public static final int DB_BATCH_INSERT_SIZE = 1000;
-
-    @Nullable
-    public static java.sql.Date sqlDate(@Nullable LocalDate date) {
-        return date != null ? java.sql.Date.valueOf(date) : null;
-    }
 
     @Nullable
     public static Double decimal(@Nullable Double number) {

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/HlaTypeDAO.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/dao/HlaTypeDAO.java
@@ -3,8 +3,7 @@ package com.hartwig.hmftools.patientdb.dao;
 import static com.hartwig.hmftools.patientdb.database.hmfpatients.Tables.HLATYPE;
 import static com.hartwig.hmftools.patientdb.database.hmfpatients.Tables.HLATYPEDETAILS;
 
-import java.sql.Timestamp;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.hartwig.hmftools.common.hla.HlaType;
@@ -26,7 +25,7 @@ class HlaTypeDAO {
     void writeType(@NotNull final String sample, @NotNull HlaType type) {
         context.delete(HLATYPE).where(HLATYPE.SAMPLEID.eq(sample)).execute();
 
-        Timestamp timestamp = new Timestamp(new Date().getTime());
+        LocalDateTime timestamp = LocalDateTime.now();
         context.insertInto(HLATYPE,
                 HLATYPE.MODIFIED,
                 HLATYPE.SAMPLEID,
@@ -53,7 +52,7 @@ class HlaTypeDAO {
 
     void writeTypeDetails(@NotNull final String sample, @NotNull List<HlaTypeDetails> typeDetails) {
         context.delete(HLATYPEDETAILS).where(HLATYPEDETAILS.SAMPLEID.eq(sample)).execute();
-        Timestamp timestamp = new Timestamp(new Date().getTime());
+        LocalDateTime timestamp = LocalDateTime.now();
 
         InsertValuesStep15 inserter = context.insertInto(HLATYPEDETAILS,
                 HLATYPEDETAILS.MODIFIED,

--- a/patient-db/src/test/java/com/hartwig/hmftools/patientdb/LoadClinicalDataTest.java
+++ b/patient-db/src/test/java/com/hartwig/hmftools/patientdb/LoadClinicalDataTest.java
@@ -76,7 +76,7 @@ public class LoadClinicalDataTest {
 
         BaselineData baselineData = patient.baselineData();
         assertNotNull(baselineData);
-        assertEquals(new Integer(1963), baselineData.birthYear());
+        assertEquals(Integer.valueOf(1963), baselineData.birthYear());
         assertEquals("Breast cancer", baselineData.curatedPrimaryTumor().searchTerm());
         assertEquals("female", baselineData.gender());
         assertEquals(LocalDate.parse("2012-02-17", DATE_FORMATTER), baselineData.informedConsentDate());

--- a/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/reportingdb/ReportingDb.java
+++ b/patient-reporter/src/main/java/com/hartwig/hmftools/patientreporter/reportingdb/ReportingDb.java
@@ -7,7 +7,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import com.google.gson.GsonBuilder;
@@ -39,7 +41,7 @@ public class ReportingDb {
 
             GenomicAnalysis analysis = report.genomicAnalysis();
 
-            String purity = new DecimalFormat("0.00").format(analysis.impliedPurity());
+            String purity = new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH)).format(analysis.impliedPurity());
             boolean hasReliableQuality = analysis.hasReliableQuality();
             boolean hasReliablePurity = analysis.hasReliablePurity();
 

--- a/pave/src/test/java/com/hartwig/hmftools/pave/DelCodingContextTest.java
+++ b/pave/src/test/java/com/hartwig/hmftools/pave/DelCodingContextTest.java
@@ -392,8 +392,8 @@ public class DelCodingContextTest
         refGenome.RefGenomeMap.put(CHR_1, chr1Bases);
 
         int[] exonStarts = { 0, 100, 200 };
-        Integer codingStart = new Integer(10);
-        Integer codingEnd = new Integer(250);
+        Integer codingStart = Integer.valueOf(10);
+        Integer codingEnd = Integer.valueOf(250);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 80, codingStart, codingEnd, false, "");

--- a/pave/src/test/java/com/hartwig/hmftools/pave/ImpactTestUtils.java
+++ b/pave/src/test/java/com/hartwig/hmftools/pave/ImpactTestUtils.java
@@ -45,8 +45,8 @@ public final class ImpactTestUtils
         // codons: 15-17, 18-20, 30-32, 33-35, 36-38, 39-50, 51-53 etc
         int[] exonStarts = { 10, 30, 50, 70, 90 };
 
-        Integer codingStart = new Integer(15);
-        Integer codingEnd = new Integer(75);
+        Integer codingStart = Integer.valueOf(15);
+        Integer codingEnd = Integer.valueOf(75);
 
         return createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -57,8 +57,8 @@ public final class ImpactTestUtils
         // codons: 95-93, 92-90, 80-78, 77-75, 74-72, 71-60, 59-57 etc
         int[] exonStarts = { 10, 30, 50, 70, 90, 110, 130 };
 
-        Integer codingStart = new Integer(15);
-        Integer codingEnd = new Integer(95);
+        Integer codingStart = Integer.valueOf(15);
+        Integer codingEnd = Integer.valueOf(95);
 
         return createTransExons(
                 GENE_ID_1, TRANS_ID_1, NEG_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");

--- a/pave/src/test/java/com/hartwig/hmftools/pave/NonCodingContextTest.java
+++ b/pave/src/test/java/com/hartwig/hmftools/pave/NonCodingContextTest.java
@@ -137,8 +137,8 @@ public class NonCodingContextTest
     {
         int[] exonStarts = { 10, 30, 50, 70, 90 };
 
-        Integer codingStart = new Integer(35);
-        Integer codingEnd = new Integer(55);
+        Integer codingStart = Integer.valueOf(35);
+        Integer codingEnd = Integer.valueOf(55);
 
         TranscriptData transDataPos = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -224,8 +224,8 @@ public class NonCodingContextTest
     {
         int[] exonStarts = { 10, 30, 50, 70, 90 };
 
-        Integer codingStart = new Integer(35);
-        Integer codingEnd = new Integer(55);
+        Integer codingStart = Integer.valueOf(35);
+        Integer codingEnd = Integer.valueOf(55);
 
         TranscriptData transDataNeg = createTransExons(
                 GENE_ID_1, TRANS_ID_1, NEG_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");
@@ -316,8 +316,8 @@ public class NonCodingContextTest
         refGenome.RefGenomeMap.put(CHR_1, refBases);
 
         int[] exonStarts = { 100, 200, 300, 400 };
-        Integer codingStart = new Integer(125);
-        Integer codingEnd = new Integer(425);
+        Integer codingStart = Integer.valueOf(125);
+        Integer codingEnd = Integer.valueOf(425);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 50, codingStart, codingEnd, false, "");

--- a/pave/src/test/java/com/hartwig/hmftools/pave/ProteinImpactTest.java
+++ b/pave/src/test/java/com/hartwig/hmftools/pave/ProteinImpactTest.java
@@ -550,8 +550,8 @@ public class ProteinImpactTest
         int[] exonStarts = { 0, 100, 200 };
 
         // codons start on at 10, 13, 16 etc
-        Integer codingStart = new Integer(10);
-        Integer codingEnd = new Integer(250);
+        Integer codingStart = Integer.valueOf(10);
+        Integer codingEnd = Integer.valueOf(250);
 
         TranscriptData transDataPos = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 80, codingStart, codingEnd, false, "");
@@ -692,8 +692,8 @@ public class ProteinImpactTest
         int[] exonStarts = { 10, 30, 50, 70};
 
         // codons start on at 10, 13, 16 etc
-        Integer codingStart = new Integer(15);
-        Integer codingEnd = new Integer(75);
+        Integer codingStart = Integer.valueOf(15);
+        Integer codingEnd = Integer.valueOf(75);
 
         TranscriptData transDataPosStrand = createTransExons(
                 GENE_ID_1, TRANS_ID_1, POS_STRAND, exonStarts, 10, codingStart, codingEnd, false, "");

--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,13 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>11</java.version>
 
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
         <maven.jaxb2.plugin.version>0.14.0</maven.jaxb2.plugin.version>
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
-        <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
 
@@ -106,20 +107,19 @@
         <aws.sdk.version>1.11.213</aws.sdk.version>
         <okhttp.version>3.9.0</okhttp.version>
         <bouncycastle.jdk15.version>1.53</bouncycastle.jdk15.version>
-        <kotlin.version>1.2.61</kotlin.version>
-        <kotlin.coroutines.version>0.23.4</kotlin.coroutines.version>
+        <kotlin.version>1.5.32</kotlin.version>
+        <kotlin.coroutines.version>1.5.2</kotlin.coroutines.version>
         <selenium.version>3.14.0</selenium.version>
         <itext.version>7.1.5</itext.version>
         <tablesaw.version>0.38.5</tablesaw.version>
 
-        <kotlintest.version>2.0.7</kotlintest.version>
+        <kotest.version>4.6.4</kotest.version>
         <junit.version>4.13.1</junit.version>
-        <jmockit.version>1.49</jmockit.version>
         <mockito.version>2.23.4</mockito.version>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
     </properties>
 
     <build>
@@ -164,11 +164,6 @@
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-maven-plugin</artifactId>
                     <version>${kotlin.version}</version>
-                    <configuration>
-                        <args>
-                            <arg>-Xcoroutines=enable</arg>
-                        </args>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.jooq</groupId>
@@ -435,12 +430,6 @@
                 <type>test-jar</type>
             </dependency>
             <dependency>
-                <groupId>org.jmockit</groupId>
-                <artifactId>jmockit</artifactId>
-                <version>${jmockit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
@@ -453,9 +442,15 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>io.kotlintest</groupId>
-                <artifactId>kotlintest</artifactId>
-                <version>${kotlintest.version}</version>
+                <groupId>io.kotest</groupId>
+                <artifactId>kotest-runner-junit5-jvm</artifactId>
+                <version>${kotest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.kotest</groupId>
+                <artifactId>kotest-assertions-core-jvm</artifactId>
+                <version>${kotest.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -114,10 +114,11 @@
 
         <kotlintest.version>2.0.7</kotlintest.version>
         <junit.version>4.13.1</junit.version>
-        <jmockit.version>1.38</jmockit.version>
+        <jmockit.version>1.49</jmockit.version>
+        <mockito.version>2.23.4</mockito.version>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
@@ -437,6 +438,12 @@
                 <groupId>org.jmockit</groupId>
                 <artifactId>jmockit</artifactId>
                 <version>${jmockit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
         <maven.jaxb2.plugin.version>0.14.0</maven.jaxb2.plugin.version>
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
@@ -87,7 +87,7 @@
         <virus-interpreter.version>1.1</virus-interpreter.version>
 
         <commons.cli.version>1.3.1</commons.cli.version>
-        <immutables.version>2.4.4</immutables.version>
+        <immutables.version>2.5.5</immutables.version>
         <htsjdk.version>2.23.0</htsjdk.version>
         <intellij.annotations.version>12.0</intellij.annotations.version>
         <google.guava.version>23.0</google.guava.version>
@@ -99,7 +99,7 @@
         <apache.log4j.version>2.8.1</apache.log4j.version>
         <apache.log4j.slf4j.version>2.8.1</apache.log4j.slf4j.version>
         <apache.lucene.version>7.1.0</apache.lucene.version>
-        <jooq.version>3.9.5</jooq.version>
+        <jooq.version>3.15.5</jooq.version>
         <mysqlconnector.version>8.0.11</mysqlconnector.version>
         <rxjava2.version>2.1.2</rxjava2.version>
         <retrofit.version>2.4.0</retrofit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
 
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
-        <maven.jaxb2.plugin.version>0.14.0</maven.jaxb2.plugin.version>
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
@@ -104,7 +103,6 @@
         <rxjava2.version>2.1.2</rxjava2.version>
         <retrofit.version>2.4.0</retrofit.version>
         <moshi.version>1.6.0</moshi.version>
-        <aws.sdk.version>1.11.213</aws.sdk.version>
         <okhttp.version>3.9.0</okhttp.version>
         <bouncycastle.jdk15.version>1.53</bouncycastle.jdk15.version>
         <kotlin.version>1.5.32</kotlin.version>
@@ -144,11 +142,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven.jar.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.jvnet.jaxb2.maven2</groupId>
-                    <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>${maven.jaxb2.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -337,11 +330,6 @@
                 <groupId>com.squareup.moshi</groupId>
                 <artifactId>moshi-kotlin</artifactId>
                 <version>${moshi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-s3</artifactId>
-                <version>${aws.sdk.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,10 @@
         <apache.commons.math3.version>3.6</apache.commons.math3.version>
         <apache.commons.csv.version>1.5</apache.commons.csv.version>
         <apache.commons.dbcp2.version>2.1.1</apache.commons.dbcp2.version>
-        <apache.log4j.version>2.8.1</apache.log4j.version>
-        <apache.log4j.slf4j.version>2.8.1</apache.log4j.slf4j.version>
+        <apache.log4j.version>2.17.1</apache.log4j.version>
         <apache.lucene.version>7.1.0</apache.lucene.version>
         <jooq.version>3.15.5</jooq.version>
-        <mysqlconnector.version>8.0.11</mysqlconnector.version>
+        <mysqlconnector.version>8.0.16</mysqlconnector.version>
         <rxjava2.version>2.1.2</rxjava2.version>
         <retrofit.version>2.4.0</retrofit.version>
         <moshi.version>1.6.0</moshi.version>
@@ -279,7 +278,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${apache.log4j.slf4j.version}</version>
+                <version>${apache.log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jooq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
         <immutables.version>2.5.5</immutables.version>
         <htsjdk.version>2.23.0</htsjdk.version>
         <intellij.annotations.version>12.0</intellij.annotations.version>
-        <google.guava.version>23.0</google.guava.version>
-        <google.gson.version>2.8.1</google.gson.version>
+        <google.guava.version>31.0.1-jre</google.guava.version>
+        <google.gson.version>2.8.9</google.gson.version>
         <apache.commons.lang3.version>3.6</apache.commons.lang3.version>
         <apache.commons.math3.version>3.6</apache.commons.math3.version>
         <apache.commons.csv.version>1.5</apache.commons.csv.version>

--- a/protect/pom.xml
+++ b/protect/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>serve</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>

--- a/protect/src/test/java/com/hartwig/hmftools/protect/ProtectAlgoTest.java
+++ b/protect/src/test/java/com/hartwig/hmftools/protect/ProtectAlgoTest.java
@@ -39,7 +39,7 @@ public class ProtectAlgoTest {
     public void canRunProtectAlgo() throws IOException {
         ProtectConfig config = ImmutableProtectConfig.builder()
                 .tumorSampleId("sample")
-                .referenceSampleId(null)
+                .referenceSampleId("ref")
                 .outputDir(Strings.EMPTY)
                 .serveActionabilityDir(SERVE_DIR)
                 .refGenomeVersion(RefGenomeVersion.V37)

--- a/purple/pom.xml
+++ b/purple/pom.xml
@@ -48,7 +48,6 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
@@ -74,7 +73,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>${maven.compiler.source}</source>

--- a/purple/pom.xml
+++ b/purple/pom.xml
@@ -28,8 +28,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/purple/pom.xml
+++ b/purple/pom.xml
@@ -27,6 +27,7 @@
             <artifactId>value</artifactId>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/purple/src/test/java/com/hartwig/hmftools/purple/gene/RegionZipperTest.java
+++ b/purple/src/test/java/com/hartwig/hmftools/purple/gene/RegionZipperTest.java
@@ -1,5 +1,8 @@
 package com.hartwig.hmftools.purple.gene;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -8,16 +11,13 @@ import com.hartwig.hmftools.common.genome.region.GenomeRegions;
 
 import org.junit.Test;
 
-import mockit.Expectations;
-import mockit.Injectable;
-
 public class RegionZipperTest {
-
-    @Injectable
-    private RegionZipperHandler<GenomeRegion, GenomeRegion> handler;
 
     @Test
     public void testZipper() {
+        @SuppressWarnings("unchecked")
+        RegionZipperHandler<GenomeRegion, GenomeRegion> handler = mock(RegionZipperHandler.class);
+
         final List<GenomeRegion> primary = Lists.newArrayList(GenomeRegions.create("1", 1, 100),
                 GenomeRegions.create("1", 500, 1000),
                 GenomeRegions.create("2", 500, 1000),
@@ -28,20 +28,18 @@ public class RegionZipperTest {
                 GenomeRegions.create("2", 500, 1000),
                 GenomeRegions.create("3", 500, 1000));
 
-        new Expectations() {{
-            handler.enterChromosome("1");
-            handler.primary(primary.get(0));
-            handler.primary(primary.get(1));
-            handler.secondary(secondary.get(0));
-            handler.enterChromosome("2");
-            handler.primary(primary.get(2));
-            handler.secondary(secondary.get(1));
-            handler.enterChromosome("3");
-            handler.secondary(secondary.get(2));
-            handler.enterChromosome("4");
-            handler.primary(primary.get(3));
-        }};
-
         RegionZipper.zip(primary, secondary, handler);
+
+        verify(handler).enterChromosome("1");
+        verify(handler).primary(primary.get(0));
+        verify(handler).primary(primary.get(1));
+        verify(handler).secondary(secondary.get(0));
+        verify(handler).enterChromosome("2");
+        verify(handler).primary(primary.get(2));
+        verify(handler).secondary(secondary.get(1));
+        verify(handler).enterChromosome("3");
+        verify(handler).secondary(secondary.get(2));
+        verify(handler).enterChromosome("4");
+        verify(handler).primary(primary.get(3));
     }
 }

--- a/purple/src/test/java/com/hartwig/hmftools/purple/recovery/RecoverStructuralVariantsTest.java
+++ b/purple/src/test/java/com/hartwig/hmftools/purple/recovery/RecoverStructuralVariantsTest.java
@@ -20,16 +20,21 @@ import com.hartwig.hmftools.common.sv.StructuralVariant;
 import com.hartwig.hmftools.common.sv.StructuralVariantType;
 
 import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import htsjdk.variant.variantcontext.VariantContext;
-import mockit.Injectable;
 
 public class RecoverStructuralVariantsTest
 {
-    @Injectable
     private RecoveredVariantFactory recoveredVariantFactory;
     private final PurityAdjuster purityAdjuster = new PurityAdjusterTypicalChromosome(Gender.FEMALE, 1, 0.68);
+
+    @Before
+    public void setup() {
+        recoveredVariantFactory = Mockito.mock(RecoveredVariantFactory.class);
+    }
 
     @Test
     public void testRecoverUnbalancedSingle() throws IOException

--- a/sage/pom.xml
+++ b/sage/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>hmf-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.hartwig</groupId>
-            <artifactId>patient-db</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>

--- a/sage/src/main/java/com/hartwig/hmftools/sage/pipeline/CandidateStage.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/pipeline/CandidateStage.java
@@ -10,6 +10,7 @@ import com.hartwig.hmftools.common.variant.hotspot.VariantHotspot;
 import com.hartwig.hmftools.sage.candidate.Candidate;
 import com.hartwig.hmftools.sage.candidate.Candidates;
 import com.hartwig.hmftools.sage.config.SageConfig;
+import com.hartwig.hmftools.sage.context.AltContext;
 import com.hartwig.hmftools.sage.coverage.Coverage;
 import com.hartwig.hmftools.sage.evidence.CandidateEvidence;
 import com.hartwig.hmftools.sage.ref.RefSequence;
@@ -62,7 +63,7 @@ public class CandidateStage
                 final String sample = mConfig.TumorIds.get(i);
                 final String sampleBam = mConfig.TumorBams.get(i);
 
-                done = done.thenApply(aVoid -> mCandidateEvidence.readBam(sample, sampleBam, refSequence, region))
+                done = done.<List<AltContext>>thenApply(aVoid -> mCandidateEvidence.readBam(sample, sampleBam, refSequence, region))
                         .thenAccept(initialCandidates::add);
             }
             return done.thenApply(y -> initialCandidates.candidates());

--- a/sage/src/main/java/com/hartwig/hmftools/sage/pipeline/EvidenceStage.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/pipeline/EvidenceStage.java
@@ -8,6 +8,7 @@ import com.hartwig.hmftools.sage.candidate.Candidate;
 import com.hartwig.hmftools.sage.config.SageConfig;
 import com.hartwig.hmftools.sage.evidence.ReadContextEvidence;
 import com.hartwig.hmftools.sage.quality.QualityRecalibrationMap;
+import com.hartwig.hmftools.sage.read.ReadContextCounter;
 import com.hartwig.hmftools.sage.read.ReadContextCounters;
 
 import org.jetbrains.annotations.NotNull;
@@ -41,7 +42,7 @@ public class EvidenceStage
                 final String sample = samples.get(i);
                 final String sampleBam = sampleBams.get(i);
 
-                done = done.thenApply(x -> mReadContextEvidence.get(initialCandidates, sample, sampleBam)).thenAccept(result::addCounters);
+                done = done.<List<ReadContextCounter>>thenApply(x -> mReadContextEvidence.get(initialCandidates, sample, sampleBam)).thenAccept(result::addCounters);
             }
 
             return done.thenApply(x -> result);

--- a/sage/src/main/java/com/hartwig/hmftools/sage/quality/BaseQualityRecalibration.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/quality/BaseQualityRecalibration.java
@@ -76,21 +76,21 @@ public class BaseQualityRecalibration
     private void processSample(final String sampleId, final String bamFile, final List<ChrBaseRegion> regions)
     {
         List<BaseQualityRegionCounter> regionCounters = Lists.newArrayList();
-        List<FutureTask> taskList = new ArrayList<FutureTask>();
+        List<FutureTask<Long>> taskList = new ArrayList<>();
 
         for(ChrBaseRegion region : regions)
         {
             BaseQualityRegionCounter regionCounter = new BaseQualityRegionCounter(mConfig, bamFile, mRefGenome, region);
             regionCounters.add(regionCounter);
 
-            FutureTask futureTask = new FutureTask(regionCounter);
+            FutureTask<Long> futureTask = new FutureTask<>(regionCounter);
             taskList.add(futureTask);
             mExecutorService.execute(futureTask);
         }
 
         try
         {
-            for(FutureTask task : taskList)
+            for(FutureTask<Long> task : taskList)
             {
                 task.get();
             }

--- a/sage/src/main/java/com/hartwig/hmftools/sage/quality/BaseQualityRegionCounter.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/quality/BaseQualityRegionCounter.java
@@ -32,7 +32,7 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 
-class BaseQualityRegionCounter implements CigarHandler, Callable
+class BaseQualityRegionCounter implements CigarHandler, Callable<Long>
 {
     private final String mBamFile;
     private final ChrBaseRegion mRegion;

--- a/serve/src/main/java/com/hartwig/hmftools/serve/extraction/codon/tools/CodonAnnotationToVCFConverter.java
+++ b/serve/src/main/java/com/hartwig/hmftools/serve/extraction/codon/tools/CodonAnnotationToVCFConverter.java
@@ -94,7 +94,7 @@ public class CodonAnnotationToVCFConverter {
                 .chr(chromosome)
                 .start(position)
                 .alleles(alleles)
-                .computeEndFromAlleles(alleles, new Long(position).intValue())
+                .computeEndFromAlleles(alleles, Long.valueOf(position).intValue())
                 .attribute(VCFWriterFactory.INPUT_FIELD, KeyFormatter.toCodonKey(gene, transcript, codonRank))
                 .attribute(VCFWriterFactory.SOURCES_FIELD, Knowledgebase.toCommaSeparatedSourceString(knowledgebases))
                 .make();

--- a/serve/src/main/java/com/hartwig/hmftools/serve/extraction/exon/tools/ExonAnnotationToVCFConverter.java
+++ b/serve/src/main/java/com/hartwig/hmftools/serve/extraction/exon/tools/ExonAnnotationToVCFConverter.java
@@ -93,7 +93,7 @@ public class ExonAnnotationToVCFConverter {
                 .chr(chromosome)
                 .start(position)
                 .alleles(alleles)
-                .computeEndFromAlleles(alleles, new Long(position).intValue())
+                .computeEndFromAlleles(alleles, Long.valueOf(position).intValue())
                 .attribute(VCFWriterFactory.INPUT_FIELD, KeyFormatter.toExonKey(gene, transcript, exonRank))
                 .attribute(VCFWriterFactory.SOURCES_FIELD, Knowledgebase.toCommaSeparatedSourceString(knowledgebases))
                 .make();

--- a/sigs/pom.xml
+++ b/sigs/pom.xml
@@ -22,19 +22,6 @@
             <groupId>com.hartwig</groupId>
             <artifactId>patient-db</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/BaReporter.java
+++ b/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/BaReporter.java
@@ -580,7 +580,7 @@ public class BaReporter
         }
         else
         {
-            Map<String,Integer> groupComboMap = new HashMap();
+            Map<String,Integer> groupComboMap = new HashMap<>();
 
             for (int i = 0; i < cssResults.size(); ++i)
             {

--- a/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/BucketAnalyser.java
+++ b/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/BucketAnalyser.java
@@ -209,7 +209,7 @@ public class BucketAnalyser
         mSigDiscovery = new SigDiscovery(this);
 
         // initialise data stores
-        mCancerSamplesMap = new HashMap();
+        mCancerSamplesMap = new HashMap<>();
 
         // initialise run state
         mHasErrors = false;
@@ -220,7 +220,7 @@ public class BucketAnalyser
         mBackgroundCount = 0;
         mPermittedElevRange = null;
         mPermittedBgRange = null;
-        mNoiseRangeMap = new HashMap();
+        mNoiseRangeMap = new HashMap<>();
 
         mSampleData = Lists.newArrayList();
 
@@ -3041,7 +3041,7 @@ public class BucketAnalyser
 
         int categoryCount = fieldNames.size() - 1; // since sampleId is the first column
 
-        HashMap<String,Integer> categoryCounts = new HashMap();
+        HashMap<String,Integer> categoryCounts = new HashMap<>();
 
         for(Integer sampleId : sampleIds)
         {

--- a/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/BucketGroup.java
+++ b/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/BucketGroup.java
@@ -80,7 +80,7 @@ public class BucketGroup  {
         mExtraBucketIds = Lists.newArrayList();
         mSampleCountTotals = Lists.newArrayList();
         mSampleCounts = Lists.newArrayList();
-        mSampleCountsMap = new HashMap();
+        mSampleCountsMap = new HashMap<>();
         mCombinedBucketCounts = null;
         mBucketRatios = null;
         mBucketRatioRanges = null;

--- a/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/SigDiscovery.java
+++ b/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/SigDiscovery.java
@@ -475,7 +475,7 @@ public class SigDiscovery
 
         LOGGER.debug("created {} overlap-unallocated bucket groups, samplesIncluded({})", newGroups.size(), allSamples.size());
 
-        Map<Integer, Integer> candidateBucketCounts = new HashMap();
+        Map<Integer, Integer> candidateBucketCounts = new HashMap<>();
         List<Integer> candidateBuckets = Lists.newArrayList();
         List<SampleData> samplesList = Lists.newArrayList();
 

--- a/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/SigOptimiser.java
+++ b/sigs/src/main/java/com/hartwig/hmftools/sigs/buckets/SigOptimiser.java
@@ -308,7 +308,7 @@ public class SigOptimiser
         mSamples.addAll(samples);
         mSampleCount = mSamples.size();
 
-        mBucketInfo = new HashMap();
+        mBucketInfo = new HashMap<>();
 
         mStartRatios = new double[mBucketCount];
         copyVector(refRatios, mStartRatios);

--- a/stat-calcs/pom.xml
+++ b/stat-calcs/pom.xml
@@ -18,15 +18,6 @@
             <groupId>com.hartwig</groupId>
             <artifactId>hmf-common</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/stat-calcs/src/main/java/com/hartwig/hmftools/statcalcs/cooc/SampleCountsCoOccurence.java
+++ b/stat-calcs/src/main/java/com/hartwig/hmftools/statcalcs/cooc/SampleCountsCoOccurence.java
@@ -55,9 +55,9 @@ public class SampleCountsCoOccurence
         mGenes = Lists.newArrayList();
 
         mCategories = Lists.newArrayList();
-        mCategoryIndexMap = new HashMap();
-        mGeneIndexMap = new HashMap();
-        mCancerSampleData = new HashMap();
+        mCategoryIndexMap = new HashMap<>();
+        mGeneIndexMap = new HashMap<>();
+        mCancerSampleData = new HashMap<>();
         mSampleCountsMatrix = null;
 
         mFisherET = new FisherExactTest();
@@ -152,10 +152,10 @@ public class SampleCountsCoOccurence
 
         mFisherET.initialise(sampleCount);
 
-        Map<String, Integer> withCategoryTotals = new HashMap();
-        Map<String, Integer> unclearCategoryTotals = new HashMap();
-        Map<String, Integer> withGeneTotals = new HashMap();
-        Map<String, Integer> unclearGeneTotals = new HashMap();
+        Map<String, Integer> withCategoryTotals = new HashMap<>();
+        Map<String, Integer> unclearCategoryTotals = new HashMap<>();
+        Map<String, Integer> withGeneTotals = new HashMap<>();
+        Map<String, Integer> unclearGeneTotals = new HashMap<>();
 
         for(final SampleGeneData sampleData : sampleDataList)
         {

--- a/stat-calcs/src/main/java/com/hartwig/hmftools/statcalcs/cooc/ThreeVarCoOccurence.java
+++ b/stat-calcs/src/main/java/com/hartwig/hmftools/statcalcs/cooc/ThreeVarCoOccurence.java
@@ -61,7 +61,7 @@ public class ThreeVarCoOccurence
         initialiseOutput(outputFile);
 
         mSamples = Lists.newArrayList();
-        mGroupingSampleGenericData = new HashMap();
+        mGroupingSampleGenericData = new HashMap<>();
         mGroupingValues = Lists.newArrayList();
         mCat1Values = Lists.newArrayList();
         mCat2Values = Lists.newArrayList();

--- a/sv-tools/pom.xml
+++ b/sv-tools/pom.xml
@@ -23,18 +23,6 @@
             <artifactId>patient-db</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
             <scope>provided</scope>

--- a/sv-tools/src/test/java/com/hartwig/hmftools/svtools/fusion_likelihood/FusionLikelihoodTest.java
+++ b/sv-tools/src/test/java/com/hartwig/hmftools/svtools/fusion_likelihood/FusionLikelihoodTest.java
@@ -527,7 +527,7 @@ public class FusionLikelihoodTest
         likelihoodCalc.initialise(delLengths, 0);
         likelihoodCalc.generateSameGeneCounts(geneData);
 
-        Integer overlapCount = new Integer((100 * 100) * 3);
+        Integer overlapCount = Integer.valueOf((100 * 100) * 3);
 
         assertEquals(1, geneData.getDelFusionBaseCounts().size());
         assertEquals(overlapCount, geneData.getDelFusionBaseCounts().get(0));

--- a/vicc-importer/pom.xml
+++ b/vicc-importer/pom.xml
@@ -106,7 +106,7 @@
                     </jdbc>
                     <generator>
                         <database>
-                            <name>org.jooq.util.mysql.MySQLDatabase</name>
+                            <name>org.jooq.meta.mysql.MySQLDatabase</name>
                             <includes>.*</includes>
                             <inputSchema>vicc_test</inputSchema>
                         </database>


### PR DESCRIPTION
@nedleitch and I made some effort to get hmftools working with java11. This means a few of the dependencies had to be upgraded, and some very small, non functional code changes to come with it. They are:

- Upgrade jooq 3.9.4 -> 3.15.4. The API is slightly changed, any date insert uses `java.time.LocalDate` instead of `java.sql.Date`
- Replace jmockit with mockito. jmockit has some issues running in java 11. This is only used in purple testing.
- Upgrade kotlin 1.2.61 -> 1.5.32.
- Replaced kotlintest with kotest. I could not get kotlintest working in java 11, and it appears kotlintest is an abandoned fork of kotest.

In this change the pom.xml has been modified to compile for Java 11.