### PR TITLE
INFRA-266 Improve patient-db loaders

### DIFF
--- a/patient-db/pom.xml
+++ b/patient-db/pom.xml
@@ -152,38 +152,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>shade</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>shade</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactSet>
-                                        <excludes>
-                                            <exclude>org.apache.lucene:*</exclude>
-                                        </excludes>
-                                    </artifactSet>
-                                    <relocations>
-                                        <relocation>
-                                            <pattern>com.google</pattern>
-                                            <shadedPattern>hmf.shaded.com.google</shadedPattern>
-                                        </relocation>
-                                    </relocations>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/CheckSampleAbsentFromDatabase.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/CheckSampleAbsentFromDatabase.java
@@ -16,10 +16,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
-public class CheckSampleExistsInDatabase
+public class CheckSampleAbsentFromDatabase
 {
 
-    private static final Logger LOGGER = LogManager.getLogger(CheckSampleExistsInDatabase.class);
+    private static final Logger LOGGER = LogManager.getLogger(CheckSampleAbsentFromDatabase.class);
 
     public static void main(@NotNull String[] args) throws ParseException, SQLException
     {
@@ -29,19 +29,19 @@ public class CheckSampleExistsInDatabase
 
         try(DatabaseAccess dbAccess = databaseAccess(cmd))
         {
-            if(dbAccess.readPurpleSampleList().contains(sample))
+            if(!dbAccess.readPurpleSampleList().contains(sample))
             {
-                LOGGER.info("Sample '{}' exists in the database", sample);
+                LOGGER.info("Sample '{}' is absent from the database", sample);
             }
             else
             {
-                LOGGER.info("Sample '{}' does not exist in the database", sample);
+                LOGGER.warn("Sample '{}' is not absent from the database", sample);
                 System.exit(2);
             }
         }
         catch(Exception e)
         {
-            LOGGER.error("Failed to check whether sample '{}' exists in database", sample, e);
+            LOGGER.error("Failed to check whether sample '{}' is absent from the database", sample, e);
             System.exit(1);
         }
     }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/CheckSampleExistsInDatabase.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/CheckSampleExistsInDatabase.java
@@ -1,0 +1,57 @@
+package com.hartwig.hmftools.patientdb;
+
+import static com.hartwig.hmftools.common.utils.config.CommonConfig.SAMPLE;
+import static com.hartwig.hmftools.patientdb.dao.DatabaseAccess.addDatabaseCmdLineArgs;
+import static com.hartwig.hmftools.patientdb.dao.DatabaseAccess.databaseAccess;
+
+import java.sql.SQLException;
+
+import com.hartwig.hmftools.patientdb.dao.DatabaseAccess;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+
+public class CheckSampleExistsInDatabase
+{
+
+    private static final Logger LOGGER = LogManager.getLogger(CheckSampleExistsInDatabase.class);
+
+    public static void main(@NotNull String[] args) throws ParseException, SQLException
+    {
+        Options options = createOptions();
+        CommandLine cmd = new DefaultParser().parse(options, args);
+        String sample = cmd.getOptionValue(SAMPLE);
+
+        try(DatabaseAccess dbAccess = databaseAccess(cmd))
+        {
+            if(dbAccess.readPurpleSampleList().contains(sample))
+            {
+                LOGGER.info("Sample '{}' exists in the database", sample);
+            }
+            else
+            {
+                LOGGER.info("Sample '{}' does not exist in the database", sample);
+                System.exit(2);
+            }
+        }
+        catch(Exception e)
+        {
+            LOGGER.error("Failed to delete sample", e);
+            System.exit(1);
+        }
+    }
+
+    @NotNull
+    private static Options createOptions()
+    {
+        Options options = new Options();
+        options.addOption(SAMPLE, true, "Tumor sample to check for in the database");
+        addDatabaseCmdLineArgs(options);
+        return options;
+    }
+}

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/CheckSampleExistsInDatabase.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/CheckSampleExistsInDatabase.java
@@ -41,7 +41,7 @@ public class CheckSampleExistsInDatabase
         }
         catch(Exception e)
         {
-            LOGGER.error("Failed to delete sample", e);
+            LOGGER.error("Failed to check whether sample '{}' exists in database", sample, e);
             System.exit(1);
         }
     }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/DeleteSampleFromDatabase.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/DeleteSampleFromDatabase.java
