### PR TITLE
ACTIN-1007: Set context to "Unknown" for promiscuous enhancer targets

### DIFF
--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/linx/LinxFusion.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/linx/LinxFusion.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 
 import com.google.common.collect.Lists;
+import com.hartwig.hmftools.common.fusion.KnownFusionType;
 import com.hartwig.hmftools.common.gene.TranscriptRegionType;
 
 import org.immutables.value.Value;
@@ -19,30 +20,52 @@ import org.immutables.value.Value;
 public abstract class LinxFusion
 {
     public abstract int fivePrimeBreakendId();
+
     public abstract int threePrimeBreakendId();
+
     public abstract String name();
+
     public abstract boolean reported();
+
     public abstract String reportedType();
+
     public abstract String reportableReasons();
+
     public abstract FusionPhasedType phased();
+
     public abstract FusionLikelihoodType likelihood();
+
     public abstract int chainLength();
+
     public abstract int chainLinks();
+
     public abstract boolean chainTerminated();
+
     public abstract String domainsKept();
+
     public abstract String domainsLost();
+
     public abstract int skippedExonsUp();
+
     public abstract int skippedExonsDown();
+
     public abstract int fusedExonUp();
+
     public abstract int fusedExonDown();
 
     // for patient report
     public abstract String geneStart();
+
     public abstract String geneContextStart();
+
     public abstract String geneTranscriptStart();
+
     public abstract String geneEnd();
+
     public abstract String geneContextEnd();
+
     public abstract String geneTranscriptEnd();
+
     public abstract Double junctionCopyNumber();
 
     private static final String FILE_EXTENSION = ".linx.fusion.tsv";
@@ -75,7 +98,7 @@ public abstract class LinxFusion
         final String header = lines.get(0);
         lines.remove(0);
 
-        Map<String,Integer> fieldsIndexMap = createFieldsIndexMap(header, TSV_DELIM);
+        Map<String, Integer> fieldsIndexMap = createFieldsIndexMap(header, TSV_DELIM);
 
         List<LinxFusion> fusions = Lists.newArrayList();
 
@@ -178,9 +201,9 @@ public abstract class LinxFusion
                 .toString();
     }
 
-    public static String context(final TranscriptRegionType regionType, int fusedExon)
+    public static String context(final TranscriptRegionType regionType, final KnownFusionType knownType, int fusedExon)
     {
-        switch (regionType)
+        switch(regionType)
         {
             case UPSTREAM:
                 return "Promoter Region";
@@ -191,9 +214,20 @@ public abstract class LinxFusion
             case EXONIC:
             case INTRONIC:
                 return String.format("Exon %d", fusedExon);
+            case UNKNOWN:
+            {
+                if(knownType == KnownFusionType.PROMISCUOUS_ENHANCER_TARGET)
+                {
+                    return "Unknown";
+                }
+                else
+                {
+                    return String.format("ERROR: %s", regionType);
+                }
+            }
         }
 
-        return String.format("ERROR: %s", regionType);
+        throw new IllegalStateException("TranscriptRegionType not supported in determination of fusion context: " + regionType);
     }
 
     public static double fusionJcn(double downstreamJcn, double upstreamJcn)

--- a/hmf-common/src/test/java/com/hartwig/hmftools/common/linx/LinxFusionTest.java
+++ b/hmf-common/src/test/java/com/hartwig/hmftools/common/linx/LinxFusionTest.java
@@ -1,0 +1,23 @@
+package com.hartwig.hmftools.common.linx;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.hartwig.hmftools.common.fusion.KnownFusionType;
+import com.hartwig.hmftools.common.gene.TranscriptRegionType;
+
+import org.junit.Test;
+
+public class LinxFusionTest
+{
+    @Test
+    public void canGenerateContextForAllTranscriptRegionTypesAndKnownTypes()
+    {
+        for(TranscriptRegionType regionType : TranscriptRegionType.values())
+        {
+            for(KnownFusionType knownType : KnownFusionType.values())
+            {
+                assertNotNull(LinxFusion.context(regionType, knownType, 0));
+            }
+        }
+    }
+}

--- a/linx/src/main/java/com/hartwig/hmftools/linx/fusion/FusionWriter.java
+++ b/linx/src/main/java/com/hartwig/hmftools/linx/fusion/FusionWriter.java
@@ -4,11 +4,11 @@ import static com.hartwig.hmftools.common.fusion.FusionCommon.FS_DOWN;
 import static com.hartwig.hmftools.common.fusion.FusionCommon.FS_UP;
 import static com.hartwig.hmftools.common.linx.LinxBreakend.BREAKEND_ORIENTATION_DOWNSTREAM;
 import static com.hartwig.hmftools.common.linx.LinxBreakend.BREAKEND_ORIENTATION_UPSTREAM;
+import static com.hartwig.hmftools.common.linx.LinxFusion.context;
+import static com.hartwig.hmftools.common.linx.LinxFusion.fusionJcn;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBufferedWriter;
 import static com.hartwig.hmftools.common.utils.sv.StartEndIterator.SE_END;
 import static com.hartwig.hmftools.common.utils.sv.StartEndIterator.SE_START;
