### PR TITLE
PatientDB: restore index prefix length of cpctEcrf.itemValue column

### DIFF
--- a/patient-db/src/main/resources/generate_database.sql
+++ b/patient-db/src/main/resources/generate_database.sql
@@ -217,7 +217,9 @@ CREATE INDEX `cpctEcrf_studyEvent` ON `cpctEcrf` (`studyEvent`);
 CREATE INDEX `cpctEcrf_form` ON `cpctEcrf` (`form`);
 CREATE INDEX `cpctEcrf_itemGroup` ON `cpctEcrf` (`itemGroup`);
 CREATE INDEX `cpctEcrf_item` ON `cpctEcrf` (`item`);
-CREATE INDEX `cpctEcrf_itemValue` ON `cpctEcrf` (`itemValue`);
+-- [jooq ignore start]
+CREATE INDEX `cpctEcrf_itemValue` ON `cpctEcrf` (`itemValue`(255));
+-- [jooq ignore stop]
 CREATE INDEX `cpctEcrf_status` ON `cpctEcrf` (`status`);
 CREATE INDEX `cpctEcrf_locked` ON `cpctEcrf` (`locked`);
 CREATE INDEX `cpctEcrf_sequenced` ON `cpctEcrf` (`sequenced`);


### PR DESCRIPTION
MySQL needs an index prefix limit for the `cpctEcrf.itemValue` column, otherwise creating the index fails. Since jOOQ cannot parse the index prefix limit we ignore this index during jOOQ code generation. The index prefix limit value 255 [was used before](https://github.com/hartwigmedical/hmftools/commit/38ba9b11ef59d8ebcccda3ed8956a9d7e92e0f4f#diff-6c4cf5de30b233ee5dc200058d99b17591b120b9793a2ae77a3098611e599d82L219).