### PR TITLE
ACTIN-642: Improve CUPPA output layout

### DIFF
--- a/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
+++ b/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
@@ -75,7 +75,7 @@ get_plot_data_probs <- function(VIS_DATA, data_value_rounding = 2){
    plot_data <- subset(VIS_DATA, data_type=="prob")
 
    plot_data$row_label <- toupper(gsub("_"," ", plot_data$clf_name))
-   plot_data$row_label <- plyr::revalue(plot_data$row_label, replace=MAPPINGS_CLASSIFIER_NAMES, warn_missing=FALSE)
+   plot_data$row_label <- revalue(plot_data$row_label, replace=MAPPINGS_CLASSIFIER_NAMES, warn_missing=FALSE)
    plot_data$row_group <- toupper(plot_data$clf_group)
 
    ## Data label --------------------------------
@@ -488,7 +488,7 @@ plot_feat_contrib <- function(VIS_DATA){
       str_split(gsub("_", " ", plot_data$feat_name), '[.]', n=2)
    ))
    colnames(affixes) <- c("feat_type", "feat_basename")
-   affixes$feat_type[affixes$feat_type == "driver"] <- "driver (DL)"
+   affixes$feat_type <- revalue(affixes$feat_type, replace=c(driver="driver (DL)"))
 
    ## Format labels --------------------------------
    plot_data$row_group <- affixes$feat_type
@@ -524,7 +524,11 @@ plot_feat_contrib <- function(VIS_DATA){
       feat_value_label[feat_value==0] <- "0"
       feat_value_label[feat_value==1] <- "1"
 
-      paste0(ifelse(grepl("\\.", affixes$feat_basename), paste(gsub("\\.", " ", affixes$feat_basename), " (", feat_value_label, ")", sep = ""), ifelse((affixes$feat_basename == "is male") | (affixes$feat_basename == "whole genome duplication"), paste(affixes$feat_basename, "=", feat_value_label, sep = " "), paste(affixes$feat_basename, "=", feat_value_label, sep = " "))))
+      driver_feat_value_label <- paste0(gsub("\\.", " ", affixes$feat_basename), " (", feat_value_label, ")")
+      trait_feat_value_label <- paste(affixes$feat_basename, "=", feat_value_label==1, sep = " ")
+      tmb_or_sv_feat_value_label <- paste(affixes$feat_basename, "=", feat_value_label, sep = " ")
+      non_driver_feat_value_label <- ifelse(affixes$feat_basename %in% c("is male", "whole genome duplication"), trait_feat_value_label, tmb_or_sv_feat_value_label)
+      paste0(ifelse(grepl("\\.", affixes$feat_basename), driver_feat_value_label, non_driver_feat_value_label))
    })
    
    ## Legend breaks --------------------------------

--- a/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
+++ b/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
@@ -501,14 +501,14 @@ plot_feat_contrib <- function(VIS_DATA){
       list(lower=0.01,  upper=1,     func=function(x) signif(x, digits=1)),
       list(lower=-Inf,  upper=0.01,  func=function(x) formatC(x, format="e", digits=0))
    )
-   
+
    data_labels <- sapply(plot_data$data_value, function(value){
       for(params in rounding_params){
          if(value >= params$lower & value < params$upper){
             return(params$func(value))
          }
       }
-      
+
       return(value)
    })
    data_labels[data_labels==1] <- "" ## odds of 1 == log(odds) of 0 -> unimportant, thus hide
@@ -522,6 +522,7 @@ plot_feat_contrib <- function(VIS_DATA){
 
       feat_value_label <- round(feat_value, digits=1)
       feat_value_label[feat_value==0] <- "0"
+      feat_value_label[feat_value==-0.00000001] <- "absent"
       feat_value_label[feat_value==1] <- "1"
 
       driver_feat_value_label <- paste0(gsub("\\.", " ", affixes$feat_basename), " (", feat_value_label, ")")
@@ -530,7 +531,7 @@ plot_feat_contrib <- function(VIS_DATA){
       non_driver_feat_value_label <- ifelse(affixes$feat_basename %in% c("is male", "whole genome duplication"), trait_feat_value_label, tmb_or_sv_feat_value_label)
       paste0(ifelse(grepl("\\.", affixes$feat_basename), driver_feat_value_label, non_driver_feat_value_label))
    })