@@ -15,25 +15,35 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
-public class DeleteSampleFromDatabase {
+public class DeleteSampleFromDatabase
+{
 
     private static final Logger LOGGER = LogManager.getLogger(DeleteSampleFromDatabase.class);
 
     private static final String SAMPLE = "sample";
 
-    public static void main(@NotNull String[] args) throws ParseException, SQLException {
+    public static void main(@NotNull String[] args) throws ParseException, SQLException
+    {
         Options options = createOptions();
         CommandLine cmd = new DefaultParser().parse(options, args);
-        DatabaseAccess dbAccess = databaseAccess(cmd);
-        String sample = cmd.getOptionValue(SAMPLE);
+        try(DatabaseAccess dbAccess = databaseAccess(cmd))
+        {
+            String sample = cmd.getOptionValue(SAMPLE);
 
-        LOGGER.info("Removing sample '{}' from database", sample);
-        dbAccess.deletePipelineDataForSample(sample);
-        LOGGER.info("Complete");
+            LOGGER.info("Removing sample '{}' from database", sample);
+            dbAccess.deletePipelineDataForSample(sample);
+            LOGGER.info("Complete");
+        }
+        catch(Exception e)
+        {
+            LOGGER.error("Failed to delete sample", e);
+            System.exit(1);
+        }
     }
 
     @NotNull
-    private static Options createOptions() {
+    private static Options createOptions()
+    {
         Options options = new Options();
         options.addOption(SAMPLE, true, "Tumor sample to delete.");
         addDatabaseCmdLineArgs(options);

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/DeleteSampleFromDatabase.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/DeleteSampleFromDatabase.java
@@ -1,5 +1,6 @@
 package com.hartwig.hmftools.patientdb;
 
+import static com.hartwig.hmftools.common.utils.config.CommonConfig.SAMPLE;
 import static com.hartwig.hmftools.patientdb.dao.DatabaseAccess.addDatabaseCmdLineArgs;
 import static com.hartwig.hmftools.patientdb.dao.DatabaseAccess.databaseAccess;
 
@@ -19,8 +20,6 @@ public class DeleteSampleFromDatabase
 {
 
     private static final Logger LOGGER = LogManager.getLogger(DeleteSampleFromDatabase.class);
-
-    private static final String SAMPLE = "sample";
 
     public static void main(@NotNull String[] args) throws ParseException, SQLException
     {

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCanonicalTranscripts.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCanonicalTranscripts.java
@@ -31,17 +31,24 @@ public class LoadCanonicalTranscripts
     {
         Options options = createOptions();
         CommandLine cmd = new DefaultParser().parse(options, args);
-        DatabaseAccess dbAccess = databaseAccess(cmd);
 
-        logVersion();
+        try(DatabaseAccess dbAccess = databaseAccess(cmd))
+        {
+            logVersion();
 
-        final String ensemblRootDir = cmd.getOptionValue(ENSEMBL_DATA_CACHE_ROOT_DIR);
+            final String ensemblRootDir = cmd.getOptionValue(ENSEMBL_DATA_CACHE_ROOT_DIR);
 
-        LOGGER.info("Persisting transcripts to database");
-        loadCanonicalTranscripts(dbAccess, ensemblRootDir, RefGenomeVersion.V37);
-        loadCanonicalTranscripts(dbAccess, ensemblRootDir, RefGenomeVersion.V38);
+            LOGGER.info("Persisting transcripts to database");
+            loadCanonicalTranscripts(dbAccess, ensemblRootDir, RefGenomeVersion.V37);
+            loadCanonicalTranscripts(dbAccess, ensemblRootDir, RefGenomeVersion.V38);
 
-        LOGGER.info("Complete");
+            LOGGER.info("Complete");
+        }
+        catch(Exception e)
+        {
+            LOGGER.error("Failed to load canonical transcripts", e);
+            System.exit(1);
+        }
     }
 
     private static void loadCanonicalTranscripts(final DatabaseAccess dbAccess, final String ensemblRootDir, final RefGenomeVersion refGenomeVersion)

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadChordData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadChordData.java
@@ -37,31 +37,40 @@ public class LoadChordData
 
         if(CommonUtils.anyNull(predictionFile, sample))
         {
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp("Patient-DB - Load Chord Data", options);
-            System.exit(1);
+            exitWithHelp(options);
         }
 
         File fileObject = new File(predictionFile);
         if(fileObject.isFile())
         {
-            DatabaseAccess dbWriter = databaseAccess(cmd);
+            try (DatabaseAccess dbWriter = databaseAccess(cmd))
+            {
+                LOGGER.info("Extracting and writing chord for {}", predictionFile);
+                ChordData chordData = ChordDataFile.read(predictionFile);
+                dbWriter.writeChord(sample, chordData);
 
-            LOGGER.info("Extracting and writing chord for {}", predictionFile);
-            ChordData chordData = ChordDataFile.read(predictionFile);
-            dbWriter.writeChord(sample, chordData);
-
-            LOGGER.info("Complete");
+                LOGGER.info("Complete");
+            }
+            catch (Exception e)
+            {
+                LOGGER.error("Failed to load Chord data", e);
+                System.exit(1);
+            }
         }
         else
         {
             if(!fileObject.exists())
             {
-                LOGGER.warn("file '{}' does not exist.", predictionFile);
+                LOGGER.warn("File '{}' does not exist.", predictionFile);
             }
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp("patient-db - load chord data", options);
+            exitWithHelp(options);
         }
+    }
+
+    private static void exitWithHelp(Options options) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("Patient-DB - Load Chord Data", options);
+        System.exit(1);
     }
 
     @NotNull

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCiderData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCiderData.java
@@ -67,8 +67,7 @@ public class LoadCiderData
         }
         catch(Exception e)
         {
-            LOGGER.error("failed to load Cider data: {}", e.toString());
-            e.printStackTrace();
+            LOGGER.error("Failed to load Cider data", e);
             System.exit(1);
         }
     }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCuppa2.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCuppa2.java
@@ -1,5 +1,6 @@
 package com.hartwig.hmftools.patientdb;
 
+import static com.hartwig.hmftools.common.utils.config.CommonConfig.SAMPLE;
 import static com.hartwig.hmftools.patientdb.CommonUtils.LOGGER;
 import static com.hartwig.hmftools.patientdb.CommonUtils.logVersion;
 import static com.hartwig.hmftools.patientdb.dao.DatabaseAccess.addDatabaseCmdLineArgs;
@@ -25,6 +26,7 @@ public class LoadCuppa2
         Options options = new Options();
 
         options.addOption(CUPPA_VIS_DATA_TSV, true, "Path to the CUPPA vis data file");
+        options.addOption(SAMPLE, true, "Sample for which we are going to load the CUPPA results");
 
         addDatabaseCmdLineArgs(options);
 
@@ -50,7 +52,7 @@ public class LoadCuppa2
         {
             LOGGER.info("Loading CUPPA from {}", new File(cuppaVisDataTsv).getParent());
             CuppaPredictions cuppaPredictions = CuppaPredictions.fromTsv(cuppaVisDataTsv);
-            String sample = cuppaPredictions.get(0).SampleId;
+            String sample = cmd.getOptionValue(SAMPLE);
             LOGGER.info("Loaded {} entries from {} for sample {}", cuppaPredictions.size(), cuppaVisDataTsv, sample);
 
             int TOP_N_PROBS = 3;

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCuppa2.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadCuppa2.java
@@ -46,15 +46,26 @@ public class LoadCuppa2
 
         logVersion();
 
-        LOGGER.info("Loading CUPPA from {}", new File(cuppaVisDataTsv).getParent());
-        CuppaPredictions cuppaPredictions = CuppaPredictions.fromTsv(cuppaVisDataTsv);
-        String sample = cuppaPredictions.get(0).SampleId;
-        LOGGER.info("Loaded {} entries from {} for sample {}", cuppaPredictions.size(), cuppaVisDataTsv, sample);
+        try
+        {
+            LOGGER.info("Loading CUPPA from {}", new File(cuppaVisDataTsv).getParent());
+            CuppaPredictions cuppaPredictions = CuppaPredictions.fromTsv(cuppaVisDataTsv);
+            String sample = cuppaPredictions.get(0).SampleId;
+            LOGGER.info("Loaded {} entries from {} for sample {}", cuppaPredictions.size(), cuppaVisDataTsv, sample);
 
-        int TOP_N_PROBS = 3;
-        LOGGER.info("Writing top {} probabilities from all classifiers to database", TOP_N_PROBS);
-        DatabaseAccess dbWriter = databaseAccess(cmd);
-        dbWriter.writeCuppa2(sample, cuppaPredictions, TOP_N_PROBS);
-        LOGGER.info("Complete");
+            int TOP_N_PROBS = 3;
+            LOGGER.info("Writing top {} probabilities from all classifiers to database", TOP_N_PROBS);
+
+            try (DatabaseAccess dbWriter = databaseAccess(cmd))
+            {
+                dbWriter.writeCuppa2(sample, cuppaPredictions, TOP_N_PROBS);
+                LOGGER.info("Complete");
+            }
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Failed to load CUPPA data", e);
+            System.exit(1);
+        }
     }
 }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadDriverGenePanel.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadDriverGenePanel.java
@@ -4,7 +4,6 @@ import static com.hartwig.hmftools.common.drivercatalog.panel.DriverGenePanelCon
 import static com.hartwig.hmftools.common.drivercatalog.panel.DriverGenePanelConfig.DRIVER_GENE_PANEL_OPTION_DESC;
 import static com.hartwig.hmftools.patientdb.CommonUtils.APP_NAME;
 import static com.hartwig.hmftools.patientdb.CommonUtils.LOGGER;
-import static com.hartwig.hmftools.patientdb.CommonUtils.logVersion;
 import static com.hartwig.hmftools.patientdb.dao.DatabaseAccess.databaseAccess;
 
 import java.io.IOException;
@@ -34,8 +33,15 @@ public class LoadDriverGenePanel
 
         LOGGER.info("Loading {} driver genes to database", driverGenes.size());
 
-        DatabaseAccess dbAccess = databaseAccess(configBuilder, true);
-        dbAccess.writeGenePanel(driverGenes);
-        LOGGER.info("Complete");
+        try (DatabaseAccess dbAccess = databaseAccess(configBuilder, true))
+        {
+            dbAccess.writeGenePanel(driverGenes);
+            LOGGER.info("Complete");
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Failed to load driver genes", e);
+            System.exit(1);
+        }
     }
 }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadFlagstatData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadFlagstatData.java
