### PR TITLE
DEV-3605 Add backticks for jOOQ code generation

### DIFF
--- a/patient-db/src/main/resources/generate_database.sql
+++ b/patient-db/src/main/resources/generate_database.sql
@@ -1,1334 +1,1335 @@
 -- noinspection SqlNoDataSourceInspectionForFile
+-- All database and field names are wrapped in backticks to force jOOQ code generation to use them literally
 
-DROP TABLE IF EXISTS patient;
-CREATE TABLE patient
-(   id int NOT NULL AUTO_INCREMENT,
-    patientIdentifier varchar(50) UNIQUE,
-    blacklisted TINYINT(1) NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `patient`;
+CREATE TABLE `patient`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientIdentifier` VARCHAR(50) UNIQUE,
+    `blacklisted` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-DROP TABLE IF EXISTS baseline;
-CREATE TABLE baseline
-(   patientId int NOT NULL,
-    registrationDate DATE,
-    informedConsentDate DATE,
-    pifVersion varchar(255),
-    inHMFDatabase TINYINT(1),
-    outsideEU TINYINT(1),
-    gender varchar(10),
-    hospital varchar(255),
-    birthYear int,
-    primaryTumorLocation varchar(255),
-    primaryTumorSubLocation varchar(255),
-    primaryTumorType varchar(255),
-    primaryTumorSubType varchar(255),
-    primaryTumorExtraDetails varchar(255),
-    primaryTumorOverridden TINYINT(1),
-    deathDate DATE,
-    hasSystemicPreTreatment varchar(3),
-    hasRadiotherapyPreTreatment varchar(3),
-    preTreatments varchar(800),
-    preTreatmentsType varchar(510),
-    preTreatmentsMechanism varchar(510),
-    PRIMARY KEY (patientId),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `baseline`;
+CREATE TABLE `baseline`
+(   `patientId` INT NOT NULL,
+    `registrationDate` DATE,
+    `informedConsentDate` DATE,
+    `pifVersion` VARCHAR(255),
+    `inHMFDatabase` TINYINT(1),
+    `outsideEU` TINYINT(1),
+    `gender` VARCHAR(10),
+    `hospital` VARCHAR(255),
+    `birthYear` INT,
+    `primaryTumorLocation` VARCHAR(255),
+    `primaryTumorSubLocation` VARCHAR(255),
+    `primaryTumorType` VARCHAR(255),
+    `primaryTumorSubType` VARCHAR(255),
+    `primaryTumorExtraDetails` VARCHAR(255),
+    `primaryTumorOverridden` TINYINT(1),
+    `deathDate` DATE,
+    `hasSystemicPreTreatment` VARCHAR(3),
+    `hasRadiotherapyPreTreatment` VARCHAR(3),
+    `preTreatments` VARCHAR(800),
+    `preTreatmentsType` VARCHAR(510),
+    `preTreatmentsMechanism` VARCHAR(510),
+    PRIMARY KEY (`patientId`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS doidNode;
-CREATE TABLE doidNode
-(   id int NOT NULL AUTO_INCREMENT,
-    patientId int NOT NULL,
-    doid varchar(255) NOT NULL,
-    doidTerm varchar(255) NOT NULL,
-    snomedConceptId varchar(255),
-    PRIMARY KEY (id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `doidNode`;
+CREATE TABLE `doidNode`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientId` INT NOT NULL,
+    `doid` VARCHAR(255) NOT NULL,
+    `doidTerm` VARCHAR(255) NOT NULL,
+    `snomedConceptId` VARCHAR(255),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS snomed;
-CREATE TABLE snomed
-(   id int NOT NULL AUTO_INCREMENT,
-    patientId int NOT NULL,
-    snomedConceptId varchar(255) NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `snomed`;
+CREATE TABLE `snomed`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientId` INT NOT NULL,
+    `snomedConceptId` VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS preTreatmentDrug;
-CREATE TABLE preTreatmentDrug
-(   id int NOT NULL AUTO_INCREMENT,
-    patientId int NOT NULL,
-    startDate DATE,
-    endDate DATE,
-    name varchar(800),
-    type varchar(255),
-    mechanism varchar(255),
-    bestResponse varchar(50),
-    PRIMARY KEY (id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `preTreatmentDrug`;
+CREATE TABLE `preTreatmentDrug`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientId` INT NOT NULL,
+    `startDate` DATE,
+    `endDate` DATE,
+    `name` VARCHAR(800),
+    `type` VARCHAR(255),
+    `mechanism` VARCHAR(255),
+    `bestResponse` VARCHAR(50),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS sample;
-CREATE TABLE sample
-(   sampleId varchar(255) NOT NULL,
-    cohortId varchar(255) NOT NULL,
-    patientId int NOT NULL,
-    setName varchar(255) NOT NULL,
-    arrivalDate DATE NOT NULL,
-    samplingDate DATE,
-    reportedDate DATE,
-    dnaNanograms int,
-    limsPrimaryTumor varchar(512),
-    pathologyTumorPercentage varchar(100),
-    PRIMARY KEY (sampleId),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `sample`;
+CREATE TABLE `sample`
+(   `sampleId` VARCHAR(255) NOT NULL,
+    `cohortId` VARCHAR(255) NOT NULL,
+    `patientId` INT NOT NULL,
+    `setName` VARCHAR(255) NOT NULL,
+    `arrivalDate` DATE NOT NULL,
+    `samplingDate` DATE,
+    `reportedDate` DATE,
+    `dnaNanograms` INT,
+    `limsPrimaryTumor` VARCHAR(512),
+    `pathologyTumorPercentage` VARCHAR(100),
+    PRIMARY KEY (`sampleId`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS snpcheck;
-CREATE TABLE snpcheck
-(   sampleId varchar(255) NOT NULL,
-    isPass TINYINT(1) NOT NULL,
-    PRIMARY KEY (sampleId)
+DROP TABLE IF EXISTS `snpcheck`;
+CREATE TABLE `snpcheck`
+(   `sampleId` VARCHAR(255) NOT NULL,
+    `isPass` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`sampleId`)
 );
 
-DROP TABLE IF EXISTS biopsy;
-CREATE TABLE biopsy
-(   id int NOT NULL,
-    sampleId varchar(255),
-    patientId int NOT NULL,
-    biopsyTaken varchar(255),
-    biopsyEvaluable varchar(255),
-    biopsyType varchar(255),
-    biopsySite varchar(255),
-    biopsyLocation varchar(255),
-    biopsyDate DATE,
-    PRIMARY KEY (id),
-    FOREIGN KEY (sampleId) REFERENCES sample(sampleId),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `biopsy`;
+CREATE TABLE `biopsy`
+(   `id` INT NOT NULL,
+    `sampleId` VARCHAR(255),
+    `patientId` INT NOT NULL,
+    `biopsyTaken` VARCHAR(255),
+    `biopsyEvaluable` VARCHAR(255),
+    `biopsyType` VARCHAR(255),
+    `biopsySite` VARCHAR(255),
+    `biopsyLocation` VARCHAR(255),
+    `biopsyDate` DATE,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`sampleId`) REFERENCES `sample`(`sampleId`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS treatment;
-CREATE TABLE treatment
-(   id int NOT NULL,
-    biopsyId int,
-    patientId int NOT NULL,
-    treatmentGiven varchar(3),
-    radiotherapyGiven varchar(3),
-    startDate DATE,
-    endDate DATE,
-    name varchar(800),
-    type varchar(255),
-    mechanism varchar(255),
-    PRIMARY KEY (id),
-    FOREIGN KEY (biopsyId) REFERENCES biopsy(id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `treatment`;
+CREATE TABLE `treatment`
+(   `id` INT NOT NULL,
+    `biopsyId` INT,
+    `patientId` INT NOT NULL,
+    `treatmentGiven` VARCHAR(3),
+    `radiotherapyGiven` VARCHAR(3),
+    `startDate` DATE,
+    `endDate` DATE,
+    `name` VARCHAR(800),
+    `type` VARCHAR(255),
+    `mechanism` VARCHAR(255),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`biopsyId`) REFERENCES `biopsy`(`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS drug;
-CREATE TABLE drug
-(   id int NOT NULL AUTO_INCREMENT,
-    treatmentId int,
-    patientId int NOT NULL,
-    startDate DATE,
-    endDate DATE,
-    name varchar(800),
-    type varchar(255),
-    mechanism varchar(255),
-    PRIMARY KEY (id),
-    FOREIGN KEY (treatmentId) REFERENCES treatment(id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `drug`;
+CREATE TABLE `drug`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `treatmentId` INT,
+    `patientId` INT NOT NULL,
+    `startDate` DATE,
+    `endDate` DATE,
+    `name` VARCHAR(800),
+    `type` VARCHAR(255),
+    `mechanism` VARCHAR(255),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`treatmentId`) REFERENCES `treatment`(`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS treatmentResponse;
-CREATE TABLE treatmentResponse
-(   id int NOT NULL AUTO_INCREMENT,
-    treatmentId int,
-    patientId int NOT NULL,
-    measurementDone varchar(5),
-    boneOnlyDisease varchar(5),
-    responseDate DATE,
-    response varchar(500),
-    PRIMARY KEY (id),
-    FOREIGN KEY (treatmentId) REFERENCES treatment(id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `treatmentResponse`;
+CREATE TABLE `treatmentResponse`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `treatmentId` INT,
+    `patientId` INT NOT NULL,
+    `measurementDone` VARCHAR(5),
+    `boneOnlyDisease` VARCHAR(5),
+    `responseDate` DATE,
+    `response` VARCHAR(500),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`treatmentId`) REFERENCES `treatment`(`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS tumorMarker;
-CREATE TABLE tumorMarker
-(   id int NOT NULL AUTO_INCREMENT,
-    patientId int NOT NULL,
-    date DATE,
-    marker varchar(50),
-    measurement varchar(50),
-    unit varchar(50),
-    PRIMARY KEY (id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `tumorMarker`;
+CREATE TABLE `tumorMarker`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientId` INT NOT NULL,
+    `date` DATE,
+    `marker` VARCHAR(50),
+    `measurement` VARCHAR(50),
+    `unit` VARCHAR(50),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS ranoMeasurement;
-CREATE TABLE ranoMeasurement
-(   id int NOT NULL AUTO_INCREMENT,
-    patientId int NOT NULL,
-    responseDate DATE,
-    therapyGiven varchar(50),
-    targetLesionResponse varchar(50),
-    noTargetLesionResponse varchar(50),
-    overallResponse varchar(50),
-    PRIMARY KEY (id),
-    FOREIGN KEY (patientId) REFERENCES patient(id)
+DROP TABLE IF EXISTS `ranoMeasurement`;
+CREATE TABLE `ranoMeasurement`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientId` INT NOT NULL,
+    `responseDate` DATE,
+    `therapyGiven` VARCHAR(50),
+    `targetLesionResponse` VARCHAR(50),
+    `noTargetLesionResponse` VARCHAR(50),
+    `overallResponse` VARCHAR(50),
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`patientId`) REFERENCES `patient`(`id`)
 );
 
-DROP TABLE IF EXISTS clinicalFindings;
-CREATE TABLE clinicalFindings
-(   id int NOT NULL AUTO_INCREMENT,
-    level varchar(30),
-    patientId varchar(20),
-    formStatus varchar(30),
-    formLocked varchar(5),
-    message varchar(1000),
-    details varchar(1000),
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `clinicalFindings`;
+CREATE TABLE `clinicalFindings`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `level` VARCHAR(30),
+    `patientId` VARCHAR(20),
+    `formStatus` VARCHAR(30),
+    `formLocked` VARCHAR(5),
+    `message` VARCHAR(1000),
+    `details` VARCHAR(1000),
+    PRIMARY KEY (`id`)
 );
 
-DROP TABLE IF EXISTS cpctEcrf;
-CREATE TABLE cpctEcrf
-(   id int NOT NULL AUTO_INCREMENT,
-    patientId varchar(20),
-    studyEvent varchar(100),
-    studyEventKey int not null,
-    form varchar(100),
-    formKey int not null,
-    itemGroup varchar(100),
-    itemGroupKey int not null,
-    item varchar(100),
-    itemValue varchar(1500),
-    status varchar(30),
-    locked varchar(5),
-    sequenced varchar(5),
-    fieldName varchar(100),
-    relevant varchar(5),
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `cpctEcrf`;
+CREATE TABLE `cpctEcrf`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientId` VARCHAR(20),
+    `studyEvent` VARCHAR(100),
+    `studyEventKey` INT NOT NULL,
+    `form` VARCHAR(100),
+    `formKey` INT NOT NULL,
+    `itemGroup` VARCHAR(100),
+    `itemGroupKey` INT NOT NULL,
+    `item` VARCHAR(100),
+    `itemValue` VARCHAR(1500),
+    `status` VARCHAR(30),
+    `locked` VARCHAR(5),
+    `sequenced` VARCHAR(5),
+    `fieldName` VARCHAR(100),
+    `relevant` VARCHAR(5),
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX cpctEcrf_patientId ON cpctEcrf (patientId);
-CREATE INDEX cpctEcrf_studyEvent ON cpctEcrf (studyEvent);
-CREATE INDEX cpctEcrf_form ON cpctEcrf (form);
-CREATE INDEX cpctEcrf_itemGroup ON cpctEcrf (itemGroup);
-CREATE INDEX cpctEcrf_item ON cpctEcrf (item);
-CREATE INDEX cpctEcrf_itemValue ON cpctEcrf (itemValue);
-CREATE INDEX cpctEcrf_status ON cpctEcrf (status);
-CREATE INDEX cpctEcrf_locked ON cpctEcrf (locked);
-CREATE INDEX cpctEcrf_sequenced ON cpctEcrf (sequenced);
-CREATE INDEX cpctEcrf_fieldName ON cpctEcrf (fieldName);
-CREATE INDEX cpctEcrf_relevant ON cpctEcrf (relevant);
+CREATE INDEX `cpctEcrf_patientId` ON `cpctEcrf` (`patientId`);
+CREATE INDEX `cpctEcrf_studyEvent` ON `cpctEcrf` (`studyEvent`);
+CREATE INDEX `cpctEcrf_form` ON `cpctEcrf` (`form`);
+CREATE INDEX `cpctEcrf_itemGroup` ON `cpctEcrf` (`itemGroup`);
+CREATE INDEX `cpctEcrf_item` ON `cpctEcrf` (`item`);
+CREATE INDEX `cpctEcrf_itemValue` ON `cpctEcrf` (`itemValue`);
+CREATE INDEX `cpctEcrf_status` ON `cpctEcrf` (`status`);
+CREATE INDEX `cpctEcrf_locked` ON `cpctEcrf` (`locked`);
+CREATE INDEX `cpctEcrf_sequenced` ON `cpctEcrf` (`sequenced`);
+CREATE INDEX `cpctEcrf_fieldName` ON `cpctEcrf` (`fieldName`);
+CREATE INDEX `cpctEcrf_relevant` ON `cpctEcrf` (`relevant`);
 
-DROP TABLE IF EXISTS cpctEcrfDatamodel;
-CREATE TABLE cpctEcrfDatamodel
-(   fieldName varchar(100),
-    description varchar(500),
-    codeList varchar(3000),
-    relevant varchar(5)
+DROP TABLE IF EXISTS `cpctEcrfDatamodel`;
+CREATE TABLE `cpctEcrfDatamodel`
+(   `fieldName` VARCHAR(100),
+    `description` VARCHAR(500),
+    `codeList` VARCHAR(3000),
+    `relevant` VARCHAR(5)
 );
 
-DROP TABLE IF EXISTS drupEcrf;
-CREATE TABLE drupEcrf
-(   id int NOT NULL AUTO_INCREMENT,
-    patientId varchar(20),
-    studyEvent varchar(100),
-    studyEventKey int not null,
-    form varchar(100),
-    formKey int not null,
-    itemGroup varchar(100),
-    itemGroupKey int not null,
-    item varchar(100),
-    itemValue varchar(15000),
-    status varchar(30),
-    locked varchar(5),
-    sequenced varchar(5),
-    fieldName varchar(100),
-    relevant varchar(5),
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `drupEcrf`;
+CREATE TABLE `drupEcrf`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `patientId` VARCHAR(20),
+    `studyEvent` VARCHAR(100),
+    `studyEventKey` INT NOT NULL,
+    `form` VARCHAR(100),
+    `formKey` INT NOT NULL,
+    `itemGroup` VARCHAR(100),
+    `itemGroupKey` INT NOT NULL,
+    `item` VARCHAR(100),
+    `itemValue` VARCHAR(15000),
+    `status` VARCHAR(30),
+    `locked` VARCHAR(5),
+    `sequenced` VARCHAR(5),
+    `fieldName` VARCHAR(100),
+    `relevant` VARCHAR(5),
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX drupEcrf_patientId ON drupEcrf (patientId);
-CREATE INDEX drupEcrf_studyEvent ON drupEcrf (studyEvent);
-CREATE INDEX drupEcrf_form ON drupEcrf (form);
-CREATE INDEX drupEcrf_itemGroup ON drupEcrf (itemGroup);
-CREATE INDEX drupEcrf_item ON drupEcrf (item);
-CREATE INDEX drupEcrf_status ON drupEcrf (status);
-CREATE INDEX drupEcrf_sequenced ON drupEcrf (sequenced);
-CREATE INDEX drupEcrf_fieldName ON drupEcrf (fieldName);
-CREATE INDEX drupEcrf_relevant ON drupEcrf (relevant);
+CREATE INDEX `drupEcrf_patientId` ON `drupEcrf` (`patientId`);
+CREATE INDEX `drupEcrf_studyEvent` ON `drupEcrf` (`studyEvent`);
+CREATE INDEX `drupEcrf_form` ON `drupEcrf` (`form`);
+CREATE INDEX `drupEcrf_itemGroup` ON `drupEcrf` (`itemGroup`);
+CREATE INDEX `drupEcrf_item` ON `drupEcrf` (`item`);
+CREATE INDEX `drupEcrf_status` ON `drupEcrf` (`status`);
+CREATE INDEX `drupEcrf_sequenced` ON `drupEcrf` (`sequenced`);
+CREATE INDEX `drupEcrf_fieldName` ON `drupEcrf` (`fieldName`);
+CREATE INDEX `drupEcrf_relevant` ON `drupEcrf` (`relevant`);
 
 
-DROP TABLE IF EXISTS drupEcrfDatamodel;
-CREATE TABLE drupEcrfDatamodel
-(   fieldName varchar(100),
-    description varchar(500),
-    codeList varchar(5000),
-    relevant varchar(5)
+DROP TABLE IF EXISTS `drupEcrfDatamodel`;
+CREATE TABLE `drupEcrfDatamodel`
+(   `fieldName` VARCHAR(100),
+    `description` VARCHAR(500),
+    `codeList` VARCHAR(5000),
+    `relevant` VARCHAR(5)
 );
 
-DROP TABLE IF EXISTS formsMetadata;
-CREATE TABLE formsMetadata
-(   id int NOT NULL,
-    tableName varchar(20),
-    form varchar(20),
-    status varchar(30),
-    locked varchar(5)
+DROP TABLE IF EXISTS `formsMetadata`;
+CREATE TABLE `formsMetadata`
+(   `id` INT NOT NULL,
+    `tableName` VARCHAR(20),
+    `form` VARCHAR(20),
+    `status` VARCHAR(30),
+    `locked` VARCHAR(5)
 );
 
-CREATE UNIQUE INDEX formsMetadata_unique_constraint on formsMetadata (id, tableName, form);
+CREATE UNIQUE INDEX `formsMetadata_unique_constraint` ON `formsMetadata` (`id`, `tableName`, `form`);
 
-DROP TABLE IF EXISTS amberPatient;
-CREATE TABLE amberPatient
-(   modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    sampleId varchar(255) NOT NULL,
-    patientId int NOT NULL,
-    PRIMARY KEY (sampleId)
+DROP TABLE IF EXISTS `amberPatient`;
+CREATE TABLE `amberPatient`
+(   `modified` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `patientId` INT NOT NULL,
+    PRIMARY KEY (`sampleId`)
 );
 
-DROP TABLE IF EXISTS amberAnonymous;
-CREATE TABLE amberAnonymous
-(   modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    sampleId varchar(255) NOT NULL,
-    hmfSampleId varchar(255) NOT NULL,
-    deleted TINYINT(1) NOT NULL,
-    PRIMARY KEY (sampleId)
+DROP TABLE IF EXISTS `amberAnonymous`;
+CREATE TABLE `amberAnonymous`
+(   `modified` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `hmfSampleId` VARCHAR(255) NOT NULL,
+    `deleted` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`sampleId`)
 );
 
-CREATE INDEX amberAnonymous_hmfSampleId ON amberAnonymous (hmfSampleId);
+CREATE INDEX `amberAnonymous_hmfSampleId` ON `amberAnonymous` (`hmfSampleId`);
 
 
-DROP TABLE IF EXISTS amberMapping;
-CREATE TABLE amberMapping
-(   modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    firstSampleId varchar(255) NOT NULL,
-    secondSampleId varchar(255) NOT NULL,
-    matches int NOT NULL,
-    sites int NOT NULL,
-    likelihood DOUBLE PRECISION NOT NULL,
-    PRIMARY KEY (firstSampleId, secondSampleId)
+DROP TABLE IF EXISTS `amberMapping`;
+CREATE TABLE `amberMapping`
+(   `modified` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `firstSampleId` VARCHAR(255) NOT NULL,
+    `secondSampleId` VARCHAR(255) NOT NULL,
+    `matches` INT NOT NULL,
+    `sites` INT NOT NULL,
+    `likelihood` DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (`firstSampleId`, `secondSampleId`)
 );
 
-DROP TABLE IF EXISTS amberSample;
-CREATE TABLE amberSample
-(   modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    sampleId varchar(255) NOT NULL,
-    site1 TINYINT NOT NULL,
-    site2 TINYINT NOT NULL,
-    site3 TINYINT NOT NULL,
-    site4 TINYINT NOT NULL,
-    site5 TINYINT NOT NULL,
-    site6 TINYINT NOT NULL,
-    site7 TINYINT NOT NULL,
-    site8 TINYINT NOT NULL,
-    site9 TINYINT NOT NULL,
-    site10 TINYINT NOT NULL,
-    site11 TINYINT NOT NULL,
-    site12 TINYINT NOT NULL,
-    site13 TINYINT NOT NULL,
-    site14 TINYINT NOT NULL,
-    site15 TINYINT NOT NULL,
-    site16 TINYINT NOT NULL,
-    site17 TINYINT NOT NULL,
-    site18 TINYINT NOT NULL,
-    site19 TINYINT NOT NULL,
-    site20 TINYINT NOT NULL,
-    site21 TINYINT NOT NULL,
-    site22 TINYINT NOT NULL,
-    site23 TINYINT NOT NULL,
-    site24 TINYINT NOT NULL,
-    site25 TINYINT NOT NULL,
-    site26 TINYINT NOT NULL,
-    site27 TINYINT NOT NULL,
-    site28 TINYINT NOT NULL,
-    site29 TINYINT NOT NULL,
-    site30 TINYINT NOT NULL,
-    site31 TINYINT NOT NULL,
-    site32 TINYINT NOT NULL,
-    site33 TINYINT NOT NULL,
-    site34 TINYINT NOT NULL,
-    site35 TINYINT NOT NULL,
-    site36 TINYINT NOT NULL,
-    site37 TINYINT NOT NULL,
-    site38 TINYINT NOT NULL,
-    site39 TINYINT NOT NULL,
-    site40 TINYINT NOT NULL,
-    site41 TINYINT NOT NULL,
-    site42 TINYINT NOT NULL,
-    site43 TINYINT NOT NULL,
-    site44 TINYINT NOT NULL,
-    site45 TINYINT NOT NULL,
-    site46 TINYINT NOT NULL,
-    site47 TINYINT NOT NULL,
-    site48 TINYINT NOT NULL,
-    site49 TINYINT NOT NULL,
-    site50 TINYINT NOT NULL,
-    site51 TINYINT NOT NULL,
-    site52 TINYINT NOT NULL,
-    site53 TINYINT NOT NULL,
-    site54 TINYINT NOT NULL,
-    site55 TINYINT NOT NULL,
-    site56 TINYINT NOT NULL,
-    site57 TINYINT NOT NULL,
-    site58 TINYINT NOT NULL,
-    site59 TINYINT NOT NULL,
-    site60 TINYINT NOT NULL,
-    site61 TINYINT NOT NULL,
-    site62 TINYINT NOT NULL,
-    site63 TINYINT NOT NULL,
-    site64 TINYINT NOT NULL,
-    site65 TINYINT NOT NULL,
-    site66 TINYINT NOT NULL,
-    site67 TINYINT NOT NULL,
-    site68 TINYINT NOT NULL,
-    site69 TINYINT NOT NULL,
-    site70 TINYINT NOT NULL,
-    site71 TINYINT NOT NULL,
-    site72 TINYINT NOT NULL,
-    site73 TINYINT NOT NULL,
-    site74 TINYINT NOT NULL,
-    site75 TINYINT NOT NULL,
-    site76 TINYINT NOT NULL,
-    site77 TINYINT NOT NULL,
-    site78 TINYINT NOT NULL,
-    site79 TINYINT NOT NULL,
-    site80 TINYINT NOT NULL,
-    site81 TINYINT NOT NULL,
-    site82 TINYINT NOT NULL,
-    site83 TINYINT NOT NULL,
-    site84 TINYINT NOT NULL,
-    site85 TINYINT NOT NULL,
-    site86 TINYINT NOT NULL,
-    site87 TINYINT NOT NULL,
-    site88 TINYINT NOT NULL,
-    site89 TINYINT NOT NULL,
-    site90 TINYINT NOT NULL,
-    site91 TINYINT NOT NULL,
-    site92 TINYINT NOT NULL,
-    site93 TINYINT NOT NULL,
-    site94 TINYINT NOT NULL,
-    site95 TINYINT NOT NULL,
-    site96 TINYINT NOT NULL,
-    site97 TINYINT NOT NULL,
-    site98 TINYINT NOT NULL,
-    site99 TINYINT NOT NULL,
-    site100 TINYINT NOT NULL,
-    PRIMARY KEY (sampleId)
+DROP TABLE IF EXISTS `amberSample`;
+CREATE TABLE `amberSample`
+(   `modified` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `site1` TINYINT NOT NULL,
+    `site2` TINYINT NOT NULL,
+    `site3` TINYINT NOT NULL,
+    `site4` TINYINT NOT NULL,
+    `site5` TINYINT NOT NULL,
+    `site6` TINYINT NOT NULL,
+    `site7` TINYINT NOT NULL,
+    `site8` TINYINT NOT NULL,
+    `site9` TINYINT NOT NULL,
+    `site10` TINYINT NOT NULL,
+    `site11` TINYINT NOT NULL,
+    `site12` TINYINT NOT NULL,
+    `site13` TINYINT NOT NULL,
+    `site14` TINYINT NOT NULL,
+    `site15` TINYINT NOT NULL,
+    `site16` TINYINT NOT NULL,
+    `site17` TINYINT NOT NULL,
+    `site18` TINYINT NOT NULL,
+    `site19` TINYINT NOT NULL,
+    `site20` TINYINT NOT NULL,
+    `site21` TINYINT NOT NULL,
+    `site22` TINYINT NOT NULL,
+    `site23` TINYINT NOT NULL,
+    `site24` TINYINT NOT NULL,
+    `site25` TINYINT NOT NULL,
+    `site26` TINYINT NOT NULL,
+    `site27` TINYINT NOT NULL,
+    `site28` TINYINT NOT NULL,
+    `site29` TINYINT NOT NULL,
+    `site30` TINYINT NOT NULL,
+    `site31` TINYINT NOT NULL,
+    `site32` TINYINT NOT NULL,
+    `site33` TINYINT NOT NULL,
+    `site34` TINYINT NOT NULL,
+    `site35` TINYINT NOT NULL,
+    `site36` TINYINT NOT NULL,
+    `site37` TINYINT NOT NULL,
+    `site38` TINYINT NOT NULL,
+    `site39` TINYINT NOT NULL,
+    `site40` TINYINT NOT NULL,
+    `site41` TINYINT NOT NULL,
+    `site42` TINYINT NOT NULL,
+    `site43` TINYINT NOT NULL,
+    `site44` TINYINT NOT NULL,
+    `site45` TINYINT NOT NULL,
+    `site46` TINYINT NOT NULL,
+    `site47` TINYINT NOT NULL,
+    `site48` TINYINT NOT NULL,
+    `site49` TINYINT NOT NULL,
+    `site50` TINYINT NOT NULL,
+    `site51` TINYINT NOT NULL,
+    `site52` TINYINT NOT NULL,
+    `site53` TINYINT NOT NULL,
+    `site54` TINYINT NOT NULL,
+    `site55` TINYINT NOT NULL,
+    `site56` TINYINT NOT NULL,
+    `site57` TINYINT NOT NULL,
+    `site58` TINYINT NOT NULL,
+    `site59` TINYINT NOT NULL,
+    `site60` TINYINT NOT NULL,
+    `site61` TINYINT NOT NULL,
+    `site62` TINYINT NOT NULL,
+    `site63` TINYINT NOT NULL,
+    `site64` TINYINT NOT NULL,
+    `site65` TINYINT NOT NULL,
+    `site66` TINYINT NOT NULL,
+    `site67` TINYINT NOT NULL,
+    `site68` TINYINT NOT NULL,
+    `site69` TINYINT NOT NULL,
+    `site70` TINYINT NOT NULL,
+    `site71` TINYINT NOT NULL,
+    `site72` TINYINT NOT NULL,
+    `site73` TINYINT NOT NULL,
+    `site74` TINYINT NOT NULL,
+    `site75` TINYINT NOT NULL,
+    `site76` TINYINT NOT NULL,
+    `site77` TINYINT NOT NULL,
+    `site78` TINYINT NOT NULL,
+    `site79` TINYINT NOT NULL,
+    `site80` TINYINT NOT NULL,
+    `site81` TINYINT NOT NULL,
+    `site82` TINYINT NOT NULL,
+    `site83` TINYINT NOT NULL,
+    `site84` TINYINT NOT NULL,
+    `site85` TINYINT NOT NULL,
+    `site86` TINYINT NOT NULL,
+    `site87` TINYINT NOT NULL,
+    `site88` TINYINT NOT NULL,
+    `site89` TINYINT NOT NULL,
+    `site90` TINYINT NOT NULL,
+    `site91` TINYINT NOT NULL,
+    `site92` TINYINT NOT NULL,
+    `site93` TINYINT NOT NULL,
+    `site94` TINYINT NOT NULL,
+    `site95` TINYINT NOT NULL,
+    `site96` TINYINT NOT NULL,
+    `site97` TINYINT NOT NULL,
+    `site98` TINYINT NOT NULL,
+    `site99` TINYINT NOT NULL,
+    `site100` TINYINT NOT NULL,
+    PRIMARY KEY (`sampleId`)
 );
 
-DROP TABLE IF EXISTS canonicalTranscript;
-CREATE TABLE canonicalTranscript
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    assembly varchar(255) NOT NULL,
-    gene varchar(50) NOT NULL,
-    geneId varchar(255) NOT NULL,
-    chromosomeBand varchar(255) NOT NULL,
-    chromosome varchar(10) NOT NULL,
-    geneStart int not null,
-    geneEnd int not null,
-    transcriptId varchar(255) NOT NULL,
-    transcriptStart int not null,
-    transcriptEnd int not null,
-    exons int not null,
-    exonStart int not null,
-    exonEnd int not null,
-    exonBases int not null,
-    strand varchar(255) not null,
-    codingStart int not null,
-    codingEnd int not null,
-    codingBases int not null,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `canonicalTranscript`;
+CREATE TABLE `canonicalTranscript`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `assembly` VARCHAR(255) NOT NULL,
+    `gene` VARCHAR(50) NOT NULL,
+    `geneId` VARCHAR(255) NOT NULL,
+    `chromosomeBand` VARCHAR(255) NOT NULL,
+    `chromosome` VARCHAR(10) NOT NULL,
+    `geneStart` INT NOT NULL,
+    `geneEnd` INT NOT NULL,
+    `transcriptId` VARCHAR(255) NOT NULL,
+    `transcriptStart` INT NOT NULL,
+    `transcriptEnd` INT NOT NULL,
+    `exons` INT NOT NULL,
+    `exonStart` INT NOT NULL,
+    `exonEnd` INT NOT NULL,
+    `exonBases` INT NOT NULL,
+    `strand` VARCHAR(255) NOT NULL,
+    `codingStart` INT NOT NULL,
+    `codingEnd` INT NOT NULL,
+    `codingBases` INT NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX canonicalTranscript_gene on canonicalTranscript (gene);
-CREATE INDEX canonicalTranscript_transcriptId on canonicalTranscript (transcriptId);
+CREATE INDEX `canonicalTranscript_gene` ON `canonicalTranscript` (`gene`);
+CREATE INDEX `canonicalTranscript_transcriptId` ON `canonicalTranscript` (`transcriptId`);
 
-DROP TABLE IF EXISTS driverGenePanel;
-CREATE TABLE driverGenePanel
-(   modified DATETIME NOT NULL,
-    gene varchar(50) NOT NULL,
-    reportMissense TINYINT(1) NOT NULL,
-    reportNonsense TINYINT(1) NOT NULL,
-    reportSplice TINYINT(1) NOT NULL,
-    reportDeletion TINYINT(1) NOT NULL,
-    reportDisruption TINYINT(1) NOT NULL,
-    reportAmplification TINYINT(1) NOT NULL,
-    reportSomaticHotspot TINYINT(1) NOT NULL,
-    reportGermlineVariant varchar(50) NOT NULL,
-    reportGermlineHotspot varchar(50) NOT NULL,
-    likelihoodType varchar(255) NOT NULL,
-    reportGermlineDisruption varchar(50) NOT NULL,
-    reportGermlineDeletion varchar(50) NOT NULL,
-    additionalReportedTranscripts varchar(255) NOT NULL,
-    reportPGX TINYINT(1) NOT NULL,
-    PRIMARY KEY (gene)
+DROP TABLE IF EXISTS `driverGenePanel`;
+CREATE TABLE `driverGenePanel`
+(   `modified` DATETIME NOT NULL,
+    `gene` VARCHAR(50) NOT NULL,
+    `reportMissense` TINYINT(1) NOT NULL,
+    `reportNonsense` TINYINT(1) NOT NULL,
+    `reportSplice` TINYINT(1) NOT NULL,
+    `reportDeletion` TINYINT(1) NOT NULL,
+    `reportDisruption` TINYINT(1) NOT NULL,
+    `reportAmplification` TINYINT(1) NOT NULL,
+    `reportSomaticHotspot` TINYINT(1) NOT NULL,
+    `reportGermlineVariant` VARCHAR(50) NOT NULL,
+    `reportGermlineHotspot` VARCHAR(50) NOT NULL,
+    `likelihoodType` VARCHAR(255) NOT NULL,
+    `reportGermlineDisruption` VARCHAR(50) NOT NULL,
+    `reportGermlineDeletion` VARCHAR(50) NOT NULL,
+    `additionalReportedTranscripts` VARCHAR(255) NOT NULL,
+    `reportPGX` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`gene`)
 );
 
-DROP TABLE if EXISTS metric;
-CREATE TABLE metric
-(   sampleId varchar(255) NOT NULL,
-    refMeanCoverage DOUBLE PRECISION NOT NULL,
-    refSdCoverage DOUBLE PRECISION NOT NULL,
-    refMedianCoverage int NOT NULL,
-    refMadCoverage int NOT NULL,
-    refPctExcAdapter DOUBLE PRECISION,
-    refPctExcMapQ DOUBLE PRECISION NOT NULL,
-    refPctExcDupe DOUBLE PRECISION NOT NULL,
-    refPctExcUnpaired DOUBLE PRECISION NOT NULL,
-    refPctExcBaseQ DOUBLE PRECISION NOT NULL,
-    refPctExcOverlap DOUBLE PRECISION NOT NULL,
-    refPctExcCapped DOUBLE PRECISION NOT NULL,
-    refPctExcTotal DOUBLE PRECISION NOT NULL,
-    refCoverage1xPercentage DOUBLE PRECISION,
-    refCoverage10xPercentage DOUBLE PRECISION NOT NULL,
-    refCoverage20xPercentage DOUBLE PRECISION NOT NULL,
-    refCoverage30xPercentage DOUBLE PRECISION NOT NULL,
-    refCoverage60xPercentage DOUBLE PRECISION NOT NULL,
-    tumorMeanCoverage DOUBLE PRECISION NOT NULL,
-    tumorSdCoverage DOUBLE PRECISION NOT NULL,
-    tumorMedianCoverage int NOT NULL,
-    tumorMadCoverage int NOT NULL,
-    tumorPctExcAdapter DOUBLE PRECISION,
-    tumorPctExcMapQ DOUBLE PRECISION NOT NULL,
-    tumorPctExcDupe DOUBLE PRECISION NOT NULL,
-    tumorPctExcUnpaired DOUBLE PRECISION NOT NULL,
-    tumorPctExcBaseQ DOUBLE PRECISION NOT NULL,
-    tumorPctExcOverlap DOUBLE PRECISION NOT NULL,
-    tumorPctExcCapped DOUBLE PRECISION NOT NULL,
-    tumorPctExcTotal DOUBLE PRECISION NOT NULL,
-    tumorCoverage1xPercentage DOUBLE PRECISION,
-    tumorCoverage10xPercentage DOUBLE PRECISION NOT NULL,
-    tumorCoverage20xPercentage DOUBLE PRECISION NOT NULL,
-    tumorCoverage30xPercentage DOUBLE PRECISION NOT NULL,
-    tumorCoverage60xPercentage DOUBLE PRECISION NOT NULL,
-    sufficientCoverage TINYINT(1) NOT NULL,
-    PRIMARY KEY (sampleId)
+DROP TABLE IF EXISTS `metric`;
+CREATE TABLE `metric`
+(   `sampleId` VARCHAR(255) NOT NULL,
+    `refMeanCoverage` DOUBLE PRECISION NOT NULL,
+    `refSdCoverage` DOUBLE PRECISION NOT NULL,
+    `refMedianCoverage` INT NOT NULL,
+    `refMadCoverage` INT NOT NULL,
+    `refPctExcAdapter` DOUBLE PRECISION,
+    `refPctExcMapQ` DOUBLE PRECISION NOT NULL,
+    `refPctExcDupe` DOUBLE PRECISION NOT NULL,
+    `refPctExcUnpaired` DOUBLE PRECISION NOT NULL,
+    `refPctExcBaseQ` DOUBLE PRECISION NOT NULL,
+    `refPctExcOverlap` DOUBLE PRECISION NOT NULL,
+    `refPctExcCapped` DOUBLE PRECISION NOT NULL,
+    `refPctExcTotal` DOUBLE PRECISION NOT NULL,
+    `refCoverage1xPercentage` DOUBLE PRECISION,
+    `refCoverage10xPercentage` DOUBLE PRECISION NOT NULL,
+    `refCoverage20xPercentage` DOUBLE PRECISION NOT NULL,
+    `refCoverage30xPercentage` DOUBLE PRECISION NOT NULL,
+    `refCoverage60xPercentage` DOUBLE PRECISION NOT NULL,
+    `tumorMeanCoverage` DOUBLE PRECISION NOT NULL,
+    `tumorSdCoverage` DOUBLE PRECISION NOT NULL,
+    `tumorMedianCoverage` INT NOT NULL,
+    `tumorMadCoverage` INT NOT NULL,
+    `tumorPctExcAdapter` DOUBLE PRECISION,
+    `tumorPctExcMapQ` DOUBLE PRECISION NOT NULL,
+    `tumorPctExcDupe` DOUBLE PRECISION NOT NULL,
+    `tumorPctExcUnpaired` DOUBLE PRECISION NOT NULL,
+    `tumorPctExcBaseQ` DOUBLE PRECISION NOT NULL,
+    `tumorPctExcOverlap` DOUBLE PRECISION NOT NULL,
+    `tumorPctExcCapped` DOUBLE PRECISION NOT NULL,
+    `tumorPctExcTotal` DOUBLE PRECISION NOT NULL,
+    `tumorCoverage1xPercentage` DOUBLE PRECISION,
+    `tumorCoverage10xPercentage` DOUBLE PRECISION NOT NULL,
+    `tumorCoverage20xPercentage` DOUBLE PRECISION NOT NULL,
+    `tumorCoverage30xPercentage` DOUBLE PRECISION NOT NULL,
+    `tumorCoverage60xPercentage` DOUBLE PRECISION NOT NULL,
+    `sufficientCoverage` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`sampleId`)
 );
 
-DROP TABLE if EXISTS flagstat;
-CREATE TABLE flagstat
-(   sampleId varchar(255) NOT NULL,
-    refUniqueReadCount BIGINT NOT NULL,
-    refSecondaryCount BIGINT NOT NULL,
-    refSupplementaryCount BIGINT NOT NULL,
-    refDuplicateProportion DOUBLE PRECISION NOT NULL,
-    refMappedProportion DOUBLE PRECISION NOT NULL,
-    refPairedInSequencingProportion DOUBLE PRECISION NOT NULL,
-    refProperlyPairedProportion DOUBLE PRECISION NOT NULL,
-    refWithItselfAndMateMappedProportion DOUBLE PRECISION NOT NULL,
-    refSingletonProportion DOUBLE PRECISION NOT NULL,
-    tumorUniqueReadCount BIGINT NOT NULL,
-    tumorSecondaryCount BIGINT NOT NULL,
-    tumorSupplementaryCount BIGINT NOT NULL,
-    tumorDuplicateProportion DOUBLE PRECISION NOT NULL,
-    tumorMappedProportion DOUBLE PRECISION NOT NULL,
-    tumorPairedInSequencingProportion DOUBLE PRECISION NOT NULL,
-    tumorProperlyPairedProportion DOUBLE PRECISION NOT NULL,
-    tumorWithItselfAndMateMappedProportion DOUBLE PRECISION NOT NULL,
-    tumorSingletonProportion DOUBLE PRECISION NOT NULL,
-    passQC TINYINT(1) NOT NULL,
-    PRIMARY KEY (sampleId)
+DROP TABLE IF EXISTS `flagstat`;
+CREATE TABLE `flagstat`
+(   `sampleId` VARCHAR(255) NOT NULL,
+    `refUniqueReadCount` BIGINT NOT NULL,
+    `refSecondaryCount` BIGINT NOT NULL,
+    `refSupplementaryCount` BIGINT NOT NULL,
+    `refDuplicateProportion` DOUBLE PRECISION NOT NULL,
+    `refMappedProportion` DOUBLE PRECISION NOT NULL,
+    `refPairedInSequencingProportion` DOUBLE PRECISION NOT NULL,
+    `refProperlyPairedProportion` DOUBLE PRECISION NOT NULL,
+    `refWithItselfAndMateMappedProportion` DOUBLE PRECISION NOT NULL,
+    `refSingletonProportion` DOUBLE PRECISION NOT NULL,
+    `tumorUniqueReadCount` BIGINT NOT NULL,
+    `tumorSecondaryCount` BIGINT NOT NULL,
+    `tumorSupplementaryCount` BIGINT NOT NULL,
+    `tumorDuplicateProportion` DOUBLE PRECISION NOT NULL,
+    `tumorMappedProportion` DOUBLE PRECISION NOT NULL,
+    `tumorPairedInSequencingProportion` DOUBLE PRECISION NOT NULL,
+    `tumorProperlyPairedProportion` DOUBLE PRECISION NOT NULL,
+    `tumorWithItselfAndMateMappedProportion` DOUBLE PRECISION NOT NULL,
+    `tumorSingletonProportion` DOUBLE PRECISION NOT NULL,
+    `passQC` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`sampleId`)
 );
 
-DROP TABLE IF EXISTS somaticVariant;
-CREATE TABLE somaticVariant
-(   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    chromosome varchar(31) NOT NULL,
-    position int not null,
-    filter varchar(255) NOT NULL,
-    type varchar(10) NOT NULL,
-    ref varchar(255) NOT NULL,
-    alt varchar(255) NOT NULL,
-    gene varchar(50) NOT NULL,
-    genesAffected int not null,
-    canonicalEffect varchar(255) NOT NULL,
-    canonicalCodingEffect varchar(50) NOT NULL,
-    canonicalHgvsCodingImpact varchar(100) NOT NULL,
-    canonicalHgvsProteinImpact varchar(200) NOT NULL,
-    spliceRegion TINYINT(1) NOT NULL,
-    otherTranscriptEffects varchar(255) NOT NULL,
-    worstCodingEffect varchar(50) NOT NULL,
-    microhomology varchar(255) NOT NULL,
-    repeatSequence varchar(255) NOT NULL,
-    repeatCount int NOT NULL,
-    alleleReadCount int NOT NULL,
-    totalReadCount int NOT NULL,
-    adjustedVaf DOUBLE PRECISION NOT NULL,
-    variantCopyNumber DOUBLE PRECISION NOT NULL,
-    copyNumber DOUBLE PRECISION NOT NULL,
-    tier varchar(20) NOT NULL,
-    trinucleotideContext varchar(3) NOT NULL,
-    subclonalLikelihood DOUBLE PRECISION NOT NULL,
-    biallelic TINYINT(1) NOT NULL,
-    hotspot varchar(20) NOT NULL,
-    mappability DOUBLE PRECISION NOT NULL,
-    germlineStatus varchar(50) NOT NULL,
-    minorAlleleCopyNumber DOUBLE PRECISION NOT NULL,
-    recovered TINYINT(1) NOT NULL,
-    kataegis varchar(20) NOT NULL,
-    referenceAlleleReadCount int,
-    referenceTotalReadCount int,
-    rnaAlleleReadCount int,
-    rnaTotalReadCount int,
-    localPhaseSet varchar(50),
-    qual double precision not null,
-    reported TINYINT(1) NOT NULL,
-    clinvarInfo varchar(255) NULL,
-    gnomadFrequency DOUBLE PRECISION NULL,
-    somaticLikelihood varchar(10) NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `somaticVariant`;
+CREATE TABLE `somaticVariant`
+(   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `chromosome` VARCHAR(31) NOT NULL,
+    `position` INT NOT NULL,
+    `filter` VARCHAR(255) NOT NULL,
+    `type` VARCHAR(10) NOT NULL,
+    `ref` VARCHAR(255) NOT NULL,
+    `alt` VARCHAR(255) NOT NULL,
+    `gene` VARCHAR(50) NOT NULL,
+    `genesAffected` INT NOT NULL,
+    `canonicalEffect` VARCHAR(255) NOT NULL,
+    `canonicalCodingEffect` VARCHAR(50) NOT NULL,
+    `canonicalHgvsCodingImpact` VARCHAR(100) NOT NULL,
+    `canonicalHgvsProteinImpact` VARCHAR(200) NOT NULL,
+    `spliceRegion` TINYINT(1) NOT NULL,
+    `otherTranscriptEffects` VARCHAR(255) NOT NULL,
+    `worstCodingEffect` VARCHAR(50) NOT NULL,
+    `microhomology` VARCHAR(255) NOT NULL,
+    `repeatSequence` VARCHAR(255) NOT NULL,
+    `repeatCount` INT NOT NULL,
+    `alleleReadCount` INT NOT NULL,
+    `totalReadCount` INT NOT NULL,
+    `adjustedVaf` DOUBLE PRECISION NOT NULL,
+    `variantCopyNumber` DOUBLE PRECISION NOT NULL,
+    `copyNumber` DOUBLE PRECISION NOT NULL,
+    `tier` VARCHAR(20) NOT NULL,
+    `trinucleotideContext` VARCHAR(3) NOT NULL,
+    `subclonalLikelihood` DOUBLE PRECISION NOT NULL,
+    `biallelic` TINYINT(1) NOT NULL,
+    `hotspot` VARCHAR(20) NOT NULL,
+    `mappability` DOUBLE PRECISION NOT NULL,
+    `germlineStatus` VARCHAR(50) NOT NULL,
+    `minorAlleleCopyNumber` DOUBLE PRECISION NOT NULL,
+    `recovered` TINYINT(1) NOT NULL,
+    `kataegis` VARCHAR(20) NOT NULL,
+    `referenceAlleleReadCount` INT,
+    `referenceTotalReadCount` INT,
+    `rnaAlleleReadCount` INT,
+    `rnaTotalReadCount` INT,
+    `localPhaseSet` VARCHAR(50),
+    `qual` DOUBLE PRECISION NOT NULL,
+    `reported` TINYINT(1) NOT NULL,
+    `clinvarInfo` VARCHAR(255) NULL,
+    `gnomadFrequency` DOUBLE PRECISION NULL,
+    `somaticLikelihood` VARCHAR(10) NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE UNIQUE INDEX somaticVariant_unique_constraint on somaticVariant (sampleId, chromosome, position, ref, alt);
-CREATE INDEX somaticVariant_sampleId on somaticVariant (sampleId);
-CREATE INDEX somaticVariant_filter on somaticVariant (filter);
-CREATE INDEX somaticVariant_type on somaticVariant (type);
-CREATE INDEX somaticVariant_gene on somaticVariant (gene);
+CREATE UNIQUE INDEX `somaticVariant_unique_constraint` ON `somaticVariant` (`sampleId`, `chromosome`, `position`, `ref`, `alt`);
+CREATE INDEX `somaticVariant_sampleId` ON `somaticVariant` (`sampleId`);
+CREATE INDEX `somaticVariant_filter` ON `somaticVariant` (`filter`);
+CREATE INDEX `somaticVariant_type` ON `somaticVariant` (`type`);
+CREATE INDEX `somaticVariant_gene` ON `somaticVariant` (`gene`);
 
-DROP TABLE IF EXISTS germlineVariant;
-CREATE TABLE germlineVariant
-(   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    chromosome varchar(255) NOT NULL,
-    position int not null,
-    filter varchar(255) NOT NULL,
-    type varchar(255) NOT NULL,
-    ref varchar(255) NOT NULL,
-    alt varchar(255) NOT NULL,
+DROP TABLE IF EXISTS `germlineVariant`;
+CREATE TABLE `germlineVariant`
+(   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `chromosome` VARCHAR(255) NOT NULL,
+    `position` INT NOT NULL,
+    `filter` VARCHAR(255) NOT NULL,
+    `type` VARCHAR(255) NOT NULL,
+    `ref` VARCHAR(255) NOT NULL,
+    `alt` VARCHAR(255) NOT NULL,
 
     -- ### SAGE
-    qual double precision not null,
-    tier varchar(20) NOT NULL,
-    germlineGenotype varchar(255) NOT NULL,
-    germlineAlleleReadCount int,
-    germlineTotalReadCount int,
-    rnaAlleleReadCount int,
-    rnaTotalReadCount int,
-    tumorAlleleReadCount int NOT NULL,
-    tumorTotalReadCount int NOT NULL,
-    localPhaseSet varchar(50),
+    `qual` DOUBLE PRECISION NOT NULL,
+    `tier` VARCHAR(20) NOT NULL,
+    `germlineGenotype` VARCHAR(255) NOT NULL,
+    `germlineAlleleReadCount` INT,
+    `germlineTotalReadCount` INT,
+    `rnaAlleleReadCount` INT,
+    `rnaTotalReadCount` INT,
+    `tumorAlleleReadCount` INT NOT NULL,
+    `tumorTotalReadCount` INT NOT NULL,
+    `localPhaseSet` VARCHAR(50),
 
     -- ### PURPLE ENRICHMENT
-    adjustedVaf DOUBLE PRECISION NOT NULL,
-    variantCopyNumber DOUBLE PRECISION NOT NULL,
-    copyNumber DOUBLE PRECISION NOT NULL,
-    biallelic TINYINT(1) NOT NULL,
-    minorAlleleCopyNumber DOUBLE PRECISION NOT NULL,
+    `adjustedVaf` DOUBLE PRECISION NOT NULL,
+    `variantCopyNumber` DOUBLE PRECISION NOT NULL,
+    `copyNumber` DOUBLE PRECISION NOT NULL,
+    `biallelic` TINYINT(1) NOT NULL,
+    `minorAlleleCopyNumber` DOUBLE PRECISION NOT NULL,
 
     -- ### PATHOGENIC
-    clinvarInfo varchar(255) NOT NULL,
-    pathogenicity varchar(255) NOT NULL,
-    pathogenic TINYINT(1) NOT NULL,
+    `clinvarInfo` VARCHAR(255) NOT NULL,
+    `pathogenicity` VARCHAR(255) NOT NULL,
+    `pathogenic` TINYINT(1) NOT NULL,
 
     -- ### PAVE IMPACTS
-    gene varchar(50) NOT NULL,
-    genesAffected int not null,
-    canonicalEffect varchar(255) NOT NULL,
-    canonicalCodingEffect varchar(50) NOT NULL,
-    canonicalHgvsCodingImpact varchar(100) NOT NULL,
-    canonicalHgvsProteinImpact varchar(200) NOT NULL,
-    spliceRegion TINYINT(1) NOT NULL,
-    otherTranscriptEffects varchar(255) NOT NULL,
-    worstCodingEffect varchar(50) NOT NULL,
+    `gene` VARCHAR(50) NOT NULL,
+    `genesAffected` INT NOT NULL,
+    `canonicalEffect` VARCHAR(255) NOT NULL,
+    `canonicalCodingEffect` VARCHAR(50) NOT NULL,
+    `canonicalHgvsCodingImpact` VARCHAR(100) NOT NULL,
+    `canonicalHgvsProteinImpact` VARCHAR(200) NOT NULL,
+    `spliceRegion` TINYINT(1) NOT NULL,
+    `otherTranscriptEffects` VARCHAR(255) NOT NULL,
+    `worstCodingEffect` VARCHAR(50) NOT NULL,
 
     -- ### REF GENOME ENRICHMENT
-    microhomology varchar(255) NOT NULL,
-    repeatSequence varchar(255) NOT NULL,
-    repeatCount int NOT NULL,
-    trinucleotideContext varchar(3) NOT NULL,
+    `microhomology` VARCHAR(255) NOT NULL,
+    `repeatSequence` VARCHAR(255) NOT NULL,
+    `repeatCount` INT NOT NULL,
+    `trinucleotideContext` VARCHAR(3) NOT NULL,
 
     -- ### DRIVER CATALOG
-    hotspot varchar(20) NOT NULL,
-    mappability DOUBLE PRECISION NOT NULL,
-    reported TINYINT(1) NOT NULL,
+    `hotspot` VARCHAR(20) NOT NULL,
+    `mappability` DOUBLE PRECISION NOT NULL,
+    `reported` TINYINT(1) NOT NULL,
 
-    PRIMARY KEY (id)
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX germlineVariant_sampleId on germlineVariant (sampleId);
-CREATE INDEX germlineVariant_filter on germlineVariant (filter);
-CREATE INDEX germlineVariant_type on germlineVariant (type);
-CREATE INDEX germlineVariant_gene on germlineVariant (gene);
+CREATE INDEX `germlineVariant_sampleId` ON `germlineVariant` (`sampleId`);
+CREATE INDEX `germlineVariant_filter` ON `germlineVariant` (`filter`);
+CREATE INDEX `germlineVariant_type` ON `germlineVariant` (`type`);
+CREATE INDEX `germlineVariant_gene` ON `germlineVariant` (`gene`);
 
-DROP TABLE IF EXISTS purity;
-CREATE TABLE purity
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    gender varchar(20) NOT NULL,
-    runMode varchar(20) NOT NULL,
-    fitMethod varchar(20) NOT NULL,
-    qcStatus varchar(255) NOT NULL,
-    purity DOUBLE PRECISION not null,
-    normFactor DOUBLE PRECISION not null,
-    score DOUBLE PRECISION not null,
-    somaticPenalty DOUBLE PRECISION not null,
-    ploidy DOUBLE PRECISION not null,
-    diploidProportion DOUBLE PRECISION not null,
-    polyclonalProportion DOUBLE PRECISION not null,
-    wholeGenomeDuplication TINYINT(1) NOT NULL,
-    minPurity DOUBLE PRECISION not null,
-    maxPurity DOUBLE PRECISION not null,
-    minPloidy DOUBLE PRECISION not null,
-    maxPloidy DOUBLE PRECISION not null,
-    minDiploidProportion DOUBLE PRECISION not null,
-    maxDiploidProportion DOUBLE PRECISION not null,
-    msIndelsPerMb DOUBLE PRECISION not null,
-    msStatus varchar(10) not null,
-    tmbPerMb DOUBLE PRECISION not null,
-    tmbStatus varchar(10) not null,
-    tml INT not null,
-    tmlStatus varchar(10) not null,
-    svTmb INT not null DEFAULT 0,
-    deletedGenes INT not null DEFAULT 0,
-    copyNumberSegments INT not null DEFAULT 0,
-    unsupportedCopyNumberSegments INT not null DEFAULT 0,
-    contamination DOUBLE PRECISION not null DEFAULT 0,
-    germlineAberration varchar(255) not null DEFAULT 'NONE',
-    amberGender varchar(20) NOT NULL,
-    targeted TINYINT(1) not null,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `purity`;
+CREATE TABLE `purity`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `gender` VARCHAR(20) NOT NULL,
+    `runMode` VARCHAR(20) NOT NULL,
+    `fitMethod` VARCHAR(20) NOT NULL,
+    `qcStatus` VARCHAR(255) NOT NULL,
+    `purity` DOUBLE PRECISION NOT NULL,
+    `normFactor` DOUBLE PRECISION NOT NULL,
+    `score` DOUBLE PRECISION NOT NULL,
+    `somaticPenalty` DOUBLE PRECISION NOT NULL,
+    `ploidy` DOUBLE PRECISION NOT NULL,
+    `diploidProportion` DOUBLE PRECISION NOT NULL,
+    `polyclonalProportion` DOUBLE PRECISION NOT NULL,
+    `wholeGenomeDuplication` TINYINT(1) NOT NULL,
+    `minPurity` DOUBLE PRECISION NOT NULL,
+    `maxPurity` DOUBLE PRECISION NOT NULL,
+    `minPloidy` DOUBLE PRECISION NOT NULL,
+    `maxPloidy` DOUBLE PRECISION NOT NULL,
+    `minDiploidProportion` DOUBLE PRECISION NOT NULL,
+    `maxDiploidProportion` DOUBLE PRECISION NOT NULL,
+    `msIndelsPerMb` DOUBLE PRECISION NOT NULL,
+    `msStatus` VARCHAR(10) NOT NULL,
+    `tmbPerMb` DOUBLE PRECISION NOT NULL,
+    `tmbStatus` VARCHAR(10) NOT NULL,
+    `tml` INT NOT NULL,
+    `tmlStatus` VARCHAR(10) NOT NULL,
+    `svTmb` INT NOT NULL DEFAULT 0,
+    `deletedGenes` INT NOT NULL DEFAULT 0,
+    `copyNumberSegments` INT NOT NULL DEFAULT 0,
+    `unsupportedCopyNumberSegments` INT NOT NULL DEFAULT 0,
+    `contamination` DOUBLE PRECISION NOT NULL DEFAULT 0,
+    `germlineAberration` VARCHAR(255) NOT NULL DEFAULT 'NONE',
+    `amberGender` VARCHAR(20) NOT NULL,
+    `targeted` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX purity_sampleId on purity (sampleId);
+CREATE INDEX `purity_sampleId` ON `purity` (`sampleId`);
 
-DROP TABLE IF EXISTS purityRange;
-CREATE TABLE purityRange
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    purity DOUBLE PRECISION not null,
-    normFactor DOUBLE PRECISION not null,
-    score DOUBLE PRECISION not null,
-    somaticPenalty DOUBLE PRECISION not null,
-    ploidy DOUBLE PRECISION not null,
-    diploidProportion DOUBLE PRECISION not null,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `purityRange`;
+CREATE TABLE `purityRange`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `purity` DOUBLE PRECISION NOT NULL,
+    `normFactor` DOUBLE PRECISION NOT NULL,
+    `score` DOUBLE PRECISION NOT NULL,
+    `somaticPenalty` DOUBLE PRECISION NOT NULL,
+    `ploidy` DOUBLE PRECISION NOT NULL,
+    `diploidProportion` DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX purityRange_sampleId on purityRange (sampleId);
+CREATE INDEX `purityRange_sampleId` ON `purityRange` (`sampleId`);
 
-DROP TABLE IF EXISTS copyNumber;
-CREATE TABLE copyNumber
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    chromosome varchar(255) NOT NULL,
-    start int not null,
-    end int not null,
-    segmentStartSupport varchar(255) NOT NULL,
-    segmentEndSupport varchar(255) NOT NULL,
-    depthWindowCount int not null,
-    bafCount int not null,
-    observedBaf DOUBLE PRECISION not null,
-    baf DOUBLE PRECISION not null,
-    copyNumber DOUBLE PRECISION not null,
-    minorAlleleCopyNumber DOUBLE PRECISION not null,
-    majorAlleleCopyNumber DOUBLE PRECISION not null,
-    copyNumberMethod varchar(255) NOT NULL,
-    gcContent DOUBLE PRECISION not null,
-    minStart int not null,
-    maxStart int not null,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `copyNumber`;
+CREATE TABLE `copyNumber`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `chromosome` VARCHAR(255) NOT NULL,
+    `start` INT NOT NULL,
+    `end` INT NOT NULL,
+    `segmentStartSupport` VARCHAR(255) NOT NULL,
+    `segmentEndSupport` VARCHAR(255) NOT NULL,
+    `depthWindowCount` INT NOT NULL,
+    `bafCount` INT NOT NULL,
+    `observedBaf` DOUBLE PRECISION NOT NULL,
+    `baf` DOUBLE PRECISION NOT NULL,
+    `copyNumber` DOUBLE PRECISION NOT NULL,
+    `minorAlleleCopyNumber` DOUBLE PRECISION NOT NULL,
+    `majorAlleleCopyNumber` DOUBLE PRECISION NOT NULL,
+    `copyNumberMethod` VARCHAR(255) NOT NULL,
+    `gcContent` DOUBLE PRECISION NOT NULL,
+    `minStart` INT NOT NULL,
+    `maxStart` INT NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE UNIQUE INDEX copyNumber_unique_constraint on copyNumber (sampleId, chromosome, start, end);
-CREATE INDEX copyNumber_sampleId on copyNumber (sampleId);
+CREATE UNIQUE INDEX `copyNumber_unique_constraint` ON `copyNumber` (`sampleId`, `chromosome`, `start`, `end`);
+CREATE INDEX `copyNumber_sampleId` ON `copyNumber` (`sampleId`);
 
-DROP TABLE IF EXISTS geneCopyNumber;
-CREATE TABLE geneCopyNumber
-(   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    chromosome varchar(31) NOT NULL,
-    start int not null,
-    end int not null,
-    gene varchar(255) NOT NULL,
-    chromosomeBand varchar(255) NOT NULL,
-    transcriptId varchar(255) NOT NULL,
-    canonicalTranscript TINYINT(1) NOT NULL,
-    minCopyNumber DOUBLE PRECISION not null,
-    maxCopyNumber DOUBLE PRECISION not null,
-    somaticRegions int not null,
-    minRegions int not null,
-    minRegionStart int not null,
-    minRegionEnd int not null,
-    minRegionStartSupport varchar(255) NOT NULL,
-    minRegionEndSupport varchar(255) NOT NULL,
-    minRegionMethod varchar(255) NOT NULL,
-    minMinorAlleleCopyNumber DOUBLE PRECISION not null,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `geneCopyNumber`;
+CREATE TABLE `geneCopyNumber`
+(   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `chromosome` VARCHAR(31) NOT NULL,
+    `start` INT NOT NULL,
+    `end` INT NOT NULL,
+    `gene` VARCHAR(255) NOT NULL,
+    `chromosomeBand` VARCHAR(255) NOT NULL,
+    `transcriptId` VARCHAR(255) NOT NULL,
+    `canonicalTranscript` TINYINT(1) NOT NULL,
+    `minCopyNumber` DOUBLE PRECISION NOT NULL,
+    `maxCopyNumber` DOUBLE PRECISION NOT NULL,
+    `somaticRegions` INT NOT NULL,
+    `minRegions` INT NOT NULL,
+    `minRegionStart` INT NOT NULL,
+    `minRegionEnd` INT NOT NULL,
+    `minRegionStartSupport` VARCHAR(255) NOT NULL,
+    `minRegionEndSupport` VARCHAR(255) NOT NULL,
+    `minRegionMethod` VARCHAR(255) NOT NULL,
+    `minMinorAlleleCopyNumber` DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE UNIQUE INDEX geneCopyNumber_unique_constraint on geneCopyNumber (sampleId, chromosome, gene, transcriptId);
-CREATE INDEX geneCopyNumber_sampleId_gene on geneCopyNumber (sampleId, gene);
-CREATE INDEX geneCopyNumber_gene on geneCopyNumber (gene);
+CREATE UNIQUE INDEX `geneCopyNumber_unique_constraint` ON `geneCopyNumber` (`sampleId`, `chromosome`, `gene`, `transcriptId`);
+CREATE INDEX `geneCopyNumber_sampleId_gene` ON `geneCopyNumber` (`sampleId`, `gene`);
+CREATE INDEX `geneCopyNumber_gene` ON `geneCopyNumber` (`gene`);
 
-DROP TABLE IF EXISTS driverCatalog;
-CREATE TABLE driverCatalog
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    chromosome varchar(10) NOT NULL,
-    chromosomeBand varchar(50) NOT NULL,
-    gene varchar(50) NOT NULL,
-    transcriptId varchar(50) NOT NULL,
-    canonicalTranscript TINYINT(1) NOT NULL DEFAULT 1,
-    category varchar(50) NOT NULL,
-    driver varchar(50) NOT NULL,
-    likelihoodMethod varchar(50) NOT NULL,
-    driverLikelihood DOUBLE PRECISION NOT NULL,
-    missense int NOT NULL,
-    nonsense int NOT NULL,
-    splice int NOT NULL,
-    frameshift int NOT NULL,
-    inframe int NOT NULL,
-    biallelic TINYINT(1) NOT NULL,
-    minCopyNumber DOUBLE PRECISION NOT NULL,
-    maxCopyNumber DOUBLE PRECISION NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `driverCatalog`;
+CREATE TABLE `driverCatalog`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `chromosome` VARCHAR(10) NOT NULL,
+    `chromosomeBand` VARCHAR(50) NOT NULL,
+    `gene` VARCHAR(50) NOT NULL,
+    `transcriptId` VARCHAR(50) NOT NULL,
+    `canonicalTranscript` TINYINT(1) NOT NULL DEFAULT 1,
+    `category` VARCHAR(50) NOT NULL,
+    `driver` VARCHAR(50) NOT NULL,
+    `likelihoodMethod` VARCHAR(50) NOT NULL,
+    `driverLikelihood` DOUBLE PRECISION NOT NULL,
+    `missense` INT NOT NULL,
+    `nonsense` INT NOT NULL,
+    `splice` INT NOT NULL,
+    `frameshift` INT NOT NULL,
+    `inframe` INT NOT NULL,
+    `biallelic` TINYINT(1) NOT NULL,
+    `minCopyNumber` DOUBLE PRECISION NOT NULL,
+    `maxCopyNumber` DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX driverCatalog_sampleId_gene on driverCatalog (sampleId, gene);
-CREATE INDEX driverCatalog_gene on driverCatalog (gene);
+CREATE INDEX `driverCatalog_sampleId_gene` ON `driverCatalog` (`sampleId`, `gene`);
+CREATE INDEX `driverCatalog_gene` ON `driverCatalog` (`gene`);
 
-DROP TABLE IF EXISTS germlineDeletion;
-CREATE TABLE germlineDeletion
-(   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    gene varchar(50) NOT NULL,
-    chromosome varchar(10) NOT NULL,
-    chromosomeBand varchar(50) NOT NULL,
-    regionStart int not null,
-    regionEnd int not null,
-    depthWindowCount int not null,
-    exonStart int not null,
-    exonEnd int not null,
-    detectionMethod varchar(20) NOT NULL,
-    germlineStatus varchar(20) NOT NULL,
-    tumorStatus varchar(20) NOT NULL,
-    germlineCopyNumber DOUBLE PRECISION NOT NULL,
-    tumorCopyNumber DOUBLE PRECISION NOT NULL,
-    filter varchar(50) NOT NULL,
-    cohortFrequency int not null,
-    reported TINYINT(1) NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `germlineDeletion`;
+CREATE TABLE `germlineDeletion`
+(   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `gene` VARCHAR(50) NOT NULL,
+    `chromosome` VARCHAR(10) NOT NULL,
+    `chromosomeBand` VARCHAR(50) NOT NULL,
+    `regionStart` INT NOT NULL,
+    `regionEnd` INT NOT NULL,
+    `depthWindowCount` INT NOT NULL,
+    `exonStart` INT NOT NULL,
+    `exonEnd` INT NOT NULL,
+    `detectionMethod` VARCHAR(20) NOT NULL,
+    `germlineStatus` VARCHAR(20) NOT NULL,
+    `tumorStatus` VARCHAR(20) NOT NULL,
+    `germlineCopyNumber` DOUBLE PRECISION NOT NULL,
+    `tumorCopyNumber` DOUBLE PRECISION NOT NULL,
+    `filter` VARCHAR(50) NOT NULL,
+    `cohortFrequency` INT NOT NULL,
+    `reported` TINYINT(1) NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX germlineDeletion_sampleId_gene on germlineDeletion (sampleId, gene);
-CREATE INDEX germlineDeletion_gene on germlineDeletion (gene);
+CREATE INDEX `germlineDeletion_sampleId_gene` ON `germlineDeletion` (`sampleId`, `gene`);
+CREATE INDEX `germlineDeletion_gene` ON `germlineDeletion` (`gene`);
 
-DROP TABLE IF EXISTS structuralVariant;
-CREATE TABLE structuralVariant
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    svId INT NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    startChromosome varchar(31) NOT NULL,
-    endChromosome varchar(31),
-    startPosition int not null,
-    endPosition int,
-    startOrientation tinyint not null,
-    endOrientation tinyint,
-    startHomologySequence varchar(255) not null,
-    endHomologySequence varchar(255),
-    startAF DOUBLE PRECISION,
-    endAF DOUBLE PRECISION,
-    junctionCopyNumber DOUBLE PRECISION,
-    adjustedAFStart DOUBLE PRECISION,
-    adjustedAFEnd DOUBLE PRECISION,
-    adjustedCopyNumberStart DOUBLE PRECISION,
-    adjustedCopyNumberEnd DOUBLE PRECISION,
-    adjustedCopyNumberChangeStart DOUBLE PRECISION,
-    adjustedCopyNumberChangeEnd DOUBLE PRECISION,
-    insertSequence varchar(2048) not null,
-    type varchar(10) NOT NULL,
-    filter varchar(50) NOT NULL,
-    imprecise TINYINT(1) NOT NULL,
-    qualScore DOUBLE PRECISION,
-    event varchar(50),
-    startTumorVariantFragmentCount int,
-    startTumorReferenceFragmentCount int,
-    startNormalVariantFragmentCount int,
-    startNormalReferenceFragmentCount int,
-    endTumorVariantFragmentCount int,
-    endTumorReferenceFragmentCount int,
-    endNormalVariantFragmentCount int,
-    endNormalReferenceFragmentCount int,
-    startIntervalOffsetStart int,
-    startIntervalOffsetEnd int,
-    endIntervalOffsetStart int,
-    endIntervalOffsetEnd int,
-    inexactHomologyOffsetStart int,
-    inexactHomologyOffsetEnd int,
-    startLinkedBy varchar(1024),
-    endLinkedBy varchar(1024),
-    vcfId varchar(50),
-    recovered TINYINT(1) NOT NULL,
-    recoveryMethod varchar(64),
-    recoveryFilter varchar(255),
-    startRefContext varchar(255),
-    endRefContext varchar(255),
-    insertSequenceAlignments varchar(512),
-    insertSequenceRepeatClass varchar(64),
-    insertSequenceRepeatType varchar(64),
-    insertSequenceRepeatOrientation tinyint,
-    insertSequenceRepeatCoverage DOUBLE PRECISION,
-    startAnchoringSupportDistance int,
-    endAnchoringSupportDistance int,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `structuralVariant`;
+CREATE TABLE `structuralVariant`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `svId` INT NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `startChromosome` VARCHAR(31) NOT NULL,
+    `endChromosome` VARCHAR(31),
+    `startPosition` INT NOT NULL,
+    `endPosition` INT,
+    `startOrientation` TINYINT NOT NULL,
+    `endOrientation` TINYINT,
+    `startHomologySequence` VARCHAR(255) NOT NULL,
+    `endHomologySequence` VARCHAR(255),
+    `startAF` DOUBLE PRECISION,
+    `endAF` DOUBLE PRECISION,
+    `junctionCopyNumber` DOUBLE PRECISION,
+    `adjustedAFStart` DOUBLE PRECISION,
+    `adjustedAFEnd` DOUBLE PRECISION,
+    `adjustedCopyNumberStart` DOUBLE PRECISION,
+    `adjustedCopyNumberEnd` DOUBLE PRECISION,
+    `adjustedCopyNumberChangeStart` DOUBLE PRECISION,
+    `adjustedCopyNumberChangeEnd` DOUBLE PRECISION,
+    `insertSequence` VARCHAR(2048) NOT NULL,
+    `type` VARCHAR(10) NOT NULL,
+    `filter` VARCHAR(50) NOT NULL,
+    `imprecise` TINYINT(1) NOT NULL,
+    `qualScore` DOUBLE PRECISION,
+    `event` VARCHAR(50),
+    `startTumorVariantFragmentCount` INT,
+    `startTumorReferenceFragmentCount` INT,
+    `startNormalVariantFragmentCount` INT,
+    `startNormalReferenceFragmentCount` INT,
+    `endTumorVariantFragmentCount` INT,
+    `endTumorReferenceFragmentCount` INT,
+    `endNormalVariantFragmentCount` INT,
+    `endNormalReferenceFragmentCount` INT,
+    `startIntervalOffsetStart` INT,
+    `startIntervalOffsetEnd` INT,
+    `endIntervalOffsetStart` INT,
+    `endIntervalOffsetEnd` INT,
+    `inexactHomologyOffsetStart` INT,
+    `inexactHomologyOffsetEnd` INT,
+    `startLinkedBy` VARCHAR(1024),
+    `endLinkedBy` VARCHAR(1024),
+    `vcfId` VARCHAR(50),
+    `recovered` TINYINT(1) NOT NULL,
+    `recoveryMethod` VARCHAR(64),
+    `recoveryFilter` VARCHAR(255),
+    `startRefContext` VARCHAR(255),
+    `endRefContext` VARCHAR(255),
+    `insertSequenceAlignments` VARCHAR(512),
+    `insertSequenceRepeatClass` VARCHAR(64),
+    `insertSequenceRepeatType` VARCHAR(64),
+    `insertSequenceRepeatOrientation` TINYINT,
+    `insertSequenceRepeatCoverage` DOUBLE PRECISION,
+    `startAnchoringSupportDistance` INT,
+    `endAnchoringSupportDistance` INT,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX structuralVariant_sampleId_svId on structuralVariant (sampleId, svId);
+CREATE INDEX `structuralVariant_sampleId_svId` ON `structuralVariant` (`sampleId`, `svId`);
 
-DROP TABLE IF EXISTS svAnnotation;
-CREATE TABLE svAnnotation
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    svId INT NOT NULL,
-    clusterId INT NOT NULL,
-    clusterReason VARCHAR(255) NULL,
-    fragileSiteStart TINYINT(1) NOT NULL,
-    fragileSiteEnd TINYINT(1) NOT NULL,
-    isFoldback TINYINT(1) NOT NULL,
-    lineTypeStart VARCHAR(20),
-    lineTypeEnd VARCHAR(20),
-    junctionCopyNumberMin DOUBLE PRECISION,
-    junctionCopyNumberMax DOUBLE PRECISION,
-    geneStart VARCHAR(20),
-    geneEnd varchar(20),
-    localTopologyIdStart INT,
-    localTopologyIdEnd INT,
-    localTopologyStart varchar(20),
-    localTopologyEnd VARCHAR(20),
-    localTICountStart INT,
-    localTICountEnd INT,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `svAnnotation`;
+CREATE TABLE `svAnnotation`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `svId` INT NOT NULL,
+    `clusterId` INT NOT NULL,
+    `clusterReason` VARCHAR(255) NULL,
+    `fragileSiteStart` TINYINT(1) NOT NULL,
+    `fragileSiteEnd` TINYINT(1) NOT NULL,
+    `isFoldback` TINYINT(1) NOT NULL,
+    `lineTypeStart` VARCHAR(20),
+    `lineTypeEnd` VARCHAR(20),
+    `junctionCopyNumberMin` DOUBLE PRECISION,
+    `junctionCopyNumberMax` DOUBLE PRECISION,
+    `geneStart` VARCHAR(20),
+    `geneEnd` VARCHAR(20),
+    `localTopologyIdStart` INT,
+    `localTopologyIdEnd` INT,
+    `localTopologyStart` VARCHAR(20),
+    `localTopologyEnd` VARCHAR(20),
+    `localTICountStart` INT,
+    `localTICountEnd` INT,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX svAnnotation_sampleId_svId on svAnnotation (sampleId, svId);
-CREATE INDEX svAnnotation_clusterId on svAnnotation (clusterId);
-CREATE INDEX svAnnotation_svId on svAnnotation (svId);
+CREATE INDEX `svAnnotation_sampleId_svId` ON `svAnnotation` (`sampleId`, `svId`);
+CREATE INDEX `svAnnotation_clusterId` ON `svAnnotation` (`clusterId`);
+CREATE INDEX `svAnnotation_svId` ON `svAnnotation` (`svId`);
 
-DROP TABLE IF EXISTS svCluster;
-CREATE TABLE svCluster
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    clusterId INT NOT NULL,
-    category VARCHAR(20),
-    synthetic TINYINT(1) NOT NULL,
-    resolvedType VARCHAR(20),
-    clusterCount INT,
-    clusterDesc VARCHAR(50),
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `svCluster`;
+CREATE TABLE `svCluster`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `clusterId` INT NOT NULL,
+    `category` VARCHAR(20),
+    `synthetic` TINYINT(1) NOT NULL,
+    `resolvedType` VARCHAR(20),
+    `clusterCount` INT,
+    `clusterDesc` VARCHAR(50),
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX svCluster_sampleId_clusterId on svCluster (sampleId, clusterId);
-CREATE INDEX svCluster_clusterId on svCluster (clusterId);
+CREATE INDEX `svCluster_sampleId_clusterId` ON `svCluster` (`sampleId`, `clusterId`);
+CREATE INDEX `svCluster_clusterId` ON `svCluster` (`clusterId`);
 
-DROP TABLE IF EXISTS svLink;
-CREATE TABLE svLink
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    clusterId INT NOT NULL,
-    chainId INT NOT NULL,
-    chainIndex VARCHAR(50) NOT NULL,
-    chainLinkCount INT NOT NULL,
-    lowerSvId INT NOT NULL,
-    upperSvId INT NOT NULL,
-    lowerBreakendIsStart TINYINT(1) NOT NULL,
-    upperBreakendIsStart TINYINT(1) NOT NULL,
-    chromosome VARCHAR(10),
-    arm VARCHAR(3),
-    assembled TINYINT(1) NOT NULL,
-    traversedSVCount INT,
-    linkLength INT,
-    junctionCopyNumber DOUBLE PRECISION,
-    junctionCopyNumberUncertainty DOUBLE PRECISION,
-    pseudogeneInfo varchar(255),
-    ecDna TINYINT(1),
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `svLink`;
+CREATE TABLE `svLink`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `clusterId` INT NOT NULL,
+    `chainId` INT NOT NULL,
+    `chainIndex` VARCHAR(50) NOT NULL,
+    `chainLinkCount` INT NOT NULL,
+    `lowerSvId` INT NOT NULL,
+    `upperSvId` INT NOT NULL,
+    `lowerBreakendIsStart` TINYINT(1) NOT NULL,
+    `upperBreakendIsStart` TINYINT(1) NOT NULL,
+    `chromosome` VARCHAR(10),
+    `arm` VARCHAR(3),
+    `assembled` TINYINT(1) NOT NULL,
+    `traversedSVCount` INT,
+    `linkLength` INT,
+    `junctionCopyNumber` DOUBLE PRECISION,
+    `junctionCopyNumberUncertainty` DOUBLE PRECISION,
+    `pseudogeneInfo` VARCHAR(255),
+    `ecDna` TINYINT(1),
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX svLink_sampleId_clusterId on svLink (sampleId, clusterId);
-CREATE INDEX svLink_clusterId on svLink (clusterId);
+CREATE INDEX `svLink_sampleId_clusterId` ON `svLink` (`sampleId`, `clusterId`);
+CREATE INDEX `svLink_clusterId` ON `svLink` (`clusterId`);
 
-DROP TABLE IF EXISTS svDriver;
-CREATE TABLE svDriver
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    clusterId INT NULL,
-    gene VARCHAR(50) NOT NULL,
-    eventType VARCHAR(50),
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `svDriver`;
+CREATE TABLE `svDriver`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `clusterId` INT NULL,
+    `gene` VARCHAR(50) NOT NULL,
+    `eventType` VARCHAR(50),
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX svDiver_sampleId_clusterId on svDriver (sampleId, clusterId);
-CREATE INDEX svDriver_clusterId on svDriver (clusterId);
+CREATE INDEX `svDiver_sampleId_clusterId` ON `svDriver` (`sampleId`, `clusterId`);
+CREATE INDEX `svDriver_clusterId` ON `svDriver` (`clusterId`);
 
-DROP TABLE IF EXISTS svBreakend;
-CREATE TABLE svBreakend
-(   id INT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    svId INT NOT NULL,
-    startBreakend TINYINT(1) NOT NULL,
-    gene VARCHAR(50) NOT NULL, -- # length here comes from ensembl db schema
-    transcriptId VARCHAR(128) NOT NULL, -- # length here comes from ensembl db schema
-    canonicalTranscript TINYINT(1) NOT NULL,
-    geneOrientation VARCHAR(20) NOT NULL,
-    disruptive TINYINT(1) NOT NULL,
-    reportedDisruption TINYINT(1) NOT NULL,
-    undisruptedCopyNumber DOUBLE PRECISION,
-    regionType VARCHAR(20) NOT NULL,
-    codingContext VARCHAR(20),
-    biotype VARCHAR(255),
-    exonicBasePhase TINYINT,
-    nextSpliceExonRank TINYINT UNSIGNED,
-    nextSpliceExonPhase TINYINT,
-    nextSpliceDistance INT,
-    totalExonCount SMALLINT NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `svBreakend`;
+CREATE TABLE `svBreakend`
+(   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `svId` INT NOT NULL,
+    `startBreakend` TINYINT(1) NOT NULL,
+    `gene` VARCHAR(50) NOT NULL, -- # length here comes from ensembl db schema
+    `transcriptId` VARCHAR(128) NOT NULL, -- # length here comes from ensembl db schema
+    `canonicalTranscript` TINYINT(1) NOT NULL,
+    `geneOrientation` VARCHAR(20) NOT NULL,
+    `disruptive` TINYINT(1) NOT NULL,
+    `reportedDisruption` TINYINT(1) NOT NULL,
+    `undisruptedCopyNumber` DOUBLE PRECISION,
+    `regionType` VARCHAR(20) NOT NULL,
+    `codingContext` VARCHAR(20),
+    `biotype` VARCHAR(255),
+    `exonicBasePhase` TINYINT,
+    `nextSpliceExonRank` TINYINT UNSIGNED,
+    `nextSpliceExonPhase` TINYINT,
+    `nextSpliceDistance` INT,
+    `totalExonCount` SMALLINT NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX svBreakend_sampleId_svId on svBreakend (sampleId, svId);
-CREATE INDEX svBreakend_gene on svBreakend (gene);
-CREATE INDEX svBreakend_transcriptId on svBreakend (transcriptId);
+CREATE INDEX `svBreakend_sampleId_svId` ON `svBreakend` (`sampleId`, `svId`);
+CREATE INDEX `svBreakend_gene` ON `svBreakend` (`gene`);
+CREATE INDEX `svBreakend_transcriptId` ON `svBreakend` (`transcriptId`);
 
-DROP TABLE IF EXISTS svFusion;
-CREATE TABLE svFusion
-(   id INT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    fivePrimeBreakendId INT UNSIGNED NOT NULL,
-    threePrimeBreakendId INT UNSIGNED NOT NULL,
-    name VARCHAR(50) NOT NULL,
-    reported TINYINT(1) NOT NULL,
-    reportedType varchar(50) NOT NULL,
-    phased VARCHAR(20) NOT NULL,
-    likelihood VARCHAR(10) NOT NULL,
-    chainLength INT,
-    chainLinks INT,
-    chainTerminated TINYINT(1),
-    domainsKept VARCHAR(255),
-    domainsLost VARCHAR(255),
-    skippedExonsUp INT,
-    skippedExonsDown INT,
-    fusedExonUp INT,
-    fusedExonDown INT,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `svFusion`;
+CREATE TABLE `svFusion`
+(   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `fivePrimeBreakendId` INT UNSIGNED NOT NULL,
+    `threePrimeBreakendId` INT UNSIGNED NOT NULL,
+    `name` VARCHAR(50) NOT NULL,
+    `reported` TINYINT(1) NOT NULL,
+    `reportedType` VARCHAR(50) NOT NULL,
+    `phased` VARCHAR(20) NOT NULL,
+    `likelihood` VARCHAR(10) NOT NULL,
+    `chainLength` INT,
+    `chainLinks` INT,
+    `chainTerminated` TINYINT(1),
+    `domainsKept` VARCHAR(255),
+    `domainsLost` VARCHAR(255),
+    `skippedExonsUp` INT,
+    `skippedExonsDown` INT,
+    `fusedExonUp` INT,
+    `fusedExonDown` INT,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX svFusion_fivePrimeBreakendId on svFusion (fivePrimeBreakendId);
-CREATE INDEX svFusion_threePrimeBreakendId on svFusion (threePrimeBreakendId);
-CREATE INDEX svFusion_sampleId on svFusion (sampleId);
+CREATE INDEX `svFusion_fivePrimeBreakendId` ON `svFusion` (`fivePrimeBreakendId`);
+CREATE INDEX `svFusion_threePrimeBreakendId` ON `svFusion` (`threePrimeBreakendId`);
+CREATE INDEX `svFusion_sampleId` ON `svFusion` (`sampleId`);
 
-DROP TABLE IF EXISTS structuralVariantGermline;
-CREATE TABLE structuralVariantGermline
-(   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    svId INT NOT NULL,
-    vcfId varchar(50),
-    chromosomeStart varchar(10) NOT NULL,
-    chromosomeEnd varchar(10),
-    positionStart int not null,
-    positionEnd int,
-    orientationStart tinyint not null,
-    orientationEnd tinyint,
-    type varchar(10) NOT NULL,
-    filter varchar(50) NOT NULL,
-    event varchar(50),
-    qualScore DOUBLE PRECISION,
-    homologySequenceStart varchar(255) not null,
-    homologySequenceEnd varchar(255),
-    junctionCopyNumber DOUBLE PRECISION,
-    adjustedAFStart DOUBLE PRECISION,
-    adjustedAFEnd DOUBLE PRECISION,
-    adjustedCopyNumberStart DOUBLE PRECISION,
-    adjustedCopyNumberEnd DOUBLE PRECISION,
-    adjustedCopyNumberChangeStart DOUBLE PRECISION,
-    adjustedCopyNumberChangeEnd DOUBLE PRECISION,
-    germlineFragments int,
-    germlineReferenceFragmentsStart int,
-    germlineReferenceFragmentsEnd int,
-    tumorFragments int,
-    tumorReferenceFragmentsStart int,
-    tumorReferenceFragmentsEnd int,
-    insertSequence varchar(2048) not null,
-    insertSequenceAlignments varchar(512),
-    insertSequenceRepeatClass varchar(64),
-    insertSequenceRepeatType varchar(64),
-    clusterId int null,
-    clusterCount int null,
-    resolvedType VARCHAR(20),
-    linkedByStart varchar(1024),
-    linkedByEnd varchar(1024),
-    cohortFrequency int not null,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `structuralVariantGermline`;
+CREATE TABLE `structuralVariantGermline`
+(   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `svId` INT NOT NULL,
+    `vcfId` VARCHAR(50),
+    `chromosomeStart` VARCHAR(10) NOT NULL,
+    `chromosomeEnd` VARCHAR(10),
+    `positionStart` INT NOT NULL,
+    `positionEnd` INT,
+    `orientationStart` TINYINT NOT NULL,
+    `orientationEnd` TINYINT,
+    `type` VARCHAR(10) NOT NULL,
+    `filter` VARCHAR(50) NOT NULL,
+    `event` VARCHAR(50),
+    `qualScore` DOUBLE PRECISION,
+    `homologySequenceStart` VARCHAR(255) NOT NULL,
+    `homologySequenceEnd` VARCHAR(255),
+    `junctionCopyNumber` DOUBLE PRECISION,
+    `adjustedAFStart` DOUBLE PRECISION,
+    `adjustedAFEnd` DOUBLE PRECISION,
+    `adjustedCopyNumberStart` DOUBLE PRECISION,
+    `adjustedCopyNumberEnd` DOUBLE PRECISION,
+    `adjustedCopyNumberChangeStart` DOUBLE PRECISION,
+    `adjustedCopyNumberChangeEnd` DOUBLE PRECISION,
+    `germlineFragments` INT,
+    `germlineReferenceFragmentsStart` INT,
+    `germlineReferenceFragmentsEnd` INT,
+    `tumorFragments` INT,
+    `tumorReferenceFragmentsStart` INT,
+    `tumorReferenceFragmentsEnd` INT,
+    `insertSequence` VARCHAR(2048) NOT NULL,
+    `insertSequenceAlignments` VARCHAR(512),
+    `insertSequenceRepeatClass` VARCHAR(64),
+    `insertSequenceRepeatType` VARCHAR(64),
+    `clusterId` INT NULL,
+    `clusterCount` INT NULL,
+    `resolvedType` VARCHAR(20),
+    `linkedByStart` VARCHAR(1024),
+    `linkedByEnd` VARCHAR(1024),
+    `cohortFrequency` INT NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX structuralVariantGermline_sampleId on structuralVariantGermline (sampleId);
+CREATE INDEX `structuralVariantGermline_sampleId` ON `structuralVariantGermline` (`sampleId`);
 
-DROP TABLE IF EXISTS svBreakendGermline;
-CREATE TABLE svBreakendGermline
-(   id INT UNSIGNED NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    svId INT NOT NULL,
-    startBreakend TINYINT(1) NOT NULL,
-    gene VARCHAR(50) NOT NULL, -- length here comes from ensembl db schema
-    transcriptId VARCHAR(128) NOT NULL, -- length here comes from ensembl db schema
-    canonicalTranscript TINYINT(1) NOT NULL,
-    geneOrientation VARCHAR(20) NOT NULL,
-    disruptive TINYINT(1) NOT NULL,
-    reportedDisruption TINYINT(1) NOT NULL,
-    undisruptedCopyNumber DOUBLE PRECISION,
-    regionType VARCHAR(20) NOT NULL,
-    codingType VARCHAR(20),
-    biotype VARCHAR(255),
-    exonicBasePhase TINYINT,
-    nextSpliceExonRank TINYINT UNSIGNED,
-    nextSpliceExonPhase TINYINT,
-    nextSpliceDistance INT,
-    totalExonCount SMALLINT NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `svBreakendGermline`;
+CREATE TABLE `svBreakendGermline`
+(   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `svId` INT NOT NULL,
+    `startBreakend` TINYINT(1) NOT NULL,
+    `gene` VARCHAR(50) NOT NULL, -- length here comes from ensembl db schema
+    `transcriptId` VARCHAR(128) NOT NULL, -- length here comes from ensembl db schema
+    `canonicalTranscript` TINYINT(1) NOT NULL,
+    `geneOrientation` VARCHAR(20) NOT NULL,
+    `disruptive` TINYINT(1) NOT NULL,
+    `reportedDisruption` TINYINT(1) NOT NULL,
+    `undisruptedCopyNumber` DOUBLE PRECISION,
+    `regionType` VARCHAR(20) NOT NULL,
+    `codingType` VARCHAR(20),
+    `biotype` VARCHAR(255),
+    `exonicBasePhase` TINYINT,
+    `nextSpliceExonRank` TINYINT UNSIGNED,
+    `nextSpliceExonPhase` TINYINT,
+    `nextSpliceDistance` INT,
+    `totalExonCount` SMALLINT NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX svBreakendGermline_sampleId_svId on svBreakendGermline (sampleId, svId);
-CREATE INDEX svBreakendGermline_gene on svBreakendGermline (gene);
-CREATE INDEX svBreakendGermline_transcriptId on svBreakendGermline (transcriptId);
+CREATE INDEX `svBreakendGermline_sampleId_svId` ON `svBreakendGermline` (`sampleId`, `svId`);
+CREATE INDEX `svBreakendGermline_gene` ON `svBreakendGermline` (`gene`);
+CREATE INDEX `svBreakendGermline_transcriptId` ON `svBreakendGermline` (`transcriptId`);
 
-DROP TABLE IF EXISTS signature;
-CREATE TABLE signature
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    signature VARCHAR(50) NOT NULL,
-    allocation DOUBLE PRECISION,
-    percent DOUBLE PRECISION,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `signature`;
+CREATE TABLE `signature`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `signature` VARCHAR(50) NOT NULL,
+    `allocation` DOUBLE PRECISION,
+    `percent` DOUBLE PRECISION,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX signature_sampleId on signature (sampleId);
+CREATE INDEX `signature_sampleId` ON `signature` (`sampleId`);
 
-DROP TABLE IF EXISTS chord;
-CREATE TABLE chord
-(   sampleId varchar(255) NOT NULL,
-    BRCA1 DOUBLE PRECISION NOT NULL,
-    BRCA2 DOUBLE PRECISION NOT NULL,
-    hrd DOUBLE PRECISION NOT NULL,
-    hrStatus varchar(255) NOT NULL,
-    hrdType varchar(255) NOT NULL,
-    remarksHrStatus varchar(255) NOT NULL,
-    remarksHrdType varchar(255) NOT NULL,
-    PRIMARY KEY (sampleId)
+DROP TABLE IF EXISTS `chord`;
+CREATE TABLE `chord`
+(   `sampleId` VARCHAR(255) NOT NULL,
+    `BRCA1` DOUBLE PRECISION NOT NULL,
+    `BRCA2` DOUBLE PRECISION NOT NULL,
+    `hrd` DOUBLE PRECISION NOT NULL,
+    `hrStatus` VARCHAR(255) NOT NULL,
+    `hrdType` VARCHAR(255) NOT NULL,
+    `remarksHrStatus` VARCHAR(255) NOT NULL,
+    `remarksHrdType` VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`sampleId`)
 );
 
-DROP TABLE IF EXISTS peachCalls;
-CREATE TABLE peachCalls
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(255) NOT NULL,
-    gene varchar(255) NOT NULL,
-    chromosome varchar(255) NOT NULL,
-    positionV37 varchar(255) NOT NULL,
-    positionV38 varchar(255) NOT NULL,
-    refV37 varchar(255) NOT NULL,
-    refV38 varchar(255) NOT NULL,
-    allele1 varchar(255) NOT NULL,
-    allele2 varchar(255) NOT NULL,
-    rsid varchar(255) NOT NULL,
-    variantAnnotationV37 varchar(255) NOT NULL,
-    filterV37 varchar(255) NOT NULL,
-    variantAnnotationV38 varchar(255) NOT NULL,
-    filterV38 varchar(255) NOT NULL,
-    panelVersion varchar(255) NOT NULL,
-    repoVersion varchar(255) NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `peachCalls`;
+CREATE TABLE `peachCalls`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `gene` VARCHAR(255) NOT NULL,
+    `chromosome` VARCHAR(255) NOT NULL,
+    `positionV37` VARCHAR(255) NOT NULL,
+    `positionV38` VARCHAR(255) NOT NULL,
+    `refV37` VARCHAR(255) NOT NULL,
+    `refV38` VARCHAR(255) NOT NULL,
+    `allele1` VARCHAR(255) NOT NULL,
+    `allele2` VARCHAR(255) NOT NULL,
+    `rsid` VARCHAR(255) NOT NULL,
+    `variantAnnotationV37` VARCHAR(255) NOT NULL,
+    `filterV37` VARCHAR(255) NOT NULL,
+    `variantAnnotationV38` VARCHAR(255) NOT NULL,
+    `filterV38` VARCHAR(255) NOT NULL,
+    `panelVersion` VARCHAR(255) NOT NULL,
+    `repoVersion` VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-DROP TABLE IF EXISTS peachGenotype;
-CREATE TABLE peachGenotype
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(255) NOT NULL,
-    gene varchar(255) NOT NULL,
-    haplotype varchar(255) NOT NULL,
-    `function` varchar(255) NOT NULL,
-    linkedDrugs varchar(255) NOT NULL,
-    urlPrescriptionInfo varchar(255) NOT NULL,
-    panelVersion varchar(255) NOT NULL,
-    repoVersion varchar(255) NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `peachGenotype`;
+CREATE TABLE `peachGenotype`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `gene` VARCHAR(255) NOT NULL,
+    `haplotype` VARCHAR(255) NOT NULL,
+    `function` VARCHAR(255) NOT NULL,
+    `linkedDrugs` VARCHAR(255) NOT NULL,
+    `urlPrescriptionInfo` VARCHAR(255) NOT NULL,
+    `panelVersion` VARCHAR(255) NOT NULL,
+    `repoVersion` VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-DROP TABLE IF EXISTS virusBreakend;
-CREATE TABLE virusBreakend
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(255) NOT NULL,
-    taxidGenus int NOT NULL,
-    nameGenus varchar(255) NOT NULL,
-    readsGenusTree int NOT NULL,
-    taxidSpecies int NOT NULL,
-    nameSpecies varchar(255) NOT NULL,
-    readsSpeciesTree int NOT NULL,
-    taxidAssigned int NOT NULL,
-    nameAssigned varchar(255) NOT NULL,
-    readsAssignedTree int NOT NULL,
-    readsAssignedDirect int NOT NULL,
-    reference varchar(255) NOT NULL,
-    referenceTaxid int NOT NULL,
-    referenceKmerCount int NOT NULL,
-    alternateKmerCount int NOT NULL,
-    RName varchar(255) NOT NULL,
-    startPos int NOT NULL,
-    endPos int NOT NULL,
-    numReads int NOT NULL,
-    covBases int NOT NULL,
-    coverage int NOT NULL,
-    meanDepth int NOT NULL,
-    meanBaseQ int NOT NULL,
-    meanMapQ int NOT NULL,
-    integrations int NOT NULL,
-    qcStatus varchar(255) NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `virusBreakend`;
+CREATE TABLE `virusBreakend`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `taxidGenus` INT NOT NULL,
+    `nameGenus` VARCHAR(255) NOT NULL,
+    `readsGenusTree` INT NOT NULL,
+    `taxidSpecies` INT NOT NULL,
+    `nameSpecies` VARCHAR(255) NOT NULL,
+    `readsSpeciesTree` INT NOT NULL,
+    `taxidAssigned` INT NOT NULL,
+    `nameAssigned` VARCHAR(255) NOT NULL,
+    `readsAssignedTree` INT NOT NULL,
+    `readsAssignedDirect` INT NOT NULL,
+    `reference` VARCHAR(255) NOT NULL,
+    `referenceTaxid` INT NOT NULL,
+    `referenceKmerCount` INT NOT NULL,
+    `alternateKmerCount` INT NOT NULL,
+    `RName` VARCHAR(255) NOT NULL,
+    `startPos` INT NOT NULL,
+    `endPos` INT NOT NULL,
+    `numReads` INT NOT NULL,
+    `covBases` INT NOT NULL,
+    `coverage` INT NOT NULL,
+    `meanDepth` INT NOT NULL,
+    `meanBaseQ` INT NOT NULL,
+    `meanMapQ` INT NOT NULL,
+    `integrations` INT NOT NULL,
+    `qcStatus` VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-DROP TABLE IF EXISTS virusAnnotation;
-CREATE TABLE virusAnnotation
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(255) NOT NULL,
-    taxid int NOT NULL,
-    virusName varchar(255) NOT NULL,
-    qcStatus varchar(255) NOT NULL,
-    integrations int NOT NULL,
-    interpretation varchar(255),
-    percentageCovered double NOT NULL,
-    meanCoverage double NOT NULL,
-    expectedClonalCoverage double,
-    reported TINYINT(1) NOT NULL,
-    likelihood VARCHAR(10) NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `virusAnnotation`;
+CREATE TABLE `virusAnnotation`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `taxid` INT NOT NULL,
+    `virusName` VARCHAR(255) NOT NULL,
+    `qcStatus` VARCHAR(255) NOT NULL,
+    `integrations` INT NOT NULL,
+    `interpretation` VARCHAR(255),
+    `percentageCovered` DOUBLE NOT NULL,
+    `meanCoverage` DOUBLE NOT NULL,
+    `expectedClonalCoverage` DOUBLE,
+    `reported` TINYINT(1) NOT NULL,
+    `likelihood` VARCHAR(10) NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-DROP TABLE IF EXISTS cuppa;
-CREATE TABLE cuppa
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(255) NOT NULL,
-    cuppaTumorLocation varchar(255) NOT NULL,
-    cuppaPrediction varchar(255),
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `cuppa`;
+CREATE TABLE `cuppa`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(255) NOT NULL,
+    `cuppaTumorLocation` VARCHAR(255) NOT NULL,
+    `cuppaPrediction` VARCHAR(255),
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX cuppa_sampleId on cuppa (sampleId);
+CREATE INDEX `cuppa_sampleId` ON `cuppa` (`sampleId`);
 
-DROP TABLE IF EXISTS rnaStatistics;
-CREATE TABLE rnaStatistics
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    qcStatus varchar(100) NOT NULL,
-    readLength int NOT NULL,
-    totalFragments int NOT NULL,
-    duplicates int NOT NULL,
-    splicedPercent DOUBLE PRECISION NOT NULL,
-    unsplicedPercent DOUBLE PRECISION NOT NULL,
-    alternateSplicePercent DOUBLE PRECISION NOT NULL,
-    chimericPercent DOUBLE PRECISION NOT NULL,
-    fragmentLengthPct05 DOUBLE PRECISION NOT NULL,
-    fragmentLengthPct50 DOUBLE PRECISION NOT NULL,
-    fragmentLengthPct95 DOUBLE PRECISION NOT NULL,
-    enrichedGenePercent DOUBLE PRECISION NOT NULL,
-    medianGCRatio DOUBLE PRECISION NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `rnaStatistics`;
+CREATE TABLE `rnaStatistics`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `qcStatus` VARCHAR(100) NOT NULL,
+    `readLength` INT NOT NULL,
+    `totalFragments` INT NOT NULL,
+    `duplicates` INT NOT NULL,
+    `splicedPercent` DOUBLE PRECISION NOT NULL,
+    `unsplicedPercent` DOUBLE PRECISION NOT NULL,
+    `alternateSplicePercent` DOUBLE PRECISION NOT NULL,
+    `chimericPercent` DOUBLE PRECISION NOT NULL,
+    `fragmentLengthPct05` DOUBLE PRECISION NOT NULL,
+    `fragmentLengthPct50` DOUBLE PRECISION NOT NULL,
+    `fragmentLengthPct95` DOUBLE PRECISION NOT NULL,
+    `enrichedGenePercent` DOUBLE PRECISION NOT NULL,
+    `medianGCRatio` DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX rnaStatistics_sampleId on rnaStatistics (sampleId);
+CREATE INDEX `rnaStatistics_sampleId` ON `rnaStatistics` (`sampleId`);
 
-DROP TABLE IF EXISTS geneExpression;
-CREATE TABLE geneExpression
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    gene VARCHAR(30) NOT NULL,
-    tpm DOUBLE PRECISION NOT NULL,
-    splicedFragments int NOT NULL,
-    unsplicedFragments int NOT NULL,
-    medianTpmCancer DOUBLE PRECISION NOT NULL,
-    percentileCancer DOUBLE PRECISION NOT NULL,
-    medianTpmCohort DOUBLE PRECISION NOT NULL,
-    percentileCohort DOUBLE PRECISION NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `geneExpression`;
+CREATE TABLE `geneExpression`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `gene` VARCHAR(30) NOT NULL,
+    `tpm` DOUBLE PRECISION NOT NULL,
+    `splicedFragments` INT NOT NULL,
+    `unsplicedFragments` INT NOT NULL,
+    `medianTpmCancer` DOUBLE PRECISION NOT NULL,
+    `percentileCancer` DOUBLE PRECISION NOT NULL,
+    `medianTpmCohort` DOUBLE PRECISION NOT NULL,
+    `percentileCohort` DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX geneExpression_sampleId_gene on geneExpression (sampleId, gene);
-CREATE INDEX geneExpression_gene on geneExpression (gene);
+CREATE INDEX `geneExpression_sampleId_gene` ON `geneExpression` (`sampleId`, `gene`);
+CREATE INDEX `geneExpression_gene` ON `geneExpression` (`gene`);
 
-DROP TABLE IF EXISTS novelSpliceJunction;
-CREATE TABLE novelSpliceJunction
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    gene VARCHAR(20) NOT NULL,
-    chromosome VARCHAR(10) NOT NULL,
-    junctionStart int NOT NULL,
-    junctionEnd int NOT NULL,
-    type VARCHAR(20) NOT NULL,
-    fragmentCount int NOT NULL,
-    depthStart int NOT NULL,
-    depthEnd int NOT NULL,
-    regionStart VARCHAR(20) NOT NULL,
-    regionEnd VARCHAR(20) NOT NULL,
-    basesStart VARCHAR(20) NOT NULL,
-    basesEnd VARCHAR(20) NOT NULL,
-    cohortFrequency int NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `novelSpliceJunction`;
+CREATE TABLE `novelSpliceJunction`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `gene` VARCHAR(20) NOT NULL,
+    `chromosome` VARCHAR(10) NOT NULL,
+    `junctionStart` INT NOT NULL,
+    `junctionEnd` INT NOT NULL,
+    `type` VARCHAR(20) NOT NULL,
+    `fragmentCount` INT NOT NULL,
+    `depthStart` INT NOT NULL,
+    `depthEnd` INT NOT NULL,
+    `regionStart` VARCHAR(20) NOT NULL,
+    `regionEnd` VARCHAR(20) NOT NULL,
+    `basesStart` VARCHAR(20) NOT NULL,
+    `basesEnd` VARCHAR(20) NOT NULL,
+    `cohortFrequency` INT NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX novelSpliceJunction_sampleId_gene on novelSpliceJunction (sampleId, gene);
-CREATE INDEX novelSpliceJunction_gene on novelSpliceJunction (gene);
+CREATE INDEX `novelSpliceJunction_sampleId_gene` ON `novelSpliceJunction` (`sampleId`, `gene`);
+CREATE INDEX `novelSpliceJunction_gene` ON `novelSpliceJunction` (`gene`);
 
-DROP TABLE IF EXISTS rnaFusion;
-CREATE TABLE rnaFusion
-(   id int NOT NULL AUTO_INCREMENT,
-    modified DATETIME NOT NULL,
-    sampleId varchar(50) NOT NULL,
-    name VARCHAR(50) NOT NULL,
-    chromosomeUp VARCHAR(10) NOT NULL,
-    chromosomeDown VARCHAR(10) NOT NULL,
-    positionUp int NOT NULL,
-    positionDown int NOT NULL,
-    orientationUp tinyint NOT NULL,
-    orientationDown tinyint NOT NULL,
-    junctionTypeUp VARCHAR(20) NOT NULL,
-    junctionTypeDown VARCHAR(20) NOT NULL,
-    svType VARCHAR(5) NOT NULL,
-    splitFragments int NOT NULL,
-    realignedFrags int NOT NULL,
-    discordantFrags int NOT NULL,
-    depthUp int NOT NULL,
-    depthDown int NOT NULL,
-    maxAnchorLengthUp int NOT NULL,
-    maxAnchorLengthDown int NOT NULL,
-    cohortFrequency int NOT NULL,
-    PRIMARY KEY (id)
+DROP TABLE IF EXISTS `rnaFusion`;
+CREATE TABLE `rnaFusion`
+(   `id` INT NOT NULL AUTO_INCREMENT,
+    `modified` DATETIME NOT NULL,
+    `sampleId` VARCHAR(50) NOT NULL,
+    `name` VARCHAR(50) NOT NULL,
+    `chromosomeUp` VARCHAR(10) NOT NULL,
+    `chromosomeDown` VARCHAR(10) NOT NULL,
+    `positionUp` INT NOT NULL,
+    `positionDown` INT NOT NULL,
+    `orientationUp` TINYINT NOT NULL,
+    `orientationDown` TINYINT NOT NULL,
+    `junctionTypeUp` VARCHAR(20) NOT NULL,
+    `junctionTypeDown` VARCHAR(20) NOT NULL,
+    `svType` VARCHAR(5) NOT NULL,
+    `splitFragments` INT NOT NULL,
+    `realignedFrags` INT NOT NULL,
+    `discordantFrags` INT NOT NULL,
+    `depthUp` INT NOT NULL,
+    `depthDown` INT NOT NULL,
+    `maxAnchorLengthUp` INT NOT NULL,
+    `maxAnchorLengthDown` INT NOT NULL,
+    `cohortFrequency` INT NOT NULL,
+    PRIMARY KEY (`id`)
 );
 
-CREATE INDEX rnaFusion_sampleId_name on rnaFusion (sampleId, name);
-CREATE INDEX rnaFusion_name on rnaFusion (name);
+CREATE INDEX `rnaFusion_sampleId_name` ON `rnaFusion` (`sampleId`, `name`);
+CREATE INDEX `rnaFusion_name` ON `rnaFusion` (`name`);

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <orange.version>2.7.1</orange.version>
         <orange-datamodel.version>1.3.1</orange-datamodel.version>
         <paddle.version>1.1</paddle.version>
-        <patient-db.version>5.33.1</patient-db.version>
+        <patient-db.version>5.33.2</patient-db.version>
         <pave.version>1.6</pave.version>
         <purple.version>4.0</purple.version>
         <sage.version>3.3.1</sage.version>


### PR DESCRIPTION
The camelCase table names are changed into upper case by jOOQ since that is the default of underlying H2 database implementation. Wrapping names in backticks avoids this.