### PR TITLE
ACTIN-353: Remove strand field from LinxBreakend ORANGE datamodel

### DIFF
--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/linx/LinxBreakend.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/linx/LinxBreakend.java
@@ -53,8 +53,6 @@ public interface LinxBreakend
 
     int orientation();
 
-    int strand();
-
     int exonUp();
 
     int exonDown();

--- a/orange-datamodel/src/test/java/com/hartwig/hmftools/datamodel/OrangeJsonTest.java
+++ b/orange-datamodel/src/test/java/com/hartwig/hmftools/datamodel/OrangeJsonTest.java
@@ -301,7 +301,6 @@ public class OrangeJsonTest
         assertEquals(2, breakend.exonDown());
         assertEquals("Upstream", breakend.geneOrientation());
         assertEquals(-1, breakend.orientation());
-        assertEquals(-1, breakend.strand());
         assertEquals(TranscriptRegionType.EXONIC, breakend.regionType());
         assertEquals(TranscriptCodingType.UTR_3P, breakend.codingType());
 

--- a/orange/src/main/java/com/hartwig/hmftools/orange/conversion/LinxConversion.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/conversion/LinxConversion.java
@@ -91,7 +91,6 @@ public final class LinxConversion
                 .codingType(TranscriptCodingType.valueOf(linxBreakend.codingType().name()))
                 .nextSpliceExonRank(linxBreakend.nextSpliceExonRank())
                 .orientation(linxBreakend.orientation())
-                .strand(linxBreakend.strand())
                 .exonUp(linxBreakend.exonUp())
                 .exonDown(linxBreakend.exonDown())
                 .junctionCopyNumber(linxBreakend.junctionCopyNumber())


### PR DESCRIPTION
Simple change, see ticket for rationale