### PR TITLE
ACTIN-1010: Add workaround for some orange to isofox cancer type mappings

### DIFF
--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/isofox/IsofoxDataLoader.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/isofox/IsofoxDataLoader.java
@@ -30,9 +30,9 @@ public final class IsofoxDataLoader
         LOGGER.info((" Loaded summary from " + isofoxSummaryCsv));
 
         GeneExpressionDistributionData geneDistributionData = new GeneExpressionDistributionData(isofoxGeneDistributionCsv);
-        if(!geneDistributionData.configuredCancerTypes().contains(isofoxCancerType))
+        if(isofoxCancerType != null && !geneDistributionData.configuredCancerTypes().contains(isofoxCancerType))
         {
-            throw new IllegalStateException("Cancer type does not exist as cohort in gene distribution data: " + isofoxCancerType);
+            throw new IllegalStateException("Cancer type does not exist as cohort in isofox gene distribution data: " + isofoxCancerType);
         }
 
         List<GeneExpression> geneExpressions =

--- a/orange/README.md
+++ b/orange/README.md
@@ -259,6 +259,8 @@ investigate potential causes for QC failure.
 
 ## Version History and Download Links
 
+- Upcoming
+    - Workaround added for bug with mapping various ORANGE cohorts to non-existing ISOFOX cohorts.  
 - [3.5.0](https://github.com/hartwigmedical/hmftools/releases/tag/orange-v3.5.0)
     - Add `PurpleTranscriptImpact.reported` and make `PurpleVariant.reported` a derived field. This
       uses the REPORTABLE_TRANSCRIPTS vcf field introduced in PURPLE 4.0.

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/OrangeAlgo.java
@@ -487,11 +487,28 @@ public class OrangeAlgo
             return null;
         }
 
-        String isofoxCancerType = cohortMapper.cancerTypeForSample(createSample(config));
-        if(isofoxCancerType == null)
+        String orangeCancerType = cohortMapper.cancerTypeForSample(createSample(config));
+        if(orangeCancerType == null)
         {
-            LOGGER.warn("Could not resolve isofox cancer type for {}", config.tumorSampleId());
+            LOGGER.warn("Could not resolve ORANGE cancer type for {}", config.tumorSampleId());
             return null;
+        }
+
+        String isofoxCancerType;
+        // TODO (KD): Replace with unified cohort mapping code (see also ACTIN-1010)
+        if(orangeCancerType.equals("Ovary/Fallopian tube"))
+        {
+            isofoxCancerType = "Ovary";
+            LOGGER.debug("Converted orange cancer type '{}' to isofox cancer type '{}'", orangeCancerType, isofoxCancerType);
+        }
+        else if(orangeCancerType.equals("Unknown"))
+        {
+            isofoxCancerType = null;
+            LOGGER.debug("Converted orange cancer type '{}' to null isofox cancer type", orangeCancerType);
+        }
+        else
+        {
+            isofoxCancerType = orangeCancerType;
         }
 
         return IsofoxDataLoader.load(isofoxCancerType,

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <lilac.version>1.7</lilac.version>
         <linx.version>2.0</linx.version>
         <neo.version>1.2</neo.version>
-        <orange.version>3.5.0</orange.version>
+        <orange.version>3.5.1</orange.version>
         <orange-datamodel.version>2.6.0</orange-datamodel.version>
         <paddle.version>1.1</paddle.version>
         <patient-db.version>6.0</patient-db.version>


### PR DESCRIPTION
Note: Have tested 3.4.0 vs 3.5.1 on:
 - Sample with orange type "Ovary/Fallopian tube"
 - Sample with orange type "Esophagus"
 - Sample with orange type "Unknown"