### PR TITLE
INFRA-204 make program exit if maven build fails

### DIFF
--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -39,7 +39,7 @@ class Maven:
     @staticmethod
     def deploy_all(*modules):
         module_str = ','.join([m.name for m in modules])
-        subprocess.run(['mvn', 'deploy', '-B', '-pl', module_str, '-am', '-DdeployAtEnd=true'])
+        subprocess.run(['mvn', 'deploy', '-B', '-pl', module_str, '-am', '-DdeployAtEnd=true'], check=True)
 
 
 def extract_hmftools_dependencies(pom_path):


### PR DESCRIPTION
This should address the issue discovered in https://console.cloud.google.com/cloud-build/builds;region=europe-west4/c97c6129-b807-46df-852e-e42457b7d04d;step=0?project=hmf-build