### PR TITLE
Add htsget support for SAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # HMF Tools
-
 This repository contains the suite of tools used in the Hartwig Medical Foundation whole genome,targeted DNA and whole transcriptome analysis pipeline.  
 
 ## DNA Pipeline Components
@@ -9,13 +8,20 @@ This repository contains the suite of tools used in the Hartwig Medical Foundati
 #### Latest Pipeline Version
 The latest HMF pipeline is v5.34. Release notes are [here](https://github.com/hartwigmedical/hmftools/blob/master/pipeline/docs/PipelineReleaseNotes.v5.34.pdf).
 
-The table below has links for the each tool used in this release. 
+The table below has links for each tool used in this release.
 
 #### Running the Pipeline
-The full pipeline can be run using a NextFlow implmentation called [OncoAnalyser](https://github.com/hartwigmedical/hmftools/blob/master/pipeline/README_ONCOANALYSER.md).
+The full pipeline can be run using a NextFlow implementation called [OncoAnalyser](https://github.com/hartwigmedical/hmftools/blob/master/pipeline/README_ONCOANALYSER.md).
 
 An example WGS pipeline which runs each of these components in turn is detailed [here](./pipeline/README_WGS.md).
 An example targeted-panel pipeline, including support for the HMF and TSO-500 panels, is detailed [here](./pipeline/README_TARGETED.md).
+
+#### Building from source
+Developers can build all the tools locally via the `hmftools-build.py` script, providing a semver-compliant release tag, i.e:
+
+```
+./hmftools-build.py --no-release sage-v6.6.6
+```
 
 #### Current versions
 | Component                         | Description                                                            | Current Version                                                                 |

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/bam/BamSampler.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/bam/BamSampler.java
@@ -4,14 +4,15 @@ import static java.lang.Math.max;
 
 import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.loadRefGenome;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource;
 import com.hartwig.hmftools.common.region.ChrBaseRegion;
 
+import htsjdk.io.HtsPath;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.cram.ref.ReferenceSource;
@@ -58,9 +59,10 @@ public class BamSampler
         if(!Files.exists(Paths.get(bamFile)))
             return false;
 
+        HtsPath path = new HtsPath(bamFile);
         SamReader samReader = SamReaderFactory.makeDefault()
                 .referenceSource(new ReferenceSource(mRefGenome.refGenomeFile()))
-                .open(new File(bamFile));
+                .open(SamInputResource.of(path.getURI()));
 
         mSlicer.slice(samReader, sampleRegion, this::processRecord);
 

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/utils/config/ConfigBuilder.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/utils/config/ConfigBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.hartwig.hmftools.common.utils.version.VersionInfo;
 
+import htsjdk.io.HtsPath;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -253,6 +254,11 @@ public class ConfigBuilder
 
         for(String path : paths)
         {
+            // It's not a path and/or contains a URI scheme, i.e: htsget://
+            HtsPath htsPath = new HtsPath(path);
+            if(!htsPath.isPath() && htsPath.toString().contains("://")) { continue; }
+
+            // It's a local filesystem path
             if(pathPrefixConfigItem != null && pathPrefixConfigItem.hasValue())
             {
                 String pathPrefix = checkAddDirSeparator(pathPrefixConfigItem.value());

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 This script does the following:
 - Whenever a user pushes a git tag in the format '<tool>-<version>' this script will parse that tag.
@@ -64,12 +66,14 @@ def main():
     parser = ArgumentParser(
         description="A tool for automatically building and deploying individual modules in HMF-tools.")
     parser.add_argument('tag', help="The semantic versioning tag in the following format: <tool-name>-<version>")
+    parser.add_argument('-nr', '--no-release', dest='deploy', help="Only build artifacts, don't try to release nor publish", action='store_true')
     args = parser.parse_args()
 
-    build_and_release(args.tag)
+    build_and_release(args)
 
 
-def build_and_release(raw_tag: str):
+def build_and_release(args):
+    raw_tag = args.tag
     match = SEMVER_REGEX.match(raw_tag)
     if not match:
         print(f"Invalid tag: '{raw_tag}' (it does not match the regex pattern: '{SEMVER_REGEX.pattern}')")
@@ -96,7 +100,8 @@ def build_and_release(raw_tag: str):
     parent_pom.set_version(tag)
     module_pom.set_version(version)
 
-    Maven.deploy_all(module_pom, *dependencies_pom)
+    if not args.deploy:
+        Maven.deploy_all(module_pom, *dependencies_pom)
 
 
 if __name__ == '__main__':

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 
         <commons.cli.version>1.3.1</commons.cli.version>
         <immutables.version>2.9.3</immutables.version>
-        <htsjdk.version>2.23.0</htsjdk.version>
+        <htsjdk.version>2.24.1</htsjdk.version>
         <intellij.annotations.version>12.0</intellij.annotations.version>
         <google.guava.version>31.0.1-jre</google.guava.version>
         <google.gson.version>2.8.9</google.gson.version>

--- a/sage/src/main/java/com/hartwig/hmftools/sage/SageApplication.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/SageApplication.java
@@ -18,10 +18,8 @@ import com.hartwig.hmftools.sage.bqr.BaseQualityRecalibration;
 import com.hartwig.hmftools.sage.bqr.BqrRecordMap;
 import com.hartwig.hmftools.sage.vcf.VcfWriter;
 
-import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
+import htsjdk.io.HtsPath;
+import htsjdk.samtools.*;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 
 public class SageApplication implements AutoCloseable
@@ -107,10 +105,12 @@ public class SageApplication implements AutoCloseable
     {
         final String bam = mConfig.Common.ReferenceBams.isEmpty() ? mConfig.TumorBams.get(0) : mConfig.Common.ReferenceBams.get(0);
 
+        HtsPath path = new HtsPath(bam);
+
         SamReader tumorReader = SamReaderFactory.makeDefault()
                 .validationStringency(mConfig.Common.BamStringency)
                 .referenceSource(new ReferenceSource(mRefData.RefGenome))
-                .open(new File(bam));
+                .open(SamInputResource.of(path.getURI()));
 
         SAMSequenceDictionary dictionary = tumorReader.getFileHeader().getSequenceDictionary();
 

--- a/sage/src/main/java/com/hartwig/hmftools/sage/SageCallConfig.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/SageCallConfig.java
@@ -17,6 +17,7 @@ import java.util.List;
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
 
+import htsjdk.io.HtsPath;
 import org.apache.logging.log4j.util.Strings;
 
 public class SageCallConfig
@@ -80,7 +81,9 @@ public class SageCallConfig
 
         for(String tumorBam : TumorBams)
         {
-            if(!new File(tumorBam).exists())
+            HtsPath tumorPath = new HtsPath(tumorBam);
+
+            if(tumorPath.isPath() && !new File(tumorBam).exists())
             {
                 SG_LOGGER.error("Unable to locate tumor bam({})", tumorBam);
                 return false;

--- a/sage/src/main/java/com/hartwig/hmftools/sage/SageConfig.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/SageConfig.java
@@ -49,6 +49,7 @@ import com.hartwig.hmftools.sage.filter.FilterConfig;
 import com.hartwig.hmftools.sage.quality.QualityConfig;
 import com.hartwig.hmftools.sage.vis.VisConfig;
 
+import htsjdk.io.HtsPath;
 import org.apache.logging.log4j.util.Strings;
 
 import htsjdk.samtools.ValidationStringency;
@@ -233,7 +234,10 @@ public class SageConfig
 
         for(String referenceBam : ReferenceBams)
         {
-            if(!new File(referenceBam).exists())
+            HtsPath tumorPath = new HtsPath(referenceBam);
+
+            // Delay remote file access checks for later when SamInputReader is instantiated
+            if(tumorPath.isPath() && !new File(referenceBam).exists())
             {
                 SG_LOGGER.error("Unable to locate reference bam({})", referenceBam);
                 return false;

--- a/sage/src/main/java/com/hartwig/hmftools/sage/bqr/BqrThread.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/bqr/BqrThread.java
@@ -15,6 +15,8 @@ import com.hartwig.hmftools.common.region.ChrBaseRegion;
 import com.hartwig.hmftools.sage.SageConfig;
 import com.hartwig.hmftools.sage.common.PartitionTask;
 
+import htsjdk.io.HtsPath;
+import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.cram.ref.ReferenceSource;
@@ -46,10 +48,12 @@ public class BqrThread extends Thread
         mResults = results;
         mKnownVariantMap = knownVariantMap;
 
+        HtsPath path = new HtsPath(bamFile);
+
         mBamReader = SamReaderFactory.makeDefault()
                 .validationStringency(mConfig.BamStringency)
                 .referenceSource(new ReferenceSource(mRefGenome))
-                .open(new File(bamFile));
+                .open(SamInputResource.of(path.getURI()));
 
         mRegionCounter = new BqrRegionReader(mConfig, mBamReader, mRefGenome, mResults, recordWriter);
 

--- a/sage/src/main/java/com/hartwig/hmftools/sage/common/SamSlicerFactory.java
+++ b/sage/src/main/java/com/hartwig/hmftools/sage/common/SamSlicerFactory.java
@@ -12,6 +12,8 @@ import com.google.common.collect.Maps;
 import com.hartwig.hmftools.common.region.ChrBaseRegion;
 import com.hartwig.hmftools.sage.SageConfig;
 
+import htsjdk.io.HtsPath;
+import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.cram.ref.ReferenceSource;
@@ -59,10 +61,12 @@ public class SamSlicerFactory
             final String sample = allSamples.get(i);
             final String bamFile = allBams.get(i);
 
+            HtsPath path = new HtsPath(bamFile);
+
             SamReader bamReader = SamReaderFactory.makeDefault()
                     .validationStringency(config.BamStringency)
                     .referenceSource(new ReferenceSource(refGenome))
-                    .open(new File(bamFile));
+                    .open(SamInputResource.of(path.getURI()));
 
             mBamReaders.put(sample, bamReader);
         }


### PR DESCRIPTION
This PR adds support for [GA4GH's htsget protocol](https://samtools.github.io/hts-specs/htsget.html). In order to test the server out I've used our own htsget server @UMCCR, [htsget-rs](https://github.com/umccr/htsget-rs), like so:

```sh
$ docker run --platform linux/amd64 -p 8081:8081 -p 8080:8080 -v $HOME/dev/umccr/sage-data/sample_data:/data/bam ghcr.io/umccr/htsget-rs:latest
```

And then running the following commandline SAGE instantiation:

```
java -Xmx15G -jar software/sage_v3.4.jar \
-reference MDX230458 \
-reference_bam htsget://localhost:8080/reads/data/bam/MDX230458_normal.sliced \
-tumor MDX230466 \
-tumor_bam htsget://localhost:8080/reads/data/bam/MDX230466_tumor.sliced \
-ref_genome ../sage-data/reference_data/genome/GRCh38_full_analysis_set_plus_decoy_hla.fa \
-ref_genome_version 38 \
-hotspots ../sage-data/reference_data/sage/KnownHotspots.somatic.38.vcf.gz \
-panel_bed ../sage-data/reference_data/sage/ActionableCodingPanel.38.bed.gz \
-coverage_bed ../sage-data/reference_data/sage/CoverageCodingPanel.38.bed.gz \
-high_confidence_bed ../sage-data/reference_data/sage/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7.bed.gz \
-ensembl_data_dir ../sage-data/reference_data/sage/ensembl_data \
-write_bqr_plot \
-vis_variants chr17:7674220:C:T \
-threads 16 \
-output_vcf ../sage-data/output/MDX230466.sage.somatic.vcf.gz
```

Please note the `htsget://` URIs in `-reference_bam` and `-tumor_bam`. That's the addition on this pullrequest: being able to access resources remotely, not based on a local filesystem. This change has been targeted for SAGE, but there's no reason to believe that it couldn't be applied to (all?) the other tools present in this repo, extending the distributed storage benefit to all your toolchain (and oncoanalyser).

The command line arguments above (and the `-v` arguments on the docker container) assume both big and private data stored in `sage-data` that I'll not be able to share publicly, but I hope that you can reproduce it under your premises? I found it hard to put together a minimal integration test for this since it involves quite big files. On the unit/functional side, I'm assuming that there's enough test coverage on htsget from htsjdk, but I'd be happy to take guidance on tests you might see lacking in this PR.

It would be preferable to extend this htsget support for VCF files as well as BAM files, [but unfortunately there's no support in the `htsjdk` library for it at the time of writing this](https://github.com/samtools/htsjdk/issues/1555), /cc @lbergelson, @cmnbroad.

Thanks @scwatts @ohofmann @reisingerf @mmalenic for making this possible!