-   
+
    ## Legend breaks --------------------------------
    exponent_range <- log10(max(plot_data$data_value)) - log10(min(plot_data$data_value))
    legend_breaks <- 10^seq(from=-10, to=10, by=if(exponent_range < 5) 1 else 2)

--- a/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
+++ b/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
@@ -518,7 +518,7 @@ plot_feat_contrib <- function(VIS_DATA){
       feat_value_label[feat_value==0] <- "0"
       feat_value_label[feat_value==1] <- "1"
 
-      paste0(ifelse(grepl("\\.", affixes$feat_basename), paste(gsub("\\.", " ", affixes$feat_basename), " (", feat_value_label, ")", sep = ""), paste(affixes$feat_basename, "=", feat_value_label, sep = " ")))
+      paste0(ifelse(grepl("\\.", affixes$feat_basename), paste(gsub("\\.", " ", affixes$feat_basename), " (", feat_value_label, ")", sep = ""), ifelse((affixes$feat_basename == "is male") | (affixes$feat_basename == "whole genome duplication"), paste(affixes$feat_basename, "=", feat_value_label, sep = " "), paste(affixes$feat_basename, "=", feat_value_label, sep = " "))))
    })
    
    ## Legend breaks --------------------------------

--- a/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
+++ b/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
@@ -67,7 +67,9 @@ get_plot_data_probs <- function(VIS_DATA, data_value_rounding = 2){
 
    plot_data <- subset(VIS_DATA, data_type=="prob")
 
-   plot_data$row_label <- toupper(plot_data$clf_name)
+   plot_data$row_label <- toupper(gsub("_"," ", plot_data$clf_name))
+   plot_data$row_label[plot_data$row_label == "GENE EXP"] <- "GENE EXPRESSION"
+   plot_data$row_label[plot_data$row_label == "GEN POS"] <- "GENOMIC POSITION"
    plot_data$row_group <- toupper(plot_data$clf_group)
 
    ## Data label --------------------------------
@@ -366,7 +368,7 @@ plot_probs <- function(VIS_DATA){
 plot_cv_performance <- function(VIS_DATA, data_value_rounding = 2){
    plot_data <- subset(VIS_DATA, data_type=="cv_performance")
 
-   plot_data$row_group <- "training_set"
+   plot_data$row_group <- "training set"
    plot_data$row_label <- plot_data$feat_name
 
    ## Data label --------------------------------
@@ -408,7 +410,7 @@ plot_cv_performance <- function(VIS_DATA, data_value_rounding = 2){
       guide=guide_colorbar(frame.colour="black", ticks.colour="black", barheight=3.5)
    ) +
    #guides(fill=FALSE) +
-   labs(title="DNA_COMBINED: Training set performance", fill="Metric value") +
+   labs(title="DNA COMBINED: Training set performance", fill="Metric value") +
    theme(legend.justification=c("left", "bottom"))
 }
 
@@ -440,7 +442,7 @@ plot_signatures <- function(
 
       feat_value <- round(feat_value, feat_value_rounding)
 
-      paste0(feat_name, " = ", feat_value, " (", perc, "%)")
+      paste0(gsub("_", " ", feat_name), " = ", feat_value, " (", perc, "%)")
    })
 
    ## Discretize quantiles --------------------------------
@@ -477,9 +479,10 @@ plot_feat_contrib <- function(VIS_DATA){
    ## Parse feature names --------------------------------
    affixes <- as.data.frame(do.call(
       rbind,
-      str_split(plot_data$feat_name, '[.]', n=2)
+      str_split(gsub("_", " ", plot_data$feat_name), '[.]', n=2)
    ))
    colnames(affixes) <- c("feat_type", "feat_basename")
+   affixes$feat_type[affixes$feat_type == "driver"] <- "driver (DL)"
 
    ## Format labels --------------------------------
    plot_data$row_group <- affixes$feat_type
@@ -515,7 +518,7 @@ plot_feat_contrib <- function(VIS_DATA){
       feat_value_label[feat_value==0] <- "0"
       feat_value_label[feat_value==1] <- "1"
 
-      paste0(affixes$feat_basename, " = ", feat_value_label)
+      paste0(ifelse(grepl("\\.", affixes$feat_basename), paste(gsub("\\.", " ", affixes$feat_basename), " (", feat_value_label, ")", sep = ""), paste(affixes$feat_basename, "=", feat_value_label, sep = " ")))
    })
    
    ## Legend breaks --------------------------------

--- a/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
+++ b/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
@@ -6,78 +6,12 @@ library(ggh4x)
 library(stringr)
 library(patchwork)
 library(plyr)
-library(dplyr)
 
 ## Args ================================
 args <- commandArgs(trailingOnly = TRUE)
 
 VIS_DATA_PATH <- args[1]
 PLOT_PATH <- args[2]
-COHORT_PERCENTILES_PATH <- "~/cuppa_sig_cohort_percentiles.tsv" #Should be changed!
-
-## Cohort percentiles ================================
-COHORT_PERCENTILES <- read.delim(COHORT_PERCENTILES_PATH)
-
-getPercentile <- function(cohortPercentiles, cohort, value, name) {
-  percentiles <- subset(cohortPercentiles, class==cohort)
-  name <- gsub("[[:punct:]]+", ".", name)
-  name <- gsub(" ", ".", name)
-  name <- paste("sig.", name, sep="")
-  percentiles <- percentiles[name][,1]
-
-  if (length(percentiles) != 101) {
-    return(-1)
-  }
-
-  if(value < percentiles[1]) {
-    if(percentiles[1] == 0) {
-      return(0)
-    }
-    else if(value == 0) {
-      return(-100)
-    }
-    else {
-      return(-percentiles[1] / value)
-    }
-  }
-  else if(value > percentiles[length(percentiles)]) {
-    maxValue <- percentiles[length(percentiles)]
-    return(ifelse(maxValue>0, value/maxValue, 100.01))
-  }
-
-  sameValueStart <- -1
-  sameValueEnd <- 0
-  for (i in 1:(length(percentiles))){
-    if(value == percentiles[i] && percentiles[i] == percentiles[i + 1]) {
-      if(sameValueStart == -1) {
-        sameValueStart <- i
-      }
-      sameValueEnd <- i + 1
-      if(i < length(percentiles) - 1) {
-        next
-      }
-    }
-
-    if(value >= percentiles[i] && value <= percentiles[i+1]) {
-      if(value > percentiles[i] && value == percentiles[i+1] && i < length(percentiles) - 1 ) {
-        next
-      }
-
-      if(value == percentiles[i] && sameValueStart >= 1 && sameValueStart < sameValueEnd) {
-        return ((0.5 * (sameValueStart - 1) + 0.5 * (sameValueEnd - 1)) * 0.01)
-      }
-
-      if(percentiles[i+1] == percentiles[i]) {
-        return((i-1) * 0.01)
-      }
-
-      upperFactor <- (value - percentiles[i]) / (percentiles[i+1] - percentiles[i])
-      return((upperFactor * i + (1 - upperFactor) * (i - 1))*0.01)
-    }
-  }
-
-  return(-1)
-}
 
 ## Load data ================================
 VIS_DATA <- read.delim(VIS_DATA_PATH)
@@ -502,8 +436,7 @@ plot_signatures <- function(
    plot_data <- subset(VIS_DATA, data_type=="sig_quantile")
 
    plot_data$row_group <- "signature"
-   plot_data <- plot_data %>% rowwise() %>% mutate(data_label = getPercentile(COHORT_PERCENTILES, cancer_type, feat_value, feat_name))
-   plot_data$data_label <- round(plot_data$data_label, data_value_rounding)
+   plot_data$data_label <- round(plot_data$data_value, data_value_rounding)
 
    ## Make row labels --------------------------------
    plot_data$row_label <- with(plot_data, {
@@ -518,17 +451,17 @@ plot_signatures <- function(
       paste0(gsub("_", " ", feat_name), " = ", feat_value, " (", perc, "%)")
    })
 
-   ## Discretize percentiles --------------------------------
-   percentile_info <- list(
-      breaks=c(-Inf, 0, 0.02, 0.98, 1, 2, Inf),
-      labels=c("< 0 (below expected range)", "0 - 0.02 (low in expected range)", "0.02 - 0.98 (expected range)", "0.98-1.00 (high in expected range)", ">1.0 (above expected range)", ">2 (well above expected range)"),
-      colors=c("#e8b6b6", "#f5dfdf", "#FFFFFF", "#f5dfdf","#e8b6b6", "#d67c81")
+   ## Discretize quantiles --------------------------------
+   quantile_info <- list(
+      breaks=c(0, 0.95, 1.2, Inf),
+      labels=c(">0 - 0.95 (in expected range)", "0.95 - 1.2 (above expected range)", ">1.2 (well above expected range)"),
+      colors=c("#C9E7CD", "#f5dfdf","#e8b6b6") ## white, green, light green, red
    )
 
    plot_data$data_value <- cut(
-      plot_data$data_label,
-      breaks=percentile_info$breaks,
-      labels=percentile_info$labels
+      plot_data$data_value,
+      breaks=quantile_info$breaks,
+      labels=quantile_info$labels
    )
 
    ## Plot --------------------------------
@@ -538,12 +471,11 @@ plot_signatures <- function(
       cell_color="grey50"
    ) +
    scale_fill_manual(
-      values=structure(percentile_info$colors, names=percentile_info$labels),
+      values=structure(quantile_info$colors, names=quantile_info$labels),
       guide=guide_legend(override.aes=list(colour="black", linetype=1)),
-      na.value="grey95", drop=TRUE
+      na.value="grey95", drop=FALSE
    ) +
-   labs(fill="Percentile in subtype cohort", title="SNV96: Mutational signatures") +
-     theme(legend.text = element_text(size=10), legend.key.size = unit(0.4, "cm"))
+   labs(fill="Quantile in subtype cohort", title="SNV96: Mutational signatures")
 }
 
 plot_feat_contrib <- function(VIS_DATA){

--- a/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
+++ b/cuppa/src/main/python/pycuppa/cuppa/visualization/plot_predictions.R
@@ -5,6 +5,7 @@ library(ggplot2)
 library(ggh4x)
 library(stringr)
 library(patchwork)
+library(plyr)
 
 ## Args ================================
 args <- commandArgs(trailingOnly = TRUE)
@@ -62,14 +63,19 @@ if(is.na(SNV_COUNT)){
    stop("`snv_count` was not found as a feature in `VIS_DATA`")
 }
 
+## Define mapping ================================
+MAPPINGS_CLASSIFIER_NAMES = c(
+  "GENE EXP"="GENE EXPRESSION",
+  "GEN POS"="GENOMIC POSITION"
+)
+
 ## Heatmap of probs ================================
 get_plot_data_probs <- function(VIS_DATA, data_value_rounding = 2){
 
    plot_data <- subset(VIS_DATA, data_type=="prob")
 
    plot_data$row_label <- toupper(gsub("_"," ", plot_data$clf_name))
-   plot_data$row_label[plot_data$row_label == "GENE EXP"] <- "GENE EXPRESSION"
-   plot_data$row_label[plot_data$row_label == "GEN POS"] <- "GENOMIC POSITION"
+   plot_data$row_label <- plyr::revalue(plot_data$row_label, replace=MAPPINGS_CLASSIFIER_NAMES, warn_missing=FALSE)
    plot_data$row_group <- toupper(plot_data$clf_group)
 
    ## Data label --------------------------------


### PR DESCRIPTION
* Remove underscores
* Rename GEN_POS to GENOMIC POSITION & GENE_EXP to GENE EXPRESSION
* Make clear that numbers behind drivers are driver likelihoods, and numbers behind "is male" and "whole genome duplication" are booleans

(Haven't made any changes to the SNV signatures highlighting yet, see mail)