@@ -43,18 +43,24 @@ public class LoadFlagstatData
             System.exit(1);
         }
 
-        DatabaseAccess dbWriter = databaseAccess(cmd);
+        try (DatabaseAccess dbWriter = databaseAccess(cmd))
+        {
+            LOGGER.info("Extracting and writing flagstats for {}", sample);
 
-        LOGGER.info("Extracting and writing flagstats for {}", sample);
+            Flagstat refFlagstat = FlagstatFile.read(refFlagstatFile);
+            LOGGER.info(" Read reference sample flagstats from {}", refFlagstatFile);
+            Flagstat tumorFlagstat = FlagstatFile.read(tumorFlagstatFile);
+            LOGGER.info(" Read tumor sample flagstats from {}", tumorFlagstatFile);
 
-        Flagstat refFlagstat = FlagstatFile.read(refFlagstatFile);
-        LOGGER.info(" Read reference sample flagstats from {}", refFlagstatFile);
-        Flagstat tumorFlagstat = FlagstatFile.read(tumorFlagstatFile);
-        LOGGER.info(" Read tumor sample flagstats from {}", tumorFlagstatFile);
+            dbWriter.writeFlagstats(sample, refFlagstat, tumorFlagstat);
 
-        dbWriter.writeFlagstats(sample, refFlagstat, tumorFlagstat);
-
-        LOGGER.info("Complete");
+            LOGGER.info("Complete");
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Failed to load flagstats", e);
+            System.exit(1);
+        }
     }
 
     @NotNull

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadPeachData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadPeachData.java
@@ -47,20 +47,26 @@ public class LoadPeachData
             System.exit(1);
         }
 
