### PR TITLE
ACTIN-324: add UGT1A1 status to front page of orange report

### DIFF
--- a/orange/README.md
+++ b/orange/README.md
@@ -213,6 +213,7 @@ investigate potential causes for QC failure.
 - Upcoming
     - Data is displayed in the report as "NA" in case of purple QC failure, in case the data by itself is not interpretable (e.g. TML)
     - The TMB status (high vs low) is displayed on the front page along with the actual TMB
+    - The status of UGT1A1 is displayed on the front page
 - [2.7.0](https://github.com/hartwigmedical/hmftools/releases/tag/orange-v2.7.0)
     - Supports panel tumor-only mode:
         - Omits Cuppa, Chord, Sigs and VirusBreakends

--- a/orange/src/main/java/com/hartwig/hmftools/orange/report/chapters/FrontPageChapter.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/report/chapters/FrontPageChapter.java
@@ -188,7 +188,8 @@ public class FrontPageChapter implements ReportChapter
         {
             addCellEntry(summary, cells, "HR deficiency score:", hrDeficiencyString());
 
-            addCellEntry(summary, cells, "DPYD status:", dpydStatus());
+            addCellEntry(summary, cells, "DPYD status:", geneStatus("DPYD"));
+            addCellEntry(summary, cells, "UGT1A1 status:", geneStatus("UGT1A1"));
 
             addCellEntry(summary, cells, "Number of SVs:", svTmbString());
             addCellEntry(summary, cells, "Max complex cluster size:", maxComplexSizeString());
@@ -489,7 +490,7 @@ public class FrontPageChapter implements ReportChapter
     }
 
     @NotNull
-    private String dpydStatus()
+    private String geneStatus(@NotNull String gene)
     {
         Set<PeachGenotype> genotypes = report.peach();
         if(genotypes == null)
@@ -500,7 +501,7 @@ public class FrontPageChapter implements ReportChapter
         Set<String> haplotypes = Sets.newHashSet();
         for(PeachGenotype genotype : genotypes)
         {
-            if(genotype.gene().equals("DPYD"))
+            if(genotype.gene().equals(gene))
             {
                 haplotypes.add(genotype.haplotype() + " (" + genotype.function() + ")");
             }


### PR DESCRIPTION
Small change, adds UGT1A1 directly under DPYD on front page of report in same format.

Testing manually with ReportGeneratorTestApplication, outputs "*1_HOM (Normal Function)" also for this gene.