### PR TITLE
DEV-3784: Expand Liftover in Compar

### DIFF
--- a/compar/src/main/java/com/hartwig/hmftools/compar/ItemComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/ItemComparer.java
@@ -14,7 +14,7 @@ public interface ItemComparer
 
     boolean processSample(final String sampleId, final List<Mismatch> mismatches);
 
-    List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess);
+    List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName);
 
     List<ComparableItem> loadFromFile(final String sampleId, final FileSources fileSources);
 

--- a/compar/src/main/java/com/hartwig/hmftools/compar/chord/ChordComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/chord/ChordComparer.java
@@ -57,7 +57,7 @@ public class ChordComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         ChordData chordData = dbAccess.readChord(sampleId);
         final List<ComparableItem> comparableItems = Lists.newArrayList();

--- a/compar/src/main/java/com/hartwig/hmftools/compar/common/CommonUtils.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/common/CommonUtils.java
@@ -1,5 +1,8 @@
 package com.hartwig.hmftools.compar.common;
 
+import static com.hartwig.hmftools.common.genome.refgenome.GenomeLiftoverCache.UNMAPPED_POSITION;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.V37;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.V38;
 import static com.hartwig.hmftools.compar.common.Category.GENE_COPY_NUMBER;
 import static com.hartwig.hmftools.compar.ComparConfig.NEW_SOURCE;
 import static com.hartwig.hmftools.compar.ComparConfig.REF_SOURCE;
@@ -16,6 +19,10 @@ import java.util.Map;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.hartwig.hmftools.common.genome.position.GenomePositionImpl;
+import com.hartwig.hmftools.common.genome.position.ImmutableGenomePositionImpl;
+import com.hartwig.hmftools.common.genome.refgenome.GenomeLiftoverCache;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.compar.ComparConfig;
 import com.hartwig.hmftools.compar.ComparableItem;
 import com.hartwig.hmftools.compar.ItemComparer;
@@ -134,7 +141,7 @@ public class CommonUtils
 
             if(!config.DbConnections.isEmpty())
             {
-                items = comparer.loadFromDb(sourceSampleId, config.DbConnections.get(sourceName));
+                items = comparer.loadFromDb(sourceSampleId, config.DbConnections.get(sourceName), sourceName);
             }
             else
             {
@@ -222,5 +229,24 @@ public class CommonUtils
 
         items2.stream().filter(x -> matchLevel != REPORTABLE || x.reportable())
                 .forEach(x -> mismatches.add(new Mismatch(null, x, NEW_ONLY, emptyDiffs)));
+    }
+
+    public static GenomePositionImpl determineComparisonGenomePosition(final String chromosome, final int position, String fileSource,
+            final boolean requiresLiftover, final GenomeLiftoverCache liftoverCache)
+    {
+        if(requiresLiftover && liftoverCache.hasMappings())
+        {
+            RefGenomeVersion destVersion = fileSource.equals(REF_SOURCE) ? V38 : V37;
+            int newPosition = liftoverCache.convertPosition(chromosome, position, destVersion);
+
+            if(newPosition != UNMAPPED_POSITION)
+            {
+                return ImmutableGenomePositionImpl.builder()
+                        .chromosome(destVersion.versionedChromosome(chromosome))
+                        .position(newPosition)
+                        .build();
+            }
+        }
+        return ImmutableGenomePositionImpl.builder().chromosome(chromosome).position(position).build();
     }
 }

--- a/compar/src/main/java/com/hartwig/hmftools/compar/cuppa/CuppaComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/cuppa/CuppaComparer.java
@@ -54,7 +54,7 @@ public class CuppaComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         // currently unsupported
         return Lists.newArrayList();

--- a/compar/src/main/java/com/hartwig/hmftools/compar/driver/DriverComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/driver/DriverComparer.java
@@ -58,7 +58,7 @@ public class DriverComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         final List<DriverCatalog> drivers = dbAccess.readDriverCatalog(sampleId);
 