-        DatabaseAccess dbWriter = databaseAccess(cmd);
+        try (DatabaseAccess dbWriter = databaseAccess(cmd))
+        {
+            LOGGER.info("Reading PEACH genotypes from {}", peachGenotypeTxt);
+            List<PeachGenotype> peachGenotype = PeachGenotypeFile.read(peachGenotypeTxt);
+            LOGGER.info(" Read {} PEACH genotypes", peachGenotype.size());
 
-        LOGGER.info("Reading PEACH genotypes from {}", peachGenotypeTxt);
-        List<PeachGenotype> peachGenotype = PeachGenotypeFile.read(peachGenotypeTxt);
-        LOGGER.info(" Read {} PEACH genotypes", peachGenotype.size());
+            LOGGER.info("Reading PEACH calls from {}", peachCallsTxt);
+            List<PeachCalls> peachCalls = PeachCallsFile.read(peachCallsTxt);
+            LOGGER.info(" Read {} PEACH calls", peachCalls.size());
 
-        LOGGER.info("Reading PEACH calls from {}", peachCallsTxt);
-        List<PeachCalls> peachCalls = PeachCallsFile.read(peachCallsTxt);
-        LOGGER.info(" Read {} PEACH calls", peachCalls.size());
+            LOGGER.info("Writing PEACH into database for {}", sample);
+            dbWriter.writePeach(sample, peachGenotype, peachCalls);
 
-        LOGGER.info("Writing PEACH into database for {}", sample);
-        dbWriter.writePeach(sample, peachGenotype, peachCalls);
-
-        LOGGER.info("Complete");
+            LOGGER.info("Complete");
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Failed to load PEACH data", e);
+            System.exit(1);
+        }
     }
 
     @NotNull

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadPurpleData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadPurpleData.java
@@ -10,7 +10,6 @@ import static com.hartwig.hmftools.common.utils.config.CommonConfig.REFERENCE;
 import static com.hartwig.hmftools.common.utils.config.CommonConfig.REFERENCE_DESC;
 import static com.hartwig.hmftools.common.utils.config.CommonConfig.SAMPLE;
 import static com.hartwig.hmftools.common.utils.config.CommonConfig.SAMPLE_DESC;
