### PR TITLE
DEV-3766: Fix germline MVLH table in PDF

### DIFF
--- a/orange/README.md
+++ b/orange/README.md
@@ -233,6 +233,8 @@ investigate potential causes for QC failure.
 
 - Upcoming
     - Clonal likelihood is set to 0 to 1 based on variant copy number when converting germline variants to somatic
+    - Bugfix: Fix bug in germline MVLH parsing that caused them to be underestimated by a factor 100.
+    - Restrict germline MVLH table on PDF and related field in JSON to genes handled by SAGE germline.  
 - [3.2.0](https://github.com/hartwigmedical/hmftools/releases/tag/orange-v3.2.0)
     - Support new ORANGE-datamodel (v2.3.0).
     - Support germline deletions heterozygous in the tumor:

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/sage/GermlineMVLHFactory.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/sage/GermlineMVLHFactory.java
@@ -1,0 +1,80 @@
+package com.hartwig.hmftools.orange.algo.sage;
+
+import static com.hartwig.hmftools.common.utils.file.FileDelimiters.TSV_DELIM;
+import static com.hartwig.hmftools.common.utils.file.FileReaderUtils.createFieldsIndexMap;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.hartwig.hmftools.common.drivercatalog.panel.DriverGene;
+import com.hartwig.hmftools.common.sage.GeneDepthFile;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class GermlineMVLHFactory
+{
+    @NotNull
+    public static Map<String, Double> loadGermlineMVLHPerGene(@NotNull String sageGermlineGeneCoverageTsv,
+            @NotNull List<DriverGene> driverGenes) throws IOException
+    {
+        List<String> lines = Files.readAllLines(new File(sageGermlineGeneCoverageTsv).toPath());
+        return parseMVLHPerGene(lines, driverGenes);
+    }
+
+    @NotNull
+    @VisibleForTesting
+    static Map<String, Double> parseMVLHPerGene(@NotNull List<String> lines, @NotNull List<DriverGene> driverGenes)
+    {
+        String header = lines.get(0);
+
+        Map<String, Integer> fieldsIndexMap = createFieldsIndexMap(header, TSV_DELIM);
+        int geneIndex = fieldsIndexMap.get(GeneDepthFile.COL_GENE);
+        int mvlhIndex = fieldsIndexMap.get(GeneDepthFile.COL_MV_LIKELIHOOD);
+
+        Map<String, Double> mvlhPerGene = Maps.newTreeMap();
+        for(String line : lines.subList(1, lines.size()))
+        {
+            String[] values = line.split(TSV_DELIM);
+            String gene = values[geneIndex];
+            double mvlh = Double.parseDouble(values[mvlhIndex]);
+
+            DriverGene matchingDriverGene = findMatchingDriverGene(gene, driverGenes);
+            if(matchingDriverGene != null && hasReliableMVLH(matchingDriverGene))
+            {
+                mvlhPerGene.put(gene, mvlh);
+            }
+        }
+        return mvlhPerGene;
+    }
+
+    @Nullable
+    private static DriverGene findMatchingDriverGene(@NotNull String geneName, @NotNull List<DriverGene> driverGenes)
+    {
+        List<DriverGene> matchingDriverGenes = driverGenes.stream().filter(d -> d.gene().equals(geneName)).collect(Collectors.toList());
+        if(matchingDriverGenes.size() == 1)
+        {
+            return matchingDriverGenes.get(0);
+        }
+        else if(matchingDriverGenes.isEmpty())
+        {
+            return null;
+        }
+        else
+        {
+            throw new IllegalStateException("More than one driver gene found with name " + geneName);
+        }
+    }
+
+    private static boolean hasReliableMVLH(@NotNull DriverGene driverGene)
+    {
+        // Note: fix this when SAGE germline starts running genome wide
+        return driverGene.reportSomatic() || driverGene.reportGermline() || driverGene.reportPGX();
+    }
+}

--- a/orange/src/main/java/com/hartwig/hmftools/orange/report/tables/GermlineLossOfHeterozygosityTable.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/report/tables/GermlineLossOfHeterozygosityTable.java
@@ -23,11 +23,6 @@ import org.jetbrains.annotations.Nullable;
 
 public final class GermlineLossOfHeterozygosityTable
 {
-
-    private GermlineLossOfHeterozygosityTable()
-    {
-    }
-
     @NotNull
     public static Table build(@NotNull String title, float width, @NotNull List<PurpleLossOfHeterozygosity> lossOfHeterozygosities,
             @Nullable IsofoxRecord isofox, @NotNull ReportResources reportResources)

--- a/orange/src/main/java/com/hartwig/hmftools/orange/report/tables/MissedVariantLikelihoodTable.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/report/tables/MissedVariantLikelihoodTable.java
@@ -1,0 +1,60 @@
+package com.hartwig.hmftools.orange.report.tables;
+
+import static com.hartwig.hmftools.orange.report.ReportResources.formatPercentageOneDecimal;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.hartwig.hmftools.orange.report.ReportResources;
+import com.hartwig.hmftools.orange.report.util.Cells;
+import com.hartwig.hmftools.orange.report.util.Tables;
+import com.itextpdf.layout.element.Cell;
+import com.itextpdf.layout.element.Table;
+
+import org.apache.logging.log4j.util.Strings;
+import org.jetbrains.annotations.NotNull;
+
+public final class MissedVariantLikelihoodTable
+{
+    @NotNull
+    public static Table build(@NotNull String title, float width, @NotNull Map<String, Double> significantGermlineMVLHPerGene,
+            @NotNull ReportResources reportResources)
+    {
+        if(significantGermlineMVLHPerGene.isEmpty())
+        {
+            return new Tables(reportResources).createEmpty(title, width);
+        }
+
+        Cells cells = new Cells(reportResources);
+        Table table = Tables.createContent(width,
+                new float[] { 2, 2, 1, 2, 2, 1, 2, 2, 1, 2, 2, 1 },
+                new Cell[] { cells.createHeader("Gene"), cells.createHeader("MVLH"), cells.createHeader(Strings.EMPTY),
+                        cells.createHeader("Gene"), cells.createHeader("MVLH"), cells.createHeader(Strings.EMPTY),
+                        cells.createHeader("Gene"), cells.createHeader("MVLH"), cells.createHeader(Strings.EMPTY),
+                        cells.createHeader("Gene"), cells.createHeader("MVLH"), cells.createHeader(Strings.EMPTY) });
+
+        Set<String> genes = Sets.newTreeSet(Comparator.naturalOrder());
+        genes.addAll(significantGermlineMVLHPerGene.keySet());
+        for(String gene : genes)
+        {
+            double mvlh = significantGermlineMVLHPerGene.get(gene);
+            table.addCell(cells.createContent(gene));
+            table.addCell(cells.createContent(formatPercentageOneDecimal(mvlh)));
+            table.addCell(cells.createContent(Strings.EMPTY));
+        }
+
+        // Make sure all rows are properly filled in case table is sparse.
+        int entryCount = significantGermlineMVLHPerGene.size();
+        if(entryCount % 4 != 0)
+        {
+            for(int i = 0; i < 12 - 3 * (entryCount % 4); i++)
+            {
+                table.addCell(cells.createContent(Strings.EMPTY));
+            }
+        }
+
+        return new Tables(reportResources).createWrapping(table, title);
+    }
+}

--- a/orange/src/test/java/com/hartwig/hmftools/orange/algo/OrangeAlgoTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/algo/OrangeAlgoTest.java
@@ -1,9 +1,21 @@
 package com.hartwig.hmftools.orange.algo;
 
+import static org.apache.commons.math3.util.Precision.EPSILON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import com.hartwig.hmftools.common.drivercatalog.DriverCategory;
+import com.hartwig.hmftools.common.drivercatalog.panel.DriverGene;
+import com.hartwig.hmftools.common.drivercatalog.panel.DriverGeneGermlineReporting;
+import com.hartwig.hmftools.common.drivercatalog.panel.ImmutableDriverGene;
+import com.hartwig.hmftools.datamodel.orange.OrangeRecord;
+import com.hartwig.hmftools.orange.ImmutableOrangeConfig;
 import com.hartwig.hmftools.orange.OrangeConfig;
 import com.hartwig.hmftools.orange.TestOrangeConfigFactory;
 
@@ -55,6 +67,59 @@ public class OrangeAlgoTest
         OrangeAlgo algo = createOrangeAlgo(config);
 
         assertNotNull(algo.run(config));
+    }
+
+    @Test
+    public void parseGermlineMVLHCorrectly()
+    {
+        String reliableMVLHGene = "FAKE1";
+        String unReliableMVLHGene = "FAKE2";
+
+        List<String> lines = List.of(
+                "gene\tchromosome\tposStart\tposEnd\tmissedVariantLikelihood\tDR_0\tDR_1\tDR_2\tDR_3\tDR_4\tDR_5\tDR_6\tDR_7\tDR_8\tDR_9\tDR_10\tDR_11\tDR_12\tDR_13\tDR_14\tDR_15\tDR_16\tDR_17\tDR_18\tDR_19\tDR_20\tDR_21\tDR_22\tDR_23\tDR_24\tDR_25\tDR_26\tDR_27\tDR_28\tDR_29\tDR_30_39\tDR_40_49\tDR_50_59\tDR_60_69\tDR_70_79\tDR_80_89\tDR_90_99\tDR_100_149\tDR_150_199\tDR_200_249\tDR_250_299\tDR_300_349\tDR_350_399\tDR_400_449\tDR_450_499\tDR_500_599\tDR_600_699\tDR_700_799\tDR_800_899\tDR_900_999\tDR_1000_1099\tDR_1100_1199\tDR_1200_1299\tDR_1300_1399\tDR_1400_1499\tDR_1500_1599\tDR_1600_1699\tDR_1700_1799\tDR_1800_1899\tDR_1900_1999\tDR_2000_2999\tDR_3000_3999\tDR_4000_4999\tDR_5000_5999\tDR_6000_6999\tDR_7000_7999\tDR_8000_8999\tDR_9000_9999\tDR_10000",
+                reliableMVLHGene + "\t7\t87133559\t87229500\t0.0002\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t9\t41\t35\t48\t41\t85\t76\t132\t132\t162\t222\t237\t2689\t454\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0",
+                unReliableMVLHGene +"\t1\t120436587\t120438959\t1.0000\t2373\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"
+        );
+
+        DriverGene driverGene1 = ImmutableDriverGene.builder()
+                .gene(reliableMVLHGene)
+                .reportMissenseAndInframe(true)
+                .reportNonsenseAndFrameshift(true)
+                .reportSplice(true)
+                .reportDeletion(true)
+                .reportDisruption(true)
+                .reportAmplification(false)
+                .reportSomaticHotspot(true)
+                .likelihoodType(DriverCategory.TSG)
+                .reportGermlineVariant(DriverGeneGermlineReporting.NONE)
+                .reportGermlineHotspot(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDeletion(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDisruption(DriverGeneGermlineReporting.NONE)
+                .reportPGX(false)
+                .build();
+        DriverGene driverGene2 = ImmutableDriverGene.builder()
+                .gene(unReliableMVLHGene)
+                .reportMissenseAndInframe(false)
+                .reportNonsenseAndFrameshift(false)
+                .reportSplice(false)
+                .reportDeletion(false)
+                .reportDisruption(false)
+                .reportAmplification(true)
+                .reportSomaticHotspot(false)
+                .likelihoodType(DriverCategory.ONCO)
+                .reportGermlineVariant(DriverGeneGermlineReporting.NONE)
+                .reportGermlineHotspot(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDeletion(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDisruption(DriverGeneGermlineReporting.NONE)
+                .reportPGX(false)
+                .build();
+        List<DriverGene> driverGenes = List.of(driverGene1, driverGene2);
+
+        Map<String, Double> mvlhPerGene = OrangeAlgo.parseMVLHPerGene(lines, driverGenes);
+
+        assertNotNull(mvlhPerGene);
+        assertEquals(0.0002D, mvlhPerGene.get(reliableMVLHGene), EPSILON);
+        assertFalse(mvlhPerGene.containsKey(unReliableMVLHGene));
     }
 
     @NotNull

--- a/orange/src/test/java/com/hartwig/hmftools/orange/algo/OrangeAlgoTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/algo/OrangeAlgoTest.java
@@ -1,21 +1,9 @@
 package com.hartwig.hmftools.orange.algo;
 
-import static org.apache.commons.math3.util.Precision.EPSILON;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
-import com.hartwig.hmftools.common.drivercatalog.DriverCategory;
-import com.hartwig.hmftools.common.drivercatalog.panel.DriverGene;
-import com.hartwig.hmftools.common.drivercatalog.panel.DriverGeneGermlineReporting;
-import com.hartwig.hmftools.common.drivercatalog.panel.ImmutableDriverGene;
-import com.hartwig.hmftools.datamodel.orange.OrangeRecord;
-import com.hartwig.hmftools.orange.ImmutableOrangeConfig;
 import com.hartwig.hmftools.orange.OrangeConfig;
 import com.hartwig.hmftools.orange.TestOrangeConfigFactory;
 
@@ -67,59 +55,6 @@ public class OrangeAlgoTest
         OrangeAlgo algo = createOrangeAlgo(config);
 
         assertNotNull(algo.run(config));
-    }
-
-    @Test
-    public void parseGermlineMVLHCorrectly()
-    {
-        String reliableMVLHGene = "FAKE1";
-        String unReliableMVLHGene = "FAKE2";
-
-        List<String> lines = List.of(
-                "gene\tchromosome\tposStart\tposEnd\tmissedVariantLikelihood\tDR_0\tDR_1\tDR_2\tDR_3\tDR_4\tDR_5\tDR_6\tDR_7\tDR_8\tDR_9\tDR_10\tDR_11\tDR_12\tDR_13\tDR_14\tDR_15\tDR_16\tDR_17\tDR_18\tDR_19\tDR_20\tDR_21\tDR_22\tDR_23\tDR_24\tDR_25\tDR_26\tDR_27\tDR_28\tDR_29\tDR_30_39\tDR_40_49\tDR_50_59\tDR_60_69\tDR_70_79\tDR_80_89\tDR_90_99\tDR_100_149\tDR_150_199\tDR_200_249\tDR_250_299\tDR_300_349\tDR_350_399\tDR_400_449\tDR_450_499\tDR_500_599\tDR_600_699\tDR_700_799\tDR_800_899\tDR_900_999\tDR_1000_1099\tDR_1100_1199\tDR_1200_1299\tDR_1300_1399\tDR_1400_1499\tDR_1500_1599\tDR_1600_1699\tDR_1700_1799\tDR_1800_1899\tDR_1900_1999\tDR_2000_2999\tDR_3000_3999\tDR_4000_4999\tDR_5000_5999\tDR_6000_6999\tDR_7000_7999\tDR_8000_8999\tDR_9000_9999\tDR_10000",
-                reliableMVLHGene + "\t7\t87133559\t87229500\t0.0002\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t9\t41\t35\t48\t41\t85\t76\t132\t132\t162\t222\t237\t2689\t454\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0",
-                unReliableMVLHGene +"\t1\t120436587\t120438959\t1.0000\t2373\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"
-        );
-
-        DriverGene driverGene1 = ImmutableDriverGene.builder()
-                .gene(reliableMVLHGene)
-                .reportMissenseAndInframe(true)
-                .reportNonsenseAndFrameshift(true)
-                .reportSplice(true)
-                .reportDeletion(true)
-                .reportDisruption(true)
-                .reportAmplification(false)
-                .reportSomaticHotspot(true)
-                .likelihoodType(DriverCategory.TSG)
-                .reportGermlineVariant(DriverGeneGermlineReporting.NONE)
-                .reportGermlineHotspot(DriverGeneGermlineReporting.NONE)
-                .reportGermlineDeletion(DriverGeneGermlineReporting.NONE)
-                .reportGermlineDisruption(DriverGeneGermlineReporting.NONE)
-                .reportPGX(false)
-                .build();
-        DriverGene driverGene2 = ImmutableDriverGene.builder()
-                .gene(unReliableMVLHGene)
-                .reportMissenseAndInframe(false)
-                .reportNonsenseAndFrameshift(false)
-                .reportSplice(false)
-                .reportDeletion(false)
-                .reportDisruption(false)
-                .reportAmplification(true)
-                .reportSomaticHotspot(false)
-                .likelihoodType(DriverCategory.ONCO)
-                .reportGermlineVariant(DriverGeneGermlineReporting.NONE)
-                .reportGermlineHotspot(DriverGeneGermlineReporting.NONE)
-                .reportGermlineDeletion(DriverGeneGermlineReporting.NONE)
-                .reportGermlineDisruption(DriverGeneGermlineReporting.NONE)
-                .reportPGX(false)
-                .build();
-        List<DriverGene> driverGenes = List.of(driverGene1, driverGene2);
-
-        Map<String, Double> mvlhPerGene = OrangeAlgo.parseMVLHPerGene(lines, driverGenes);
-
-        assertNotNull(mvlhPerGene);
-        assertEquals(0.0002D, mvlhPerGene.get(reliableMVLHGene), EPSILON);
-        assertFalse(mvlhPerGene.containsKey(unReliableMVLHGene));
     }
 
     @NotNull

--- a/orange/src/test/java/com/hartwig/hmftools/orange/algo/sage/GermlineMVLHFactoryTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/algo/sage/GermlineMVLHFactoryTest.java
@@ -1,0 +1,72 @@
+package com.hartwig.hmftools.orange.algo.sage;
+
+import static org.apache.commons.math3.util.Precision.EPSILON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+import java.util.Map;
+
+import com.hartwig.hmftools.common.drivercatalog.DriverCategory;
+import com.hartwig.hmftools.common.drivercatalog.panel.DriverGene;
+import com.hartwig.hmftools.common.drivercatalog.panel.DriverGeneGermlineReporting;
+import com.hartwig.hmftools.common.drivercatalog.panel.ImmutableDriverGene;
+
+import org.junit.Test;
+
+public class GermlineMVLHFactoryTest
+{
+    @Test
+    public void parseGermlineMVLHCorrectly()
+    {
+        String reliableMVLHGene = "FAKE1";
+        String unReliableMVLHGene = "FAKE2";
+
+        List<String> lines = List.of(
+                "gene\tchromosome\tposStart\tposEnd\tmissedVariantLikelihood\tDR_0\tDR_1\tDR_2\tDR_3\tDR_4\tDR_5\tDR_6\tDR_7\tDR_8\tDR_9\tDR_10\tDR_11\tDR_12\tDR_13\tDR_14\tDR_15\tDR_16\tDR_17\tDR_18\tDR_19\tDR_20\tDR_21\tDR_22\tDR_23\tDR_24\tDR_25\tDR_26\tDR_27\tDR_28\tDR_29\tDR_30_39\tDR_40_49\tDR_50_59\tDR_60_69\tDR_70_79\tDR_80_89\tDR_90_99\tDR_100_149\tDR_150_199\tDR_200_249\tDR_250_299\tDR_300_349\tDR_350_399\tDR_400_449\tDR_450_499\tDR_500_599\tDR_600_699\tDR_700_799\tDR_800_899\tDR_900_999\tDR_1000_1099\tDR_1100_1199\tDR_1200_1299\tDR_1300_1399\tDR_1400_1499\tDR_1500_1599\tDR_1600_1699\tDR_1700_1799\tDR_1800_1899\tDR_1900_1999\tDR_2000_2999\tDR_3000_3999\tDR_4000_4999\tDR_5000_5999\tDR_6000_6999\tDR_7000_7999\tDR_8000_8999\tDR_9000_9999\tDR_10000",
+                reliableMVLHGene + "\t7\t87133559\t87229500\t0.0002\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t9\t41\t35\t48\t41\t85\t76\t132\t132\t162\t222\t237\t2689\t454\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0",
+                unReliableMVLHGene +"\t1\t120436587\t120438959\t1.0000\t2373\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"
+        );
+
+        DriverGene driverGene1 = ImmutableDriverGene.builder()
+                .gene(reliableMVLHGene)
+                .reportMissenseAndInframe(true)
+                .reportNonsenseAndFrameshift(true)
+                .reportSplice(true)
+                .reportDeletion(true)
+                .reportDisruption(true)
+                .reportAmplification(false)
+                .reportSomaticHotspot(true)
+                .likelihoodType(DriverCategory.TSG)
+                .reportGermlineVariant(DriverGeneGermlineReporting.NONE)
+                .reportGermlineHotspot(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDeletion(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDisruption(DriverGeneGermlineReporting.NONE)
+                .reportPGX(false)
+                .build();
+        DriverGene driverGene2 = ImmutableDriverGene.builder()
+                .gene(unReliableMVLHGene)
+                .reportMissenseAndInframe(false)
+                .reportNonsenseAndFrameshift(false)
+                .reportSplice(false)
+                .reportDeletion(false)
+                .reportDisruption(false)
+                .reportAmplification(true)
+                .reportSomaticHotspot(false)
+                .likelihoodType(DriverCategory.ONCO)
+                .reportGermlineVariant(DriverGeneGermlineReporting.NONE)
+                .reportGermlineHotspot(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDeletion(DriverGeneGermlineReporting.NONE)
+                .reportGermlineDisruption(DriverGeneGermlineReporting.NONE)
+                .reportPGX(false)
+                .build();
+        List<DriverGene> driverGenes = List.of(driverGene1, driverGene2);
+
+        Map<String, Double> mvlhPerGene = GermlineMVLHFactory.parseMVLHPerGene(lines, driverGenes);
+
+        assertNotNull(mvlhPerGene);
+        assertEquals(0.0002D, mvlhPerGene.get(reliableMVLHGene), EPSILON);
+        assertFalse(mvlhPerGene.containsKey(unReliableMVLHGene));
+    }
+}


### PR DESCRIPTION
Changes:
- Remove unneeded division by 100 from when the input file contained percentages instead of factors.
- There are genes that have MVLH 100% and depth 0 in the input file due to being ignored by SAGE germline entirely. Remove these genes from both the MVLH table in the PDF and the related field in the JSON.

Please feel free to add more reviewers if you want.

I couldn't think of a better way to do the test I added to OrangeAlgoTest. If you can, please let me know.