--- a/compar/src/main/java/com/hartwig/hmftools/compar/lilac/LilacComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/lilac/LilacComparer.java
@@ -68,7 +68,7 @@ public class LilacComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         return Lists.newArrayList();
     }

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
@@ -120,7 +120,7 @@ public class DisruptionComparer implements ItemComparer
                         var.startChromosome(), var.startPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
                 GenomePositionImpl comparisonEndGenomePosition = determineComparisonGenomePosition(
                         var.endChromosome(), var.endPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
-                boolean checkTranscript = mConfig.AlternateTranscriptDriverGenes.contains(breakend.gene());
+                boolean checkTranscript = mConfig.AlternateTranscriptDriverGenes.contains(breakend.gene()) || !breakend.canonical();
                 DisruptionData disruptionData =
                         new DisruptionData(var, breakend, comparisonStartGenomePosition, comparisonEndGenomePosition, checkTranscript);
                 items.add(disruptionData);

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
@@ -120,7 +120,7 @@ public class DisruptionComparer implements ItemComparer
                         var.startChromosome(), var.startPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
                 GenomePositionImpl comparisonEndGenomePosition = determineComparisonGenomePosition(
                         var.endChromosome(), var.endPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
-                boolean checkTranscript = mConfig.AlternateTranscriptDriverGenes.contains(breakend.gene()) || !breakend.canonical();
+                boolean checkTranscript = !breakend.canonical();
                 DisruptionData disruptionData =
                         new DisruptionData(var, breakend, comparisonStartGenomePosition, comparisonEndGenomePosition, checkTranscript);
                 items.add(disruptionData);

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
@@ -120,7 +120,9 @@ public class DisruptionComparer implements ItemComparer
                         var.startChromosome(), var.startPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
                 GenomePositionImpl comparisonEndGenomePosition = determineComparisonGenomePosition(
                         var.endChromosome(), var.endPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
-                DisruptionData disruptionData = new DisruptionData(var, breakend, comparisonStartGenomePosition, comparisonEndGenomePosition);
+                boolean checkTranscript = mConfig.AlternateTranscriptDriverGenes.contains(breakend.gene());
+                DisruptionData disruptionData =
+                        new DisruptionData(var, breakend, comparisonStartGenomePosition, comparisonEndGenomePosition, checkTranscript);
                 items.add(disruptionData);
             }
         }

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionComparer.java
@@ -4,6 +4,7 @@ import static com.hartwig.hmftools.common.sv.StructuralVariantData.convertSvData
 import static com.hartwig.hmftools.compar.common.Category.DISRUPTION;
 import static com.hartwig.hmftools.compar.common.CommonUtils.FLD_REPORTED;
 import static com.hartwig.hmftools.compar.ComparConfig.CMP_LOGGER;
+import static com.hartwig.hmftools.compar.common.CommonUtils.determineComparisonGenomePosition;
 import static com.hartwig.hmftools.compar.linx.DisruptionData.FLD_CODING_CONTEXT;
 import static com.hartwig.hmftools.compar.linx.DisruptionData.FLD_GENE_ORIENT;
 import static com.hartwig.hmftools.compar.linx.DisruptionData.FLD_NEXT_SPLICE;
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
+import com.hartwig.hmftools.common.genome.position.GenomePositionImpl;
 import com.hartwig.hmftools.common.purple.PurpleCommon;
 import com.hartwig.hmftools.common.sv.EnrichedStructuralVariant;
 import com.hartwig.hmftools.common.sv.EnrichedStructuralVariantFactory;
@@ -63,11 +65,11 @@ public class DisruptionComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         final List<StructuralVariantData> svDataList = dbAccess.readStructuralVariantData(sampleId);
         final List<LinxBreakend> breakends = dbAccess.readBreakends(sampleId);
-        return buildBreakends(svDataList, breakends);
+        return buildBreakends(svDataList, breakends, sourceName);
     }
 
     @Override
@@ -92,7 +94,7 @@ public class DisruptionComparer implements ItemComparer
 
             CMP_LOGGER.debug("sample({}) loaded {} SVs {} breakends",sampleId, svDataList.size(), breakends.size());
 
-            return buildBreakends(svDataList, breakends);
+            return buildBreakends(svDataList, breakends, fileSources.Source);
 
         }
         catch(IOException e)
@@ -102,7 +104,7 @@ public class DisruptionComparer implements ItemComparer
         }
     }
 
