### PR TITLE
DEV-3251 Fix the orange conversion for virus interpretation

### DIFF
--- a/orange/src/main/java/com/hartwig/hmftools/orange/conversion/OrangeConversion.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/conversion/OrangeConversion.java
@@ -26,6 +26,7 @@ import com.hartwig.hmftools.datamodel.virus.ImmutableVirusInterpreterData;
 import com.hartwig.hmftools.datamodel.virus.VirusBreakendQCStatus;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation;
 import com.hartwig.hmftools.datamodel.virus.VirusInterpreterData;
+import com.hartwig.hmftools.datamodel.virus.VirusLikelihoodType;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -64,10 +65,7 @@ public final class OrangeConversion {
 
     @NotNull
     public static OrangeDoidNode convert(@NotNull DoidNode doidNode) {
-        return ImmutableOrangeDoidNode.builder()
-                .doid(doidNode.doid())
-                .doidTerm(doidNode.doidTerm())
-                .build();
+        return ImmutableOrangeDoidNode.builder().doid(doidNode.doid()).doidTerm(doidNode.doidTerm()).build();
     }
 
     @NotNull
@@ -108,9 +106,12 @@ public final class OrangeConversion {
                 .name(annotatedVirus.name())
                 .qcStatus(VirusBreakendQCStatus.valueOf(annotatedVirus.qcStatus().name()))
                 .integrations(annotatedVirus.integrations())
-                .interpretation(VirusInterpretation.valueOf(annotatedVirus.interpretation()))
+                .interpretation(
+                        annotatedVirus.interpretation() != null ? VirusInterpretation.valueOf(annotatedVirus.interpretation()) : null)
                 .percentageCovered(annotatedVirus.percentageCovered())
                 .reported(annotatedVirus.reported())
+                .meanCoverage(annotatedVirus.meanCoverage())
+                .virusDriverLikelihoodType(VirusLikelihoodType.valueOf(annotatedVirus.virusDriverLikelihoodType().name()))
                 .build();
     }
 

--- a/orange/src/test/java/com/hartwig/hmftools/orange/conversion/OrangeConversionTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/conversion/OrangeConversionTest.java
@@ -1,0 +1,46 @@
+package com.hartwig.hmftools.orange.conversion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.hartwig.hmftools.datamodel.virus.AnnotatedVirus;
+import com.hartwig.hmftools.datamodel.virus.VirusInterpreterData;
+
+import org.junit.Test;
+
+public class OrangeConversionTest {
+
+    @Test
+    public void shouldConvertAnnotatedVirus() {
+        assertTrue(OrangeConversion.convert(TestCommonDatamodelFactory.emptyVirusInterpreterData()).allViruses().isEmpty());
+        assertEqualsValue(OrangeConversion.convert(TestCommonDatamodelFactory.minimalVirusInterpreterData()),
+                TestCommonDatamodelFactory.minimalVirusInterpreterData());
+        assertEqualsValue(OrangeConversion.convert(TestCommonDatamodelFactory.exhaustiveVirusInterpreterData()),
+                TestCommonDatamodelFactory.exhaustiveVirusInterpreterData());
+    }
+
+    private static void assertEqualsValue(VirusInterpreterData converted, com.hartwig.hmftools.common.virus.VirusInterpreterData input) {
+        assertEqualsValue(converted.allViruses(), input.allViruses());
+        assertEqualsValue(converted.reportableViruses(), input.reportableViruses());
+    }
+
+    private static void assertEqualsValue(List<AnnotatedVirus> converted, List<com.hartwig.hmftools.common.virus.AnnotatedVirus> input) {
+        assertEquals(converted.size(), input.size());
+        for (int i = 0; i < input.size(); i++) {
+            assertEqualsValue(converted.get(i), input.get(i));
+        }
+    }
+
+    private static void assertEqualsValue(AnnotatedVirus converted, com.hartwig.hmftools.common.virus.AnnotatedVirus input) {
+        assertEquals(converted.name(), input.name());
+        assertEquals(converted.qcStatus().name(), input.qcStatus().name());
+        assertEquals(converted.integrations(), input.integrations());
+        assertEquals(converted.percentageCovered(), input.percentageCovered(), 0.01);
+        assertEquals(converted.meanCoverage(), input.meanCoverage(), 0.01);
+        assertEquals(converted.expectedClonalCoverage(), input.expectedClonalCoverage());
+        assertEquals(converted.reported(), input.reported());
+        assertEquals(converted.virusDriverLikelihoodType().name(), input.virusDriverLikelihoodType().name());
+    }
+}

--- a/orange/src/test/java/com/hartwig/hmftools/orange/conversion/OrangeConversionTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/conversion/OrangeConversionTest.java
@@ -12,35 +12,37 @@ import org.junit.Test;
 
 public class OrangeConversionTest {
 
+    private static final double EPSILON = 0.01;
+
     @Test
     public void shouldConvertAnnotatedVirus() {
         assertTrue(OrangeConversion.convert(TestCommonDatamodelFactory.emptyVirusInterpreterData()).allViruses().isEmpty());
-        assertEqualsValue(OrangeConversion.convert(TestCommonDatamodelFactory.minimalVirusInterpreterData()),
-                TestCommonDatamodelFactory.minimalVirusInterpreterData());
-        assertEqualsValue(OrangeConversion.convert(TestCommonDatamodelFactory.exhaustiveVirusInterpreterData()),
-                TestCommonDatamodelFactory.exhaustiveVirusInterpreterData());
+        assertEqualsValue(TestCommonDatamodelFactory.minimalVirusInterpreterData(),
+                OrangeConversion.convert(TestCommonDatamodelFactory.minimalVirusInterpreterData()));
+        assertEqualsValue(TestCommonDatamodelFactory.exhaustiveVirusInterpreterData(),
+                OrangeConversion.convert(TestCommonDatamodelFactory.exhaustiveVirusInterpreterData()));
     }
 
-    private static void assertEqualsValue(VirusInterpreterData converted, com.hartwig.hmftools.common.virus.VirusInterpreterData input) {
-        assertEqualsValue(converted.allViruses(), input.allViruses());
-        assertEqualsValue(converted.reportableViruses(), input.reportableViruses());
+    private static void assertEqualsValue(com.hartwig.hmftools.common.virus.VirusInterpreterData input, VirusInterpreterData converted) {
+        assertEqualsValue(input.allViruses(), converted.allViruses());
+        assertEqualsValue(input.reportableViruses(), converted.reportableViruses());
     }
 
-    private static void assertEqualsValue(List<AnnotatedVirus> converted, List<com.hartwig.hmftools.common.virus.AnnotatedVirus> input) {
+    private static void assertEqualsValue(List<com.hartwig.hmftools.common.virus.AnnotatedVirus> input, List<AnnotatedVirus> converted) {
         assertEquals(converted.size(), input.size());
         for (int i = 0; i < input.size(); i++) {
-            assertEqualsValue(converted.get(i), input.get(i));
+            assertEqualsValue(input.get(i), converted.get(i));
         }
     }
 
-    private static void assertEqualsValue(AnnotatedVirus converted, com.hartwig.hmftools.common.virus.AnnotatedVirus input) {
-        assertEquals(converted.name(), input.name());
-        assertEquals(converted.qcStatus().name(), input.qcStatus().name());
-        assertEquals(converted.integrations(), input.integrations());
-        assertEquals(converted.percentageCovered(), input.percentageCovered(), 0.01);
-        assertEquals(converted.meanCoverage(), input.meanCoverage(), 0.01);
-        assertEquals(converted.expectedClonalCoverage(), input.expectedClonalCoverage());
-        assertEquals(converted.reported(), input.reported());
-        assertEquals(converted.virusDriverLikelihoodType().name(), input.virusDriverLikelihoodType().name());
+    private static void assertEqualsValue(com.hartwig.hmftools.common.virus.AnnotatedVirus input, AnnotatedVirus converted) {
+        assertEquals(input.name(), converted.name());
+        assertEquals(input.qcStatus().name(), converted.qcStatus().name());
+        assertEquals(input.integrations(), converted.integrations());
+        assertEquals(input.percentageCovered(), converted.percentageCovered(), EPSILON);
+        assertEquals(input.meanCoverage(), converted.meanCoverage(), EPSILON);
+        assertEquals(input.expectedClonalCoverage(), converted.expectedClonalCoverage());
+        assertEquals(input.reported(), converted.reported());
+        assertEquals(input.virusDriverLikelihoodType().name(), converted.virusDriverLikelihoodType().name());
     }
 }

--- a/orange/src/test/java/com/hartwig/hmftools/orange/conversion/TestCommonDatamodelFactory.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/conversion/TestCommonDatamodelFactory.java
@@ -1,0 +1,39 @@
+package com.hartwig.hmftools.orange.conversion;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.virus.AnnotatedVirus;
+import com.hartwig.hmftools.common.virus.ImmutableAnnotatedVirus;
+import com.hartwig.hmftools.common.virus.ImmutableVirusInterpreterData;
+import com.hartwig.hmftools.common.virus.VirusBreakendQCStatus;
+import com.hartwig.hmftools.common.virus.VirusInterpreterData;
+import com.hartwig.hmftools.common.virus.VirusLikelihoodType;
+
+class TestCommonDatamodelFactory {
+
+    static VirusInterpreterData emptyVirusInterpreterData() {
+        return ImmutableVirusInterpreterData.builder().build();
+    }
+
+    static VirusInterpreterData minimalVirusInterpreterData() {
+        AnnotatedVirus virus = minimalAnnotatedVirusBuilder().build();
+        return ImmutableVirusInterpreterData.builder().addReportableViruses(virus).addAllAllViruses(List.of(virus)).build();
+    }
+
+    static VirusInterpreterData exhaustiveVirusInterpreterData() {
+        AnnotatedVirus virus = minimalAnnotatedVirusBuilder().interpretation("MCV").expectedClonalCoverage(1.0).build();
+        return ImmutableVirusInterpreterData.builder().addReportableViruses(virus).addAllAllViruses(List.of(virus)).build();
+    }
+
+    private static ImmutableAnnotatedVirus.Builder minimalAnnotatedVirusBuilder() {
+        return ImmutableAnnotatedVirus.builder()
+                .taxid(1)
+                .name("virus_name")
+                .qcStatus(VirusBreakendQCStatus.NO_ABNORMALITIES)
+                .integrations(1)
+                .virusDriverLikelihoodType(VirusLikelihoodType.HIGH)
+                .percentageCovered(1.0)
+                .meanCoverage(1.0)
+                .reported(true);
+    }
+}

--- a/orange/src/test/java/com/hartwig/hmftools/orange/conversion/TestCommonDatamodelFactory.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/conversion/TestCommonDatamodelFactory.java
@@ -1,7 +1,5 @@
 package com.hartwig.hmftools.orange.conversion;
 
-import java.util.List;
-
 import com.hartwig.hmftools.common.virus.AnnotatedVirus;
 import com.hartwig.hmftools.common.virus.ImmutableAnnotatedVirus;
 import com.hartwig.hmftools.common.virus.ImmutableVirusInterpreterData;
@@ -16,12 +14,14 @@ class TestCommonDatamodelFactory {
     }
 
     static VirusInterpreterData minimalVirusInterpreterData() {
-        AnnotatedVirus virus = minimalAnnotatedVirusBuilder().build();
-        return ImmutableVirusInterpreterData.builder().addReportableViruses(virus).addAllAllViruses(List.of(virus)).build();
+        return virusInterpreterDataWith(minimalAnnotatedVirusBuilder().build());
     }
 
     static VirusInterpreterData exhaustiveVirusInterpreterData() {
-        AnnotatedVirus virus = minimalAnnotatedVirusBuilder().interpretation("MCV").expectedClonalCoverage(1.0).build();
+        return virusInterpreterDataWith(minimalAnnotatedVirusBuilder().interpretation("MCV").expectedClonalCoverage(1.0).build());
+    }
+
+    private static ImmutableVirusInterpreterData virusInterpreterDataWith(AnnotatedVirus virus) {
         return ImmutableVirusInterpreterData.builder().addReportableViruses(virus).addAllViruses(virus).build();
     }
 

--- a/orange/src/test/java/com/hartwig/hmftools/orange/conversion/TestCommonDatamodelFactory.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/conversion/TestCommonDatamodelFactory.java
@@ -22,7 +22,7 @@ class TestCommonDatamodelFactory {
 
     static VirusInterpreterData exhaustiveVirusInterpreterData() {
         AnnotatedVirus virus = minimalAnnotatedVirusBuilder().interpretation("MCV").expectedClonalCoverage(1.0).build();
-        return ImmutableVirusInterpreterData.builder().addReportableViruses(virus).addAllAllViruses(List.of(virus)).build();
+        return ImmutableVirusInterpreterData.builder().addReportableViruses(virus).addAllViruses(virus).build();
     }
 
     private static ImmutableAnnotatedVirus.Builder minimalAnnotatedVirusBuilder() {

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <linx.version>1.23.3</linx.version>
         <mark-dups.version>1.0</mark-dups.version>
         <neo.version>1.0</neo.version>
-        <orange.version>2.4.0</orange.version>
+        <orange.version>2.4.1</orange.version>
         <orange-datamodel.version>1.0.1</orange-datamodel.version>
         <paddle.version>1.0</paddle.version>
         <patient-db.version>5.32</patient-db.version>


### PR DESCRIPTION
Add the two missed fields and also handle the nullable interpretation field.

Adds a test as well which asserts for an empty, minimal, and exhaustive test datamodel. If we like how this test looks will add the same for the other converted datamodel classes.