-import static com.hartwig.hmftools.common.linx.LinxFusion.context;
-import static com.hartwig.hmftools.common.linx.LinxFusion.fusionJcn;
 import static com.hartwig.hmftools.linx.LinxConfig.LNX_LOGGER;
 
 import java.io.BufferedWriter;
@@ -18,14 +18,14 @@ import java.util.Map;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.hartwig.hmftools.linx.gene.BreakendGeneData;
-import com.hartwig.hmftools.linx.gene.BreakendTransData;
 import com.hartwig.hmftools.common.linx.ImmutableLinxBreakend;
 import com.hartwig.hmftools.common.linx.ImmutableLinxFusion;
 import com.hartwig.hmftools.common.linx.LinxBreakend;
 import com.hartwig.hmftools.common.linx.LinxFusion;
 import com.hartwig.hmftools.linx.CohortDataWriter;
 import com.hartwig.hmftools.linx.CohortFileInterface;
+import com.hartwig.hmftools.linx.gene.BreakendGeneData;
+import com.hartwig.hmftools.linx.gene.BreakendTransData;
 
 public class FusionWriter implements CohortFileInterface
 {
@@ -43,7 +43,7 @@ public class FusionWriter implements CohortFileInterface
             final List<LinxFusion> fusions, final List<LinxBreakend> breakends)
     {
         int breakendId = 0;
-        Map<BreakendTransData,Integer> transIdMap = Maps.newHashMap();
+        Map<BreakendTransData, Integer> transIdMap = Maps.newHashMap();
 
         for(final BreakendTransData transcript : transcripts)
         {
@@ -70,7 +70,9 @@ public class FusionWriter implements CohortFileInterface
                     .exonicBasePhase(transcript.Phase)
                     .nextSpliceExonRank(transcript.nextSpliceExonRank())
                     .nextSpliceExonPhase(transcript.Phase)
-                    .nextSpliceDistance(transcript.isUpstream() ? transcript.prevSpliceAcceptorDistance() : transcript.nextSpliceAcceptorDistance())
+                    .nextSpliceDistance(transcript.isUpstream()
+                            ? transcript.prevSpliceAcceptorDistance()
+                            : transcript.nextSpliceAcceptorDistance())
                     .totalExonCount(transcript.TransData.exons().size())
                     .chromosome(gene.chromosome())
                     .orientation(gene.orientation())
@@ -106,10 +108,12 @@ public class FusionWriter implements CohortFileInterface
                     .fusedExonDown(geneFusion.getFusedExon(false))
                     .geneStart(geneFusion.geneName(FS_UP))
                     .geneTranscriptStart(geneFusion.upstreamTrans().transName())
-                    .geneContextStart(context(geneFusion.upstreamTrans().regionType(), geneFusion.getFusedExon(true)))
+                    .geneContextStart(context(geneFusion.upstreamTrans()
+                            .regionType(), geneFusion.knownType(), geneFusion.getFusedExon(true)))
                     .geneEnd(geneFusion.geneName(FS_DOWN))
                     .geneTranscriptEnd(geneFusion.downstreamTrans().transName())
-                    .geneContextEnd(context(geneFusion.downstreamTrans().regionType(), geneFusion.getFusedExon(false)))
+                    .geneContextEnd(context(geneFusion.downstreamTrans()
+                            .regionType(), geneFusion.knownType(), geneFusion.getFusedExon(false)))
                     .junctionCopyNumber(fusionJcn(geneFusion.upstreamTrans().gene().jcn(), geneFusion.downstreamTrans().gene().jcn()))
                     .build());
         }
@@ -118,7 +122,9 @@ public class FusionWriter implements CohortFileInterface
     public void writeSampleData(final String sampleId, final List<LinxFusion> fusions, final List<LinxBreakend> breakends)
     {
         if(mOutputDir == null)
+        {
             return;
+        }
 
         try
         {
@@ -138,7 +144,10 @@ public class FusionWriter implements CohortFileInterface
     private static final String COHORT_WRITER_FUSION = "Fusion";
 
     @Override
-    public String fileType() { return COHORT_WRITER_FUSION; }
+    public String fileType()
+    {
+        return COHORT_WRITER_FUSION;
+    }
 
     @Override
     public BufferedWriter createWriter(final String outputDir)
@@ -188,7 +197,7 @@ public class FusionWriter implements CohortFileInterface
             writer.newLine();
             return writer;
         }
-        catch (final IOException e)
+        catch(final IOException e)
         {
             LNX_LOGGER.error("error writing fusions: {}", e.toString());
             return null;
@@ -241,8 +250,8 @@ public class FusionWriter implements CohortFileInterface
         }
 
         sb.append(String.format(",%s,%s,%f,%d",
-                    fusion.downstreamTrans().getProteinFeaturesKept(), fusion.downstreamTrans().getProteinFeaturesLost(),
-                    fusion.priority(), fusion.id()));
+                fusion.downstreamTrans().getProteinFeaturesKept(), fusion.downstreamTrans().getProteinFeaturesLost(),
+                fusion.priority(), fusion.id()));
 
         String chainInfo = String.format(",%s,%s", annotations.terminatedUp(), annotations.terminatedDown());
 


### PR DESCRIPTION
Note: Have changed the catch-all in the context function to an exception rather than "ERROR" string since all current transcript region types are now covered.

For extra safety, added a unit test that will fail in case someone would add a new type of TranscriptRegionType. 