### PR TITLE
ACTIN-170 Persist/read the config with the orange record

### DIFF
--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangeConfig.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangeConfig.java
@@ -1,0 +1,132 @@
+package com.hartwig.hmftools.datamodel.orange;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.immutables.value.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Value.Immutable
+@Value.Style(passAnnotations = { NotNull.class, Nullable.class })
+public interface OrangeConfig {
+
+    Logger LOGGER = LogManager.getLogger(OrangeConfig.class);
+
+    @NotNull
+    String tumorSampleId();
+
+    @Nullable
+    String referenceSampleId();
+
+    @Nullable
+    OrangeRNAConfig rnaConfig();
+
+    @NotNull
+    Set<String> primaryTumorDoids();
+
+    @NotNull
+    LocalDate experimentDate();
+
+    @NotNull
+    OrangeRefGenomeVersion refGenomeVersion();
+
+    @NotNull
+    String outputDir();
+
+    @NotNull
+    String doidJsonFile();
+
+    @NotNull
+    String cohortMappingTsv();
+
+    @NotNull
+    String cohortPercentilesTsv();
+
+    @NotNull
+    String driverGenePanelTsv();
+
+    @NotNull
+    String knownFusionFile();
+
+    @NotNull
+    String ensemblDataDirectory();
+
+    @Nullable
+    String pipelineVersionFile();
+
+    @Nullable
+    String refSampleWGSMetricsFile();
+
+    @Nullable
+    String refSampleFlagstatFile();
+
+    @NotNull
+    String tumorSampleWGSMetricsFile();
+
+    @NotNull
+    String tumorSampleFlagstatFile();
+
+    @Nullable
+    String sageGermlineGeneCoverageTsv();
+
+    @Nullable
+    String sageSomaticRefSampleBQRPlot();
+
+    @NotNull
+    String sageSomaticTumorSampleBQRPlot();
+
+    @NotNull
+    String purpleDataDirectory();
+
+    @NotNull
+    String purplePlotDirectory();
+
+    @NotNull
+    String linxSomaticDataDirectory();
+
+    @Nullable
+    String linxGermlineDataDirectory();
+
+    @NotNull
+    String linxPlotDirectory();
+
+    @NotNull
+    String lilacResultCsv();
+
+    @NotNull
+    String lilacQcCsv();
+
+    @Nullable
+    String annotatedVirusTsv();
+
+    @Nullable
+    String chordPredictionTxt();
+
+    @Nullable
+    String cuppaResultCsv();
+
+    @Nullable
+    String cuppaSummaryPlot();
+
+    @Nullable
+    String cuppaFeaturePlot();
+
+    @Nullable
+    String cuppaChartPlot();
+
+    @Nullable
+    String peachGenotypeTsv();
+
+    @Nullable
+    String sigsAllocationTsv();
+
+    boolean convertGermlineToSomatic();
+
+    boolean limitJsonOutput();
+
+    boolean addDisclaimer();
+
+}

--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangeRNAConfig.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangeRNAConfig.java
@@ -1,0 +1,36 @@
+package com.hartwig.hmftools.datamodel.orange;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.immutables.value.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Value.Immutable
+@Value.Style(passAnnotations = { NotNull.class, Nullable.class })
+public interface OrangeRNAConfig {
+
+    Logger LOGGER = LogManager.getLogger(OrangeRNAConfig.class);
+
+    @NotNull
+    String rnaSampleId();
+
+    @NotNull
+    String isofoxGeneDistributionCsv();
+
+    @NotNull
+    String isofoxAltSjCohortCsv();
+
+    @NotNull
+    String isofoxSummaryCsv();
+
+    @NotNull
+    String isofoxGeneDataCsv();
+
+    @NotNull
+    String isofoxFusionCsv();
+
+    @NotNull
+    String isofoxAltSpliceJunctionCsv();
+
+}

--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangeRecord.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangeRecord.java
@@ -24,8 +24,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Gson.TypeAdapters
 @Value.Immutable
