### PR TITLE
INFRA-347: Support unusual esophageal DOID configuration in cohort mapping

### DIFF
--- a/orange/src/main/java/com/hartwig/hmftools/orange/cohort/mapping/CohortConstants.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/cohort/mapping/CohortConstants.java
@@ -46,6 +46,7 @@ public final class CohortConstants
 
         DOID_COMBINATIONS_TO_MAP_TO_STOMACH.add(Sets.newHashSet("0080374", "10534"));
         DOID_COMBINATIONS_TO_MAP_TO_STOMACH.add(Sets.newHashSet("0080374", "5517"));
+        DOID_COMBINATIONS_TO_MAP_TO_STOMACH.add(Sets.newHashSet("0080374", "5516"));
         DOID_COMBINATIONS_TO_MAP_TO_STOMACH.add(Sets.newHashSet("0080374", "3717"));
         DOID_COMBINATIONS_TO_MAP_TO_STOMACH.add(Sets.newHashSet("0080375", "10534"));
         DOID_COMBINATIONS_TO_MAP_TO_STOMACH.add(Sets.newHashSet("0080375", "5517"));

--- a/orange/src/main/java/com/hartwig/hmftools/orange/cohort/mapping/CohortConstants.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/cohort/mapping/CohortConstants.java
@@ -36,6 +36,7 @@ public final class CohortConstants
         DOID_COMBINATIONS_TO_MAP_TO_ESOPHAGUS.add(Sets.newHashSet("0080374", "5041"));
         DOID_COMBINATIONS_TO_MAP_TO_ESOPHAGUS.add(Sets.newHashSet("0080374", "1107"));
         DOID_COMBINATIONS_TO_MAP_TO_ESOPHAGUS.add(Sets.newHashSet("0080374", "4914"));
+        DOID_COMBINATIONS_TO_MAP_TO_ESOPHAGUS.add(Sets.newHashSet("0080374", "3748"));
         DOID_COMBINATIONS_TO_MAP_TO_ESOPHAGUS.add(Sets.newHashSet("0080375", "5041"));
         DOID_COMBINATIONS_TO_MAP_TO_ESOPHAGUS.add(Sets.newHashSet("0080375", "1107"));
         DOID_COMBINATIONS_TO_MAP_TO_ESOPHAGUS.add(Sets.newHashSet("0080375", "4914"));

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <linx.version>2.0</linx.version>
         <mark-dups.version>1.1</mark-dups.version>
         <neo.version>1.2</neo.version>
-        <orange.version>3.3.0</orange.version>
+        <orange.version>3.3.1</orange.version>
         <orange-datamodel.version>2.3.0</orange-datamodel.version>
         <paddle.version>1.1</paddle.version>
         <patient-db.version>5.35</patient-db.version>


### PR DESCRIPTION
Added the combination of DOID 3738 (esophageal squamous cell carcinoma) and 0080374 (gastroesophageal cancer) to  the explicit list of doid combinations to be mapped to esophageal cohort