### PR TITLE
prototype of adding a level of argument grouping to ConfigBuilder

### DIFF
--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/utils/config/ConfigGroup.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/utils/config/ConfigGroup.java
@@ -1,0 +1,39 @@
+package com.hartwig.hmftools.common.utils.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ConfigGroup
+{
+    private final String mName;
+    private final String mDescription;
+    private final List<ConfigItem> mItems;
+
+    public ConfigGroup(@NotNull final String name, @NotNull final String description)
+    {
+        mItems = new ArrayList<>();
+        mName = name;
+        mDescription = description;
+    }
+
+    public void addConfigItem(@NotNull final ConfigItem item)
+    {
+        mItems.add(item);
+    }
+
+    public void addConfigItem(
+            @NotNull final ConfigItemType type, @NotNull final String name, final boolean required, @NotNull final String description,
+            @Nullable final String defaultValue)
+    {
+        addConfigItem(new ConfigItem(type, name, required, description, defaultValue));
+    }
+
+    @NotNull
+    protected List<ConfigItem> getConfigItems()
+    {
+        return mItems;
+    }
+}

--- a/hmf-common/src/test/java/com/hartwig/hmftools/common/utils/ConfigBuilderTest.java
+++ b/hmf-common/src/test/java/com/hartwig/hmftools/common/utils/ConfigBuilderTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+import com.hartwig.hmftools.common.utils.config.ConfigGroup;
 
 import org.junit.Test;
 
@@ -87,4 +88,43 @@ public class ConfigBuilderTest
         assertFalse(configBuilder.parseCommandLine(args));
     }
 
+    @Test
+    public void TestConfigGroup()
+    {
+        ConfigBuilder configBuilder = new ConfigBuilder();
+
+        // shared arg
+        configBuilder.addConfigItem(STRING, "shared", true, "value for both groups", "item needed for both groups");
+
+        // group of args handled together
+        final ConfigGroup group1 = configBuilder.newConfigGroup("mode1", "group desc");
+        group1.addConfigItem(STRING, "item1", true, "item desc", "default");
+
+        // alternate group of args
+        final ConfigGroup group2 = configBuilder.newConfigGroup("mode2", "group desc");
+        group2.addConfigItem(STRING, "item2", true, "item desc", "default");
+
+        // valid args for mode1. when groups are specified, a valid group must
+        // be given as the first argument.
+        String[] args1 = {
+                "mode1",
+                "-shared",
+                "shared_value",
+                "-item1",
+                "val"
+        };
+
+        assertTrue(configBuilder.parseCommandLine(args1));
+
+        // valid args for mode2
+        String[] args2 = {
+                "mode2",
+                "-shared",
+                "shared_value",
+                "-item2",
+                "val"
+        };
+
+        assertTrue(configBuilder.parseCommandLine(args2));
+    }
 }


### PR DESCRIPTION
**Not for merging**

This is a small prototype of adding argument grouping into our CLI support, intended for design review. A simple implementation turned out to be straightforward to add.

For ACTIN-273, we want to disallow invalid combinations of arguments to orange, which is complicated by the different modes of operation (targeted vs whole-genome etc). Many CLI parsers support sub-commands, this example adds a very simple subcommand argument grouping mechanism to ConfigBuilder. 

The unit test gives an example. Subcommands are optional - current  ConfigBuilder users not affected. When subcommands are configured, each gets its own set of argument specifications, and global level arguments will be shared across all sub-commands. When configured, the first argument to the application must be a valid subcommand. Multiple sub-commands in a single invocation are not allowed.

Something like the following:

```bash
# run myapp in cmd1 mode that requires -arg1 and -arg2. 
$ myapp cmd1 -arg1 val1 -arg2 val2 -global_arg global_val
# run myapp with cmd2 that requires -arg3.
$ myapp cmd2 -arg3 val1 -global_arg global_val
```

Does this seem like enough flexibility to cover the needs of ACTIN-273, while pushing argument consistency verification into ConfigBuilder and not having a bunch of custom verification in the application code?