-    private List<ComparableItem> buildBreakends(final List<StructuralVariantData> svDataList, final List<LinxBreakend> breakends)
+    private List<ComparableItem> buildBreakends(final List<StructuralVariantData> svDataList, final List<LinxBreakend> breakends, final String sourceName)
     {
         List<ComparableItem> items = Lists.newArrayList();
 
@@ -114,7 +116,11 @@ public class DisruptionComparer implements ItemComparer
             {
                 breakends.remove(breakend);
 
-                DisruptionData disruptionData = new DisruptionData(var, breakend);
+                GenomePositionImpl comparisonStartGenomePosition = determineComparisonGenomePosition(
+                        var.startChromosome(), var.startPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+                GenomePositionImpl comparisonEndGenomePosition = determineComparisonGenomePosition(
+                        var.endChromosome(), var.endPosition(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+                DisruptionData disruptionData = new DisruptionData(var, breakend, comparisonStartGenomePosition, comparisonEndGenomePosition);
                 items.add(disruptionData);
             }
         }

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionData.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionData.java
@@ -8,6 +8,7 @@ import static com.hartwig.hmftools.compar.common.MismatchType.VALUE;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import com.hartwig.hmftools.common.genome.position.GenomePositionImpl;
 import com.hartwig.hmftools.common.sv.StructuralVariantData;
 import com.hartwig.hmftools.common.linx.LinxBreakend;
 import com.hartwig.hmftools.compar.common.Category;
@@ -20,16 +21,21 @@ public class DisruptionData implements ComparableItem
 {
     public final StructuralVariantData SvData;
     public final LinxBreakend Breakend;
+    private final GenomePositionImpl mComparisonStartGenomePosition;
+    private final GenomePositionImpl mComparisonEndGenomePosition;
 
     protected static final String FLD_REGION_TYPE = "RegionType";
     protected static final String FLD_CODING_CONTEXT = "CodingContext";
     protected static final String FLD_GENE_ORIENT = "GeneOrientation";
     protected static final String FLD_NEXT_SPLICE = "NextSpliceExonRank";
 
-    public DisruptionData(final StructuralVariantData svData, final LinxBreakend breakend)
+    public DisruptionData(final StructuralVariantData svData, final LinxBreakend breakend,
+            final GenomePositionImpl comparisonStartGenomePosition, final GenomePositionImpl comparisonEndGenomePosition)
     {
         SvData = svData;
         Breakend = breakend;
+        mComparisonStartGenomePosition = comparisonStartGenomePosition;
+        mComparisonEndGenomePosition = comparisonEndGenomePosition;
     }
 
     @Override
@@ -38,9 +44,20 @@ public class DisruptionData implements ComparableItem
     @Override
     public String key()
     {
-        return String.format("%s %d_%s %s:%d-%s:%d",
-                Breakend.gene(), SvData.id(), SvData.type(),
-                SvData.startChromosome(), SvData.startPosition(), SvData.endChromosome(), SvData.endPosition());
+        if(mComparisonStartGenomePosition.position() != SvData.startPosition() || mComparisonEndGenomePosition.position() != SvData.endPosition())
+        {
+            return String.format("%s %d_%s %s:%d-%s:%d liftover(%s:%d-%s:%d)",
+                    Breakend.gene(), SvData.id(), SvData.type(),
+                    SvData.startChromosome(), SvData.startPosition(), SvData.endChromosome(), SvData.endPosition(),
+                    mComparisonStartGenomePosition.chromosome(), mComparisonStartGenomePosition.position(),
+                    mComparisonEndGenomePosition.chromosome(), mComparisonEndGenomePosition.position());
+        }
+        else
+        {
+            return String.format("%s %d_%s %s:%d-%s:%d",
+                    Breakend.gene(), SvData.id(), SvData.type(),
+                    SvData.startChromosome(), SvData.startPosition(), SvData.endChromosome(), SvData.endPosition());
+        }
     }
 
     @Override
@@ -66,10 +83,10 @@ public class DisruptionData implements ComparableItem
         if(otherSv.SvData.type() != SvData.type())
             return false;
 
-        if(!otherSv.SvData.startChromosome().equals(SvData.startChromosome()) || !otherSv.SvData.endChromosome().equals(SvData.endChromosome()))
+        if(!otherSv.SvData.startChromosome().equals(mComparisonStartGenomePosition.chromosome()) || !otherSv.SvData.endChromosome().equals(mComparisonEndGenomePosition.chromosome()))
             return false;
 
-        if(otherSv.SvData.startPosition() != SvData.startPosition() || otherSv.SvData.endPosition() != SvData.endPosition())
+        if(otherSv.SvData.startPosition() != mComparisonStartGenomePosition.position() || otherSv.SvData.endPosition() != mComparisonEndGenomePosition.position())
             return false;
 
         if(otherSv.SvData.startOrientation() != SvData.startOrientation() || otherSv.SvData.endOrientation() != SvData.endOrientation())

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionData.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionData.java
@@ -23,6 +23,7 @@ public class DisruptionData implements ComparableItem
     public final LinxBreakend Breakend;
     private final GenomePositionImpl mComparisonStartGenomePosition;
     private final GenomePositionImpl mComparisonEndGenomePosition;
+    private final boolean mCheckTranscript;
 
     protected static final String FLD_REGION_TYPE = "RegionType";
     protected static final String FLD_CODING_CONTEXT = "CodingContext";
@@ -30,12 +31,14 @@ public class DisruptionData implements ComparableItem
     protected static final String FLD_NEXT_SPLICE = "NextSpliceExonRank";
 
     public DisruptionData(final StructuralVariantData svData, final LinxBreakend breakend,
-            final GenomePositionImpl comparisonStartGenomePosition, final GenomePositionImpl comparisonEndGenomePosition)
+            final GenomePositionImpl comparisonStartGenomePosition, final GenomePositionImpl comparisonEndGenomePosition,
+            final boolean checkTranscript)
     {
         SvData = svData;
         Breakend = breakend;
         mComparisonStartGenomePosition = comparisonStartGenomePosition;
         mComparisonEndGenomePosition = comparisonEndGenomePosition;
+        mCheckTranscript = checkTranscript;
     }
 
     @Override
@@ -92,7 +95,10 @@ public class DisruptionData implements ComparableItem
         if(otherSv.SvData.startOrientation() != SvData.startOrientation() || otherSv.SvData.endOrientation() != SvData.endOrientation())
             return false;
 
-        if(!otherSv.Breakend.transcriptId().equals(Breakend.transcriptId()))
+        if(!otherSv.Breakend.gene().equals(Breakend.gene()))
+            return false;
+
+        if(mCheckTranscript && !otherSv.Breakend.transcriptId().equals(Breakend.transcriptId()))
             return false;
 
         return true;

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionData.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/DisruptionData.java
@@ -98,7 +98,7 @@ public class DisruptionData implements ComparableItem
         if(!otherSv.Breakend.gene().equals(Breakend.gene()))
             return false;
 
-        if(mCheckTranscript && !otherSv.Breakend.transcriptId().equals(Breakend.transcriptId()))
+        if((otherSv.mCheckTranscript || mCheckTranscript) && !otherSv.Breakend.transcriptId().equals(Breakend.transcriptId()))
             return false;
 
         return true;

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/FusionComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/FusionComparer.java
@@ -55,7 +55,7 @@ public class FusionComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         List<LinxFusion> fusions = dbAccess.readFusions(sampleId);
         return processFusions(fusions);

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/GermlineSvComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/GermlineSvComparer.java
@@ -6,6 +6,7 @@ import static com.hartwig.hmftools.compar.common.Category.GERMLINE_SV;
 import static com.hartwig.hmftools.compar.common.CommonUtils.FLD_QUAL;
 import static com.hartwig.hmftools.compar.common.CommonUtils.FLD_REPORTED;
 import static com.hartwig.hmftools.compar.ComparConfig.CMP_LOGGER;
+import static com.hartwig.hmftools.compar.common.CommonUtils.determineComparisonGenomePosition;
 import static com.hartwig.hmftools.compar.linx.GermlineSvData.FLD_GERMLINE_FRAGS;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
+import com.hartwig.hmftools.common.genome.position.GenomePositionImpl;
 import com.hartwig.hmftools.common.linx.LinxBreakend;
 import com.hartwig.hmftools.common.linx.LinxGermlineSv;
 import com.hartwig.hmftools.compar.common.Category;
@@ -60,7 +62,7 @@ public class GermlineSvComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         // final List<StructuralVariantData> svDataList = dbAccess.readStructuralVariantGe(sampleId);
         // currently unsupported
@@ -91,7 +93,11 @@ public class GermlineSvComparer implements ItemComparer
                 for(LinxGermlineSv germlineSv : germlineSvs)
                 {
                     boolean isReported = germlineBreakends.stream().anyMatch(x -> x.svId() == germlineSv.SvId);
-                    items.add(new GermlineSvData(germlineSv, isReported));
+                    GenomePositionImpl comparisonStartGenomePosition = determineComparisonGenomePosition(
+                            germlineSv.ChromosomeStart, germlineSv.PositionStart, fileSources.Source, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+                    GenomePositionImpl comparisonEndGenomePosition = determineComparisonGenomePosition(
+                            germlineSv.ChromosomeEnd, germlineSv.PositionEnd, fileSources.Source, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+                    items.add(new GermlineSvData(germlineSv, isReported, comparisonStartGenomePosition, comparisonEndGenomePosition));
                 }
             }
             else
@@ -110,7 +116,11 @@ public class GermlineSvComparer implements ItemComparer
                     LinxGermlineSv germlineSv = germlineSvs.get(i);
                     String[] values = rawGermlineSvs.get(i).split(TSV_DELIM, -1);
                     boolean isReported = Boolean.parseBoolean(values[reportedIndex]);
-                    items.add(new GermlineSvData(germlineSv, isReported));
+                    GenomePositionImpl comparisonStartGenomePosition = determineComparisonGenomePosition(
+                            germlineSv.ChromosomeStart, germlineSv.PositionStart, fileSources.Source, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+                    GenomePositionImpl comparisonEndGenomePosition = determineComparisonGenomePosition(
+                            germlineSv.ChromosomeEnd, germlineSv.PositionEnd, fileSources.Source, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+                    items.add(new GermlineSvData(germlineSv, isReported, comparisonStartGenomePosition, comparisonEndGenomePosition));
                 }
             }
 

--- a/compar/src/main/java/com/hartwig/hmftools/compar/linx/GermlineSvData.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/linx/GermlineSvData.java
@@ -8,6 +8,7 @@ import static com.hartwig.hmftools.compar.common.MismatchType.VALUE;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import com.hartwig.hmftools.common.genome.position.GenomePositionImpl;
 import com.hartwig.hmftools.common.linx.LinxGermlineSv;
 import com.hartwig.hmftools.compar.common.Category;
 import com.hartwig.hmftools.compar.ComparableItem;
@@ -19,13 +20,18 @@ public class GermlineSvData implements ComparableItem
 {
     public final LinxGermlineSv SvData;
     private final boolean mIsReported;
+    private final GenomePositionImpl mComparisonStartGenomePosition;
+    private final GenomePositionImpl mComparisonEndGenomePosition;
 
     protected static final String FLD_GERMLINE_FRAGS = "GermlineFragments";
 
-    public GermlineSvData(final LinxGermlineSv svData, boolean isReported)
+    public GermlineSvData(final LinxGermlineSv svData, boolean isReported, final GenomePositionImpl comparisonStartGenomePosition,
+            final GenomePositionImpl comparisonEndGenomePosition)
     {
         SvData = svData;
         mIsReported = isReported;
+        mComparisonStartGenomePosition = comparisonStartGenomePosition;
+        mComparisonEndGenomePosition = comparisonEndGenomePosition;
     }
 
     @Override
@@ -34,9 +40,20 @@ public class GermlineSvData implements ComparableItem
     @Override
     public String key()
     {
-        return String.format("%s:%s %s:%d:%d-%s:%d%d %s",
-                SvData.EventId, SvData.Type, SvData.ChromosomeStart, SvData.PositionStart, SvData.OrientStart,
-                SvData.ChromosomeEnd, SvData.PositionEnd, SvData.OrientEnd, SvData.GeneName);
+        if(mComparisonStartGenomePosition.position() != SvData.PositionStart || mComparisonEndGenomePosition.position() != SvData.PositionEnd)
+        {
+            return String.format("%s:%s %s:%d:%d-%s:%d%d %s liftover(%s:%d-%s:%d)",
+                    SvData.EventId, SvData.Type, SvData.ChromosomeStart, SvData.PositionStart, SvData.OrientStart,
+                    SvData.ChromosomeEnd, SvData.PositionEnd, SvData.OrientEnd, SvData.GeneName,
+                    mComparisonStartGenomePosition.chromosome(), mComparisonStartGenomePosition.position(),
+                    mComparisonEndGenomePosition.chromosome(), mComparisonEndGenomePosition.position());
+        }
+        else
+        {
+            return String.format("%s:%s %s:%d:%d-%s:%d%d %s",
+                    SvData.EventId, SvData.Type, SvData.ChromosomeStart, SvData.PositionStart, SvData.OrientStart,
+                    SvData.ChromosomeEnd, SvData.PositionEnd, SvData.OrientEnd, SvData.GeneName);
+        }
     }
 
     @Override
@@ -62,10 +79,10 @@ public class GermlineSvData implements ComparableItem
         if(otherSv.SvData.Type != SvData.Type)
             return false;
 
-        if(!otherSv.SvData.ChromosomeStart.equals(SvData.ChromosomeStart) || !otherSv.SvData.ChromosomeEnd.equals(SvData.ChromosomeEnd))
+        if(!otherSv.SvData.ChromosomeStart.equals(mComparisonStartGenomePosition.chromosome()) || !otherSv.SvData.ChromosomeEnd.equals(mComparisonEndGenomePosition.chromosome()))
             return false;
 
-        if(otherSv.SvData.PositionStart != SvData.PositionStart || otherSv.SvData.PositionEnd != SvData.PositionEnd)
+        if(otherSv.SvData.PositionStart != mComparisonStartGenomePosition.position() || otherSv.SvData.PositionEnd != mComparisonEndGenomePosition.position())
             return false;
 
         if(otherSv.SvData.OrientStart != SvData.OrientStart || otherSv.SvData.OrientEnd != SvData.OrientEnd)

--- a/compar/src/main/java/com/hartwig/hmftools/compar/mutation/GermlineVariantComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/mutation/GermlineVariantComparer.java
@@ -4,11 +4,13 @@ import static com.hartwig.hmftools.common.variant.SomaticVariantFactory.PASS_FIL
 import static com.hartwig.hmftools.compar.common.Category.GERMLINE_VARIANT;
 import static com.hartwig.hmftools.compar.common.CommonUtils.FLD_QUAL;
 import static com.hartwig.hmftools.compar.ComparConfig.CMP_LOGGER;
+import static com.hartwig.hmftools.compar.common.CommonUtils.determineComparisonGenomePosition;
 import static com.hartwig.hmftools.patientdb.database.hmfpatients.Tables.GERMLINEVARIANT;
 
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import com.hartwig.hmftools.common.genome.position.GenomePositionImpl;
 import com.hartwig.hmftools.common.purple.PurpleCommon;
 import com.hartwig.hmftools.common.variant.GermlineVariant;
 import com.hartwig.hmftools.common.variant.GermlineVariantFactory;
@@ -59,7 +61,7 @@ public class GermlineVariantComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         Result<Record> result = dbAccess.context().select()
                 .from(GERMLINEVARIANT)
@@ -71,7 +73,9 @@ public class GermlineVariantComparer implements ItemComparer
         for (Record record : result)
         {
             GermlineVariant variant = GermlineVariantDAO.buildFromRecord(record);
-            variants.add(new GermlineVariantData(variant));
+            GenomePositionImpl comparisonGenomePosition = determineComparisonGenomePosition(
+                    variant.chromosome(), variant.position(), sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+            variants.add(new GermlineVariantData(variant, comparisonGenomePosition));
         }
 
         return variants;
@@ -87,7 +91,15 @@ public class GermlineVariantComparer implements ItemComparer
         try
         {
             List<GermlineVariant> variants = GermlineVariantFactory.fromVCFFile(sampleId, vcfFile);
-            variants.stream().filter(x -> !x.isFiltered()).forEach(x -> comparableItems.add(new GermlineVariantData(x)));
+            for(GermlineVariant variant : variants)
+            {
+                if(!variant.isFiltered())
+                {
+                    GenomePositionImpl comparisonGenomePosition = determineComparisonGenomePosition(
+                            variant.chromosome(), variant.position(), fileSources.Source, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+                    comparableItems.add(new GermlineVariantData(variant, comparisonGenomePosition));
+                }
+            }
 
             CMP_LOGGER.debug("sample({}) loaded {} {} germline variants", sampleId, fileSources.Source, comparableItems.size());
         }

--- a/compar/src/main/java/com/hartwig/hmftools/compar/mutation/SomaticVariantComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/mutation/SomaticVariantComparer.java
@@ -1,8 +1,5 @@
 package com.hartwig.hmftools.compar.mutation;
 
-import static com.hartwig.hmftools.common.genome.refgenome.GenomeLiftoverCache.UNMAPPED_POSITION;
-import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.V37;
-import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.V38;
 import static com.hartwig.hmftools.common.variant.SageVcfTags.LOCAL_PHASE_SET;
 import static com.hartwig.hmftools.common.variant.SomaticVariantFactory.PASS_FILTER;
 import static com.hartwig.hmftools.compar.common.Category.SOMATIC_VARIANT;
@@ -10,7 +7,7 @@ import static com.hartwig.hmftools.compar.common.CommonUtils.FLD_QUAL;
 import static com.hartwig.hmftools.compar.ComparConfig.CMP_LOGGER;
 import static com.hartwig.hmftools.compar.ComparConfig.NEW_SOURCE;
 import static com.hartwig.hmftools.compar.ComparConfig.REF_SOURCE;
-import static com.hartwig.hmftools.compar.common.FileSources.liftoverSourceGenomeVersion;
+import static com.hartwig.hmftools.compar.common.CommonUtils.determineComparisonGenomePosition;
 import static com.hartwig.hmftools.compar.common.MatchLevel.REPORTABLE;
 import static com.hartwig.hmftools.compar.common.MismatchType.INVALID_BOTH;
 import static com.hartwig.hmftools.compar.common.MismatchType.INVALID_NEW;
@@ -21,16 +18,14 @@ import static com.hartwig.hmftools.compar.mutation.SomaticVariantData.FLD_LPS;
 import static com.hartwig.hmftools.compar.mutation.SomaticVariantData.FLD_SUBCLONAL_LIKELIHOOD;
 import static com.hartwig.hmftools.patientdb.database.hmfpatients.tables.Somaticvariant.SOMATICVARIANT;
 
-import static htsjdk.tribble.AbstractFeatureReader.getFeatureReader;
-
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.hartwig.hmftools.common.genome.chromosome.HumanChromosome;
+import com.hartwig.hmftools.common.genome.position.GenomePositionImpl;
 import com.hartwig.hmftools.common.genome.refgenome.RefGenomeFunctions;
-import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.purple.PurpleCommon;
 import com.hartwig.hmftools.common.variant.Hotspot;
 import com.hartwig.hmftools.common.variant.VariantTier;
@@ -89,7 +84,7 @@ public class SomaticVariantComparer implements ItemComparer
 
             if(!mConfig.DbConnections.isEmpty())
             {
-                variants.addAll(loadVariants(sourceSampleId, mConfig.DbConnections.get(sourceName)));
+                variants.addAll(loadVariants(sourceSampleId, mConfig.DbConnections.get(sourceName), sourceName));
             }
             else
             {
@@ -306,14 +301,14 @@ public class SomaticVariantComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         final List<ComparableItem> items = Lists.newArrayList();
-        loadVariants(sampleId, dbAccess).forEach(x -> items.add(x));
+        loadVariants(sampleId, dbAccess, sourceName).forEach(x -> items.add(x));
         return items;
     }
 
-    private List<SomaticVariantData> loadVariants(final String sampleId, final DatabaseAccess dbAccess)
+    private List<SomaticVariantData> loadVariants(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         final List<SomaticVariantData> variants = Lists.newArrayList();
 
@@ -326,7 +321,11 @@ public class SomaticVariantComparer implements ItemComparer
 
         for(Record record : results)
         {
-            variants.add(SomaticVariantData.fromRecord(record));
+            final SomaticVariantData variant = SomaticVariantData.fromRecord(record);
+            GenomePositionImpl comparisonGenomePosition = determineComparisonGenomePosition(
+                    variant.Chromosome, variant.Position, sourceName, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+            variant.setComparisonCoordinates(comparisonGenomePosition.chromosome(), comparisonGenomePosition.position());
+            variants.add(variant);
         }
 
         return variants;
@@ -356,9 +355,6 @@ public class SomaticVariantComparer implements ItemComparer
             return null;
         }
 
-        RefGenomeVersion sourceVersion = liftoverSourceGenomeVersion(fileSources.Source);
-        RefGenomeVersion destVersion = sourceVersion.is37() ? V38 : V37;
-
         for(VariantContext variantContext : vcfFileReader.iterator())
         {
             if(variantContext.isFiltered())
@@ -369,15 +365,11 @@ public class SomaticVariantComparer implements ItemComparer
             if(mConfig.RestrictToDrivers && !mConfig.DriverGenes.contains(variant.Gene))
                 continue;
 
+            GenomePositionImpl comparisonGenomePosition = determineComparisonGenomePosition(
+                    variant.Chromosome, variant.Position, fileSources.Source, mConfig.RequiresLiftover, mConfig.LiftoverCache);
+            variant.setComparisonCoordinates(comparisonGenomePosition.chromosome(), comparisonGenomePosition.position());
+
             variants.add(variant);
-
-            if(mConfig.RequiresLiftover && mConfig.LiftoverCache.hasMappings())
-            {
-                int newPosition = mConfig.LiftoverCache.convertPosition(variant.Chromosome, variant.Position, destVersion);
-
-                if(newPosition != UNMAPPED_POSITION)
-                    variant.setComparisonCoordinates(destVersion.versionedChromosome(variant.Chromosome), newPosition);
-            }
         }
 
         CMP_LOGGER.debug("sample({}) loaded {} {} somatic variants", sampleId, fileSources.Source, variants.size());

--- a/compar/src/main/java/com/hartwig/hmftools/compar/purple/CopyNumberComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/purple/CopyNumberComparer.java
@@ -57,7 +57,7 @@ public class CopyNumberComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         final List<PurpleCopyNumber> copyNumbers = dbAccess.readCopynumbers(sampleId);
         List<ComparableItem> items = Lists.newArrayList();

--- a/compar/src/main/java/com/hartwig/hmftools/compar/purple/GeneCopyNumberComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/purple/GeneCopyNumberComparer.java
@@ -65,7 +65,7 @@ public class GeneCopyNumberComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         List<ComparableItem> items = Lists.newArrayList();
 

--- a/compar/src/main/java/com/hartwig/hmftools/compar/purple/GermlineDeletionComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/purple/GermlineDeletionComparer.java
@@ -56,7 +56,7 @@ public class GermlineDeletionComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         final List<GermlineDeletion> germlineDeletions = dbAccess.readGermlineDeletions(sampleId);
         List<ComparableItem> items = Lists.newArrayList();

--- a/compar/src/main/java/com/hartwig/hmftools/compar/purple/PurityComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/purple/PurityComparer.java
@@ -76,7 +76,7 @@ public class PurityComparer implements ItemComparer
     }
 
     @Override
-    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess)
+    public List<ComparableItem> loadFromDb(final String sampleId, final DatabaseAccess dbAccess, final String sourceName)
     {
         final PurityContext purityContext = dbAccess.readPurityContext(sampleId);
 

--- a/hmf-common/pom.xml
+++ b/hmf-common/pom.xml
@@ -15,6 +15,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.intellij</groupId>
             <artifactId>annotations</artifactId>
         </dependency>

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/genome/position/GenomePositionImpl.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/genome/position/GenomePositionImpl.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Value.Immutable
 @Value.Style(passAnnotations = { NotNull.class, Nullable.class })
-abstract class GenomePositionImpl implements GenomePosition
+public abstract class GenomePositionImpl implements GenomePosition
 {
 
 }


### PR DESCRIPTION
Liftover was only being done for somatic variants when reading from file. Now will be done for somatic and germline variants and disruptions when reading from file or SQL DB.

Also remove strict requirement that transcript IDs are equal for matching somatic disruptions against each other, since this caused unnecessary mismatches when comparing 37 vs 38. Instead of always matching transcript IDs, always match gene names and skip transcript ID matching when the transcripts are both canonical.