-import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
 import static com.hartwig.hmftools.common.utils.config.ConfigUtils.setLogLevel;
 import static com.hartwig.hmftools.patientdb.CommonUtils.LOGGER;
 import static com.hartwig.hmftools.patientdb.CommonUtils.logVersion;
@@ -77,11 +76,8 @@ public class LoadPurpleData
         setLogLevel(configBuilder);
         logVersion();
 
-        try
+        try(DatabaseAccess dbAccess = databaseAccess(configBuilder))
         {
-
-            DatabaseAccess dbAccess = databaseAccess(configBuilder);
-
             String sampleId = configBuilder.getValue(SAMPLE);
             String referenceId = configBuilder.getValue(REFERENCE);
             String rnaId = configBuilder.getValue(RNA_SAMPLE);
@@ -128,8 +124,7 @@ public class LoadPurpleData
         }
         catch(Exception e)
         {
-            LOGGER.error("failed to load Purple data: {}", e.toString());
-            e.printStackTrace();
+            LOGGER.error("Failed to load Purple data", e);
             System.exit(1);
         }
     }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadSignatures.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadSignatures.java
@@ -27,22 +27,29 @@ public class LoadSignatures
     {
         Options options = createOptions();
         CommandLine cmd = new DefaultParser().parse(options, args);
-        DatabaseAccess dbAccess = createDatabaseAccess(cmd);
 
         logVersion();
 
-        if(dbAccess == null) {
+        try (DatabaseAccess dbAccess = createDatabaseAccess(cmd))
+        {
+            if(dbAccess == null)
+            {
+                LOGGER.error("Failed to create DB connection");
+                System.exit(1);
+            }
 
-            LOGGER.error("Failed to create DB connection");
+            String sampleId = cmd.getOptionValue(SAMPLE);
+            String sampleDir = cmd.getOptionValue(SAMPLE_DIR);
+
+            loadSignatureData(dbAccess, sampleId, sampleDir);
+
+            LOGGER.info("signature allocation loading complete");
+        }
+        catch(Exception e)
+        {
+            LOGGER.error("Failed to load signature allocations", e);
             System.exit(1);
         }
-
-        String sampleId = cmd.getOptionValue(SAMPLE);
-        String sampleDir = cmd.getOptionValue(SAMPLE_DIR);
-
-        loadSignatureData(dbAccess, sampleId, sampleDir);
-
-        LOGGER.info("signature allocation loading complete");
     }
 
     private static void loadSignatureData(final DatabaseAccess dbAccess, final String sampleId, final String sampleDir)

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadTealData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadTealData.java
@@ -65,8 +65,7 @@ public class LoadTealData
         }
         catch(Exception e)
         {
-            LOGGER.error("failed to load Teal data: {}", e.toString());
-            e.printStackTrace();
+            LOGGER.error("Failed to load Teal data", e);
             System.exit(1);
         }
     }

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadVirusBreakendData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadVirusBreakendData.java
@@ -42,16 +42,22 @@ public class LoadVirusBreakendData
             System.exit(1);
         }
 