-@Value.Style(passAnnotations = {NotNull.class, Nullable.class})
+@Value.Style(passAnnotations = { NotNull.class, Nullable.class })
 public interface OrangeRecord {
+
+    @NotNull
+    OrangeConfig config();
 
     @NotNull
     String sampleId();

--- a/orange/src/main/java/com/hartwig/hmftools/orange/OrangeApplication.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/OrangeApplication.java
@@ -2,6 +2,7 @@ package com.hartwig.hmftools.orange;
 
 import java.io.IOException;
 
+import com.hartwig.hmftools.datamodel.orange.OrangeConfig;
 import com.hartwig.hmftools.datamodel.orange.OrangeRecord;
 import com.hartwig.hmftools.orange.algo.OrangeAlgo;
 import com.hartwig.hmftools.orange.report.ReportWriter;
@@ -25,11 +26,11 @@ public class OrangeApplication {
     public static void main(String[] args) throws IOException {
         LOGGER.info("Running {} v{}", APPLICATION, VERSION);
 
-        Options options = OrangeConfig.createOptions();
+        Options options = OrangeCommandLine.createOptions();
 
         OrangeConfig config = null;
         try {
-            config = OrangeConfig.createConfig(new DefaultParser().parse(options, args));
+            config = OrangeCommandLine.createConfig(new DefaultParser().parse(options, args));
         } catch (ParseException exception) {
             LOGGER.warn(exception);
             new HelpFormatter().printHelp(APPLICATION, options);

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
@@ -56,14 +56,14 @@ import com.hartwig.hmftools.datamodel.orange.ExperimentType;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangePlots;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeRecord;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeSample;
+import com.hartwig.hmftools.datamodel.orange.OrangeConfig;
 import com.hartwig.hmftools.datamodel.orange.OrangePlots;
+import com.hartwig.hmftools.datamodel.orange.OrangeRNAConfig;
 import com.hartwig.hmftools.datamodel.orange.OrangeRecord;
 import com.hartwig.hmftools.datamodel.orange.OrangeSample;
 import com.hartwig.hmftools.datamodel.orange.PercentileType;
 import com.hartwig.hmftools.datamodel.purple.PurpleRecord;
 import com.hartwig.hmftools.datamodel.wildtype.WildTypeGene;
-import com.hartwig.hmftools.orange.OrangeConfig;
-import com.hartwig.hmftools.orange.OrangeRNAConfig;
 import com.hartwig.hmftools.orange.algo.cuppa.CuppaDataFactory;
 import com.hartwig.hmftools.orange.algo.isofox.IsofoxInterpreter;
 import com.hartwig.hmftools.orange.algo.linx.LinxInterpreter;
@@ -319,7 +319,8 @@ public class OrangeAlgo {
 
     @NotNull
     private static EnsemblDataCache loadEnsemblDataCache(@NotNull OrangeConfig config) {
-        EnsemblDataCache ensemblDataCache = new EnsemblDataCache(config.ensemblDataDirectory(), RefGenomeVersion.from(config.refGenomeVersion().name()));
+        EnsemblDataCache ensemblDataCache =
+                new EnsemblDataCache(config.ensemblDataDirectory(), RefGenomeVersion.from(config.refGenomeVersion().name()));
         ensemblDataCache.load(false);
         return ensemblDataCache;
     }

--- a/orange/src/main/java/com/hartwig/hmftools/orange/report/ReportWriterFactory.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/report/ReportWriterFactory.java
@@ -1,6 +1,7 @@
 package com.hartwig.hmftools.orange.report;
 
-import com.hartwig.hmftools.orange.OrangeConfig;
+import com.hartwig.hmftools.datamodel.orange.OrangeConfig;
+import com.hartwig.hmftools.orange.OrangeCommandLine;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/orange/src/test/java/com/hartwig/hmftools/orange/TestOrangeConfigFactory.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/TestOrangeConfigFactory.java
@@ -3,6 +3,9 @@ package com.hartwig.hmftools.orange;
 import java.time.LocalDate;
 
 import com.google.common.io.Resources;
+import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeConfig;
+import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeRNAConfig;
+import com.hartwig.hmftools.datamodel.orange.OrangeConfig;
 import com.hartwig.hmftools.datamodel.orange.OrangeRefGenomeVersion;
 
 import org.apache.logging.log4j.util.Strings;

--- a/orange/src/test/java/com/hartwig/hmftools/orange/algo/OrangeAlgoTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/algo/OrangeAlgoTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 
 import com.google.common.collect.Sets;
-import com.hartwig.hmftools.orange.ImmutableOrangeConfig;
-import com.hartwig.hmftools.orange.OrangeConfig;
+import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeConfig;
+import com.hartwig.hmftools.datamodel.orange.OrangeConfig;
 import com.hartwig.hmftools.orange.TestOrangeConfigFactory;
 
 import org.junit.Test;

--- a/orange/src/test/java/com/hartwig/hmftools/orange/report/ReportGeneratorTestApplication.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/report/ReportGeneratorTestApplication.java
@@ -14,15 +14,15 @@ import com.hartwig.hmftools.datamodel.isofox.ImmutableIsofoxRecord;
 import com.hartwig.hmftools.datamodel.linx.ImmutableLinxRecord;
 import com.hartwig.hmftools.datamodel.linx.LinxBreakend;
 import com.hartwig.hmftools.datamodel.linx.LinxSvAnnotation;
+import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeConfig;
 import com.hartwig.hmftools.datamodel.orange.ImmutableOrangeRecord;
+import com.hartwig.hmftools.datamodel.orange.OrangeConfig;
 import com.hartwig.hmftools.datamodel.orange.OrangeRecord;
 import com.hartwig.hmftools.datamodel.orange.PercentileType;
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleRecord;
 import com.hartwig.hmftools.datamodel.purple.PurpleDriver;
 import com.hartwig.hmftools.datamodel.purple.PurpleDriverType;
 import com.hartwig.hmftools.datamodel.purple.PurpleGeneCopyNumber;
-import com.hartwig.hmftools.orange.ImmutableOrangeConfig;
-import com.hartwig.hmftools.orange.OrangeConfig;
 import com.hartwig.hmftools.orange.TestOrangeConfigFactory;
 import com.hartwig.hmftools.orange.TestOrangeReportFactory;
 import com.hartwig.hmftools.orange.algo.OrangeAlgo;
@@ -147,8 +147,8 @@ public class ReportGeneratorTestApplication {
             @NotNull List<PurpleDriver> drivers) {
         List<String> copyNumberDriverGenes = Lists.newArrayList();
         for (PurpleDriver driver : drivers) {
-            if (driver.driver() == PurpleDriverType.AMP || driver.driver() == PurpleDriverType.PARTIAL_AMP || driver.driver() == PurpleDriverType.DEL
-                    || driver.driver() == PurpleDriverType.GERMLINE_DELETION) {
+            if (driver.driver() == PurpleDriverType.AMP || driver.driver() == PurpleDriverType.PARTIAL_AMP
+                    || driver.driver() == PurpleDriverType.DEL || driver.driver() == PurpleDriverType.GERMLINE_DELETION) {
                 copyNumberDriverGenes.add(driver.gene());
             }
         }

--- a/orange/src/test/java/com/hartwig/hmftools/orange/report/ReportWriterTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/report/ReportWriterTest.java
@@ -2,8 +2,8 @@ package com.hartwig.hmftools.orange.report;
 
 import java.io.IOException;
 
+import com.hartwig.hmftools.datamodel.orange.OrangeConfig;
 import com.hartwig.hmftools.datamodel.orange.OrangeRecord;
-import com.hartwig.hmftools.orange.OrangeConfig;
 import com.hartwig.hmftools.orange.TestOrangeConfigFactory;
 import com.hartwig.hmftools.orange.TestOrangeReportFactory;
 import com.hartwig.hmftools.orange.algo.OrangeAlgo;


### PR DESCRIPTION
Persist the full input config with the orange record such that it can be read back and used when rerunning.