### PR TITLE
ACTIN-999: Remove pre-LILAC v1.6 check from ORANGE

### DIFF
--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
@@ -221,12 +221,6 @@ public class OrangeAlgo
             LOGGER.info("Wild-type calling skipped due to insufficient tumor sample quality");
         }
 
-        // TODO update hasRef flag after LILAC v1.6 is released, which fixes tumor-only fragments
-        // being written to the ref field.
-        //   boolean hasRef = config.refSampleWGSMetricsFile() != null && config.refSampleFlagstatFile() != null;
-        boolean hasRef = true;
-        boolean hasRna = config.rnaConfig() != null;
-
         OrangeRecord report = ImmutableOrangeRecord.builder()
                 .sampleId(config.tumorSampleId())
                 .samplingDate(config.samplingDate())
@@ -241,7 +235,7 @@ public class OrangeAlgo
                 .linx(linx)
                 .wildTypeGenes(wildTypeGenes)
                 .isofox(isofox)
-                .lilac(OrangeConversion.convert(lilac, hasRef, hasRna))
+                .lilac(OrangeConversion.convert(lilac, config.wgsRefConfig() != null, config.rnaConfig() != null))
                 .virusInterpreter(virusInterpreter != null ? OrangeConversion.convert(virusInterpreter) : null)
                 .chord(chord != null ? OrangeConversion.convert(chord) : null)
                 .cuppa(cuppa)

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
@@ -221,6 +221,7 @@ public class OrangeAlgo
             LOGGER.info("Wild-type calling skipped due to insufficient tumor sample quality");
         }
 
+        boolean hasRefSample = config.wgsRefConfig() != null && config.wgsRefConfig().referenceSampleId() != null;
         OrangeRecord report = ImmutableOrangeRecord.builder()
                 .sampleId(config.tumorSampleId())
                 .samplingDate(config.samplingDate())
@@ -235,7 +236,7 @@ public class OrangeAlgo
                 .linx(linx)
                 .wildTypeGenes(wildTypeGenes)
                 .isofox(isofox)
-                .lilac(OrangeConversion.convert(lilac, config.wgsRefConfig() != null, config.rnaConfig() != null))
+                .lilac(OrangeConversion.convert(lilac, hasRefSample, config.rnaConfig() != null))
                 .virusInterpreter(virusInterpreter != null ? OrangeConversion.convert(virusInterpreter) : null)
                 .chord(chord != null ? OrangeConversion.convert(chord) : null)
                 .cuppa(cuppa)


### PR DESCRIPTION
LILAC pre v1.6 used to write fragment counts to ref fields in case it was run in tumor-only mode. This has been fixed in LILAC v1.6, and since we depend on that now, we can remove the work-around for this in ORANGE.

With this change, ORANGE assumes tumor fragments are filled in when run in tumor-only mode. 

Have tested using COLO829 tumor+ref and tumor-only. 