-        DatabaseAccess dbWriter = databaseAccess(cmd);
+        try (DatabaseAccess dbWriter = databaseAccess(cmd))
+        {
+            LOGGER.info("Reading virus breakend TSV {}", virusBreakendTsv);
+            List<VirusBreakend> virusBreakends = VirusBreakendFile.read(virusBreakendTsv);
+            LOGGER.info(" Read {} virus breakends", virusBreakends.size());
 
-        LOGGER.info("Reading virus breakend TSV {}", virusBreakendTsv);
-        List<VirusBreakend> virusBreakends = VirusBreakendFile.read(virusBreakendTsv);
-        LOGGER.info(" Read {} virus breakends", virusBreakends.size());
+            LOGGER.info("Writing virus breakends into database for {}", sample);
+            dbWriter.writeVirusBreakend(sample, virusBreakends);
 
-        LOGGER.info("Writing virus breakends into database for {}", sample);
-        dbWriter.writeVirusBreakend(sample, virusBreakends);
-
-        LOGGER.info("Complete");
+            LOGGER.info("Complete");
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Failed to load virus breakends", e);
+            System.exit(1);
+        }
     }
 
     @NotNull

--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadVirusInterpreter.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/LoadVirusInterpreter.java
@@ -42,16 +42,22 @@ public class LoadVirusInterpreter
             System.exit(1);
         }
 
-        DatabaseAccess dbWriter = databaseAccess(cmd);
+        try (DatabaseAccess dbWriter = databaseAccess(cmd))
+        {
+            LOGGER.info("Reading virus annotation TSV {}", virusAnnotationTsv);
+            List<AnnotatedVirus> virusAnnotations = AnnotatedVirusFile.read(virusAnnotationTsv);
+            LOGGER.info(" Read {} virus annotation", virusAnnotations.size());
 
-        LOGGER.info("Reading virus annotation TSV {}", virusAnnotationTsv);
-        List<AnnotatedVirus> virusAnnotations = AnnotatedVirusFile.read(virusAnnotationTsv);
-        LOGGER.info(" Read {} virus annotation", virusAnnotations.size());
+            LOGGER.info("Writing virus annotations into database for {}", sample);
+            dbWriter.writeVirusInterpreter(sample, virusAnnotations);
 
-        LOGGER.info("Writing virus annotations into database for {}", sample);
-        dbWriter.writeVirusInterpreter(sample, virusAnnotations);
-
-        LOGGER.info("Complete");
+            LOGGER.info("Complete");
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Failed to load virus annotations", e);
+            System.exit(1);
+        }
     }
 
     @NotNull


### PR DESCRIPTION
Several small improvements and additions to patient-db that make it possible to run the loader classes as separate processes in an automated way:
* Let all loaders return exit code `1` on failure.
* Let all loaders use try-with-resources to close the database connection on failure.
* Add class `CheckSampleExistsInDatabase`, which is used by automation to check whether a sample already exists.
* Add a `-sample` parameter to `LoadCuppa2`. Using the TSV header doesn't work since that's often just "sample_1" instead of the real sample ID.

Also removed the "shade" profile, which is no longer needed when the `patient-db.jar` is run as a separate process.