### PR TITLE
ACTIN-151: Fix expression selection bug for unknown cohort

### DIFF
--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/isofox/GeneExpressionDistributionData.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/isofox/GeneExpressionDistributionData.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 public class GeneExpressionDistributionData
 {
     private static final Logger LOGGER = LogManager.getLogger(GeneExpressionDistributionData.class);
+    public static final int NOT_AVAILABLE = -1;
 
     private final Map<String, Map<String, double[]>> mGenePercentiles; // by geneId and then cancer type
     private final Map<String, Map<String, Double>> mGeneMedians;
@@ -89,7 +90,7 @@ public class GeneExpressionDistributionData
 
         if(medianMap == null || !medianMap.containsKey(cancerType))
         {
-            return -1;
+            return NOT_AVAILABLE;
         }
 
         return medianMap.get(cancerType);
@@ -101,7 +102,7 @@ public class GeneExpressionDistributionData
 
         if(percentileMap == null || !percentileMap.containsKey(cancerType))
         {
-            return -1;
+            return NOT_AVAILABLE;
         }
 
         return getPercentile(percentileMap.get(cancerType), sampleTpm);

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/isofox/ExpressionSelector.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/isofox/ExpressionSelector.java
@@ -2,11 +2,12 @@ package com.hartwig.hmftools.orange.algo.isofox;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.hartwig.hmftools.common.drivercatalog.DriverCategory;
 import com.hartwig.hmftools.common.drivercatalog.panel.DriverGene;
+import com.hartwig.hmftools.common.isofox.GeneExpressionDistributionData;
 import com.hartwig.hmftools.datamodel.isofox.GeneExpression;
 
 import org.jetbrains.annotations.NotNull;
@@ -22,47 +23,37 @@ final class ExpressionSelector {
     @NotNull
     public static List<GeneExpression> selectHighExpressionGenes(@NotNull List<GeneExpression> expressions,
             @NotNull List<DriverGene> driverGenes) {
-        Set<String> oncogenes = extractGenesOfType(driverGenes, DriverCategory.ONCO);
-
-        List<GeneExpression> result = Lists.newArrayList();
-        for (GeneExpression expression : expressions) {
-            boolean isOncogene = oncogenes.contains(expression.geneName());
-            boolean hasHighExpressionCohort = expression.percentileCohort() >= HIGH_EXPRESSION_PERCENTILE_CUTOFF;
-            boolean hasHighExpressionCancer = expression.percentileCancer() >= HIGH_EXPRESSION_PERCENTILE_CUTOFF;
-            if (isOncogene && hasHighExpressionCohort && hasHighExpressionCancer) {
-                result.add(expression);
-            }
-        }
-
-        return result;
+        return selectGenesMatchingCriteria(expressions,
+                extractGenesOfType(driverGenes, DriverCategory.ONCO),
+                percentile -> percentile >= HIGH_EXPRESSION_PERCENTILE_CUTOFF);
     }
 
     @NotNull
     public static List<GeneExpression> selectLowExpressionGenes(@NotNull List<GeneExpression> expressions,
             @NotNull List<DriverGene> driverGenes) {
-        Set<String> suppressors = extractGenesOfType(driverGenes, DriverCategory.TSG);
+        return selectGenesMatchingCriteria(expressions,
+                extractGenesOfType(driverGenes, DriverCategory.TSG),
+                percentile -> percentile <= LOW_EXPRESSION_PERCENTILE_CUTOFF);
+    }
 
-        List<GeneExpression> result = Lists.newArrayList();
-        for (GeneExpression expression : expressions) {
-            boolean isTSG = suppressors.contains(expression.geneName());
-            boolean hasLowExpressionCohort = expression.percentileCohort() <= LOW_EXPRESSION_PERCENTILE_CUTOFF;
-            boolean hasLowExpressionCancer = expression.percentileCancer() <= LOW_EXPRESSION_PERCENTILE_CUTOFF;
-            if (isTSG && hasLowExpressionCohort && hasLowExpressionCancer) {
-                result.add(expression);
-            }
-        }
-
-        return result;
+    @NotNull
+    private static List<GeneExpression> selectGenesMatchingCriteria(@NotNull List<GeneExpression> expressions, Set<String> genesOfType,
+            Predicate<Double> evaluatePercentileThreshold) {
+        return expressions.stream().filter(expression -> {
+            boolean geneMatchesType = genesOfType.contains(expression.geneName());
+            boolean percentileCancerMeetsThreshold = evaluatePercentileThreshold.test(expression.percentileCancer());
+            boolean percentileCohortMeetsThreshold =
+                    expression.percentileCohort() == GeneExpressionDistributionData.NOT_AVAILABLE || evaluatePercentileThreshold.test(
+                            expression.percentileCohort());
+            return geneMatchesType && percentileCancerMeetsThreshold && percentileCohortMeetsThreshold;
+        }).collect(Collectors.toList());
     }
 
     @NotNull
     private static Set<String> extractGenesOfType(@NotNull List<DriverGene> driverGenes, @NotNull DriverCategory categoryToInclude) {
-        Set<String> filtered = Sets.newHashSet();
-        for (DriverGene driverGene : driverGenes) {
-            if (driverGene.likelihoodType() == categoryToInclude) {
-                filtered.add(driverGene.gene());
-            }
-        }
-        return filtered;
+        return driverGenes.stream()
+                .filter(driverGene -> driverGene.likelihoodType() == categoryToInclude)
+                .map(DriverGene::gene)
+                .collect(Collectors.toSet());
     }
 }

--- a/orange/src/test/java/com/hartwig/hmftools/orange/algo/isofox/ExpressionSelectorTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/algo/isofox/ExpressionSelectorTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Lists;
 import com.hartwig.hmftools.common.drivercatalog.DriverCategory;
 import com.hartwig.hmftools.common.drivercatalog.panel.DriverGene;
 import com.hartwig.hmftools.common.drivercatalog.panel.DriverGeneTestFactory;
+import com.hartwig.hmftools.common.isofox.GeneExpressionDistributionData;
 import com.hartwig.hmftools.datamodel.isofox.GeneExpression;
 
 import org.jetbrains.annotations.NotNull;
@@ -17,7 +18,7 @@ import org.junit.Test;
 public class ExpressionSelectorTest {
 
     @Test
-    public void canSelectHighExpressionGenes() {
+    public void shouldSelectHighExpressionGenes() {
         GeneExpression highExpressionGene1 = create("gene 1", 0.95, 0.95);
         GeneExpression nonHighExpressionGene1 = create("gene 1", 0.85, 0.95);
         GeneExpression highExpressionGene2 = create("gene 2", 0.95, 0.95);
@@ -34,7 +35,18 @@ public class ExpressionSelectorTest {
     }
 
     @Test
-    public void canSelectLowExpressionGenes() {
+    public void shouldSelectHighExpressionGeneWithoutCohort() {
+        GeneExpression highExpressionGene = create("gene 1", GeneExpressionDistributionData.NOT_AVAILABLE, 0.95);
+        DriverGene driver = DriverGeneTestFactory.builder().gene("gene 1").likelihoodType(DriverCategory.ONCO).build();
+
+        List<GeneExpression> highExpression = ExpressionSelector.selectHighExpressionGenes(List.of(highExpressionGene), List.of(driver));
+
+        assertEquals(1, highExpression.size());
+        assertTrue(highExpression.contains(highExpressionGene));
+    }
+
+    @Test
+    public void shouldSelectLowExpressionGenes() {
         GeneExpression lowExpressionGene1 = create("gene 1", 0.02, 0.02);
         GeneExpression nonLowExpressionGene1 = create("gene 1", 0.02, 0.08);
         GeneExpression lowExpressionGene2 = create("gene 2", 0.02, 0.02);
@@ -48,6 +60,17 @@ public class ExpressionSelectorTest {
 
         assertEquals(1, lowExpression.size());
         assertTrue(lowExpression.contains(lowExpressionGene2));
+    }
+
+    @Test
+    public void shouldSelectLowExpressionGenesWithoutCohort() {
+        GeneExpression lowExpressionGene = create("gene 2", GeneExpressionDistributionData.NOT_AVAILABLE, 0.02);
+        DriverGene driver = DriverGeneTestFactory.builder().gene("gene 2").likelihoodType(DriverCategory.TSG).build();
+
+        List<GeneExpression> lowExpression = ExpressionSelector.selectLowExpressionGenes(List.of(lowExpressionGene), List.of(driver));
+
+        assertEquals(1, lowExpression.size());
+        assertTrue(lowExpression.contains(lowExpressionGene));
     }
 
     @NotNull


### PR DESCRIPTION
The cohort isn't indicated when ingesting the isofox results but we can detect the special n/a value of -1. When this isn't provided, there is no filtering on cohort percentile so the number of genes meeting the expression thresholds is expected to be higher.