### PR TITLE
Actin 333: orange-datamodel jdk17 support

### DIFF
--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/LocalDateAdapter.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/LocalDateAdapter.java
@@ -1,0 +1,73 @@
+package com.hartwig.hmftools.datamodel;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+public class LocalDateAdapter extends TypeAdapter<LocalDate>
+{
+
+    @Override
+    public void write(final JsonWriter jsonWriter, final LocalDate localDate) throws IOException
+    {
+        if(localDate == null)
+        {
+            jsonWriter.nullValue();
+            return;
+        }
+        jsonWriter.beginObject();
+        jsonWriter.name("year").value(localDate.getYear());
+        jsonWriter.name("month").value(localDate.getMonthValue());
+        jsonWriter.name("day").value(localDate.getDayOfMonth());
+        jsonWriter.endObject();
+        //        jsonWriter.value(localDate.toString());
+    }
+
+    @Override
+    public LocalDate read(final JsonReader jsonReader) throws IOException
+    {
+        if(jsonReader.peek() == JsonToken.NULL)
+        {
+            jsonReader.nextNull();
+            return null;
+        }
+
+        int year = -1;
+        int month = -1;
+        int day = -1;
+
+        jsonReader.beginObject();
+        while(jsonReader.hasNext())
+        {
+            String name = jsonReader.nextName();
+            if(name.equals("year"))
+            {
+                year = jsonReader.nextInt();
+            }
+            else if(name.equals("month"))
+            {
+                month = jsonReader.nextInt();
+            }
+            else if(name.equals("day"))
+            {
+                day = jsonReader.nextInt();
+            }
+            else
+            {
+                jsonReader.skipValue(); // Ignore unexpected fields
+            }
+        }
+        jsonReader.endObject();
+
+        if(year == -1 && month == -1 && day == -1)
+        {
+            throw new IllegalArgumentException("Invalid JSON format");
+        }
+
+        return LocalDate.of(year, month, day);
+    }
+}

--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/LocalDateAdapter.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/LocalDateAdapter.java
@@ -24,7 +24,6 @@ public class LocalDateAdapter extends TypeAdapter<LocalDate>
         jsonWriter.name("month").value(localDate.getMonthValue());
         jsonWriter.name("day").value(localDate.getDayOfMonth());
         jsonWriter.endObject();
-        //        jsonWriter.value(localDate.toString());
     }
 
     @Override

--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/OrangeJson.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/OrangeJson.java
@@ -6,6 +6,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
+import java.time.LocalDate;
 import java.util.ServiceLoader;
 
 import com.google.gson.Gson;
@@ -36,7 +37,9 @@ public class OrangeJson {
         for (TypeAdapterFactory factory : ServiceLoader.load(TypeAdapterFactory.class)) {
             gsonBuilder.registerTypeAdapterFactory(factory);
         }
-        gson = gsonBuilder.serializeNulls().serializeSpecialFloatingPointValues().create();
+        gson = gsonBuilder.serializeNulls().serializeSpecialFloatingPointValues()
+                .registerTypeAdapter(LocalDate.class, new LocalDateAdapter())
+                .create();
     }
 
     @NotNull

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <mark-dups.version>1.1</mark-dups.version>
         <neo.version>1.1</neo.version>
         <orange.version>2.8.0</orange.version>
-        <orange-datamodel.version>1.3.1</orange-datamodel.version>
+        <orange-datamodel.version>1.3.2</orange-datamodel.version>
         <paddle.version>1.1</paddle.version>
         <patient-db.version>5.33.2</patient-db.version>
         <pave.version>1.6</pave.version>


### PR DESCRIPTION
When using orange-datamodel in jdk17, reflection errors on LocalDate cause json serialization errors. This adds a type adapter to fix the problem. The json file itself maintains the same format:

```json
  "experimentDate": {
    "year": 2022,
    "month": 1,
    "day": 20
  },
```