### PR TITLE
ACTIN-1057: Filter NaN likelihoods from CUPPA when converting in ORANGE

### DIFF
--- a/orange/README.md
+++ b/orange/README.md
@@ -259,8 +259,10 @@ investigate potential causes for QC failure.
 
 ## Version History and Download Links
 
+- Upcoming
+    - Cuppa predictions with NaN likelihood are filtered in the ORANGE conversion of CUPPA results
 - [3.5.1](https://github.com/hartwigmedical/hmftools/releases/tag/orange-v3.5.1)
-    - Workaround added for bug with mapping various ORANGE cohorts to non-existing ISOFOX cohorts.  
+    - Workaround added for bug with mapping various ORANGE cohorts to non-existing ISOFOX cohorts.
 - [3.5.0](https://github.com/hartwigmedical/hmftools/releases/tag/orange-v3.5.0)
     - Add `PurpleTranscriptImpact.reported` and make `PurpleVariant.reported` a derived field. This
       uses the REPORTABLE_TRANSCRIPTS vcf field introduced in PURPLE 4.0.

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/cuppa/CuppaDataFactory.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/cuppa/CuppaDataFactory.java
@@ -79,7 +79,7 @@ public final class CuppaDataFactory
                     .altSjCohortClassifier(probabilitiesByClassifier.get(ClassifierName.ALT_SJ))
                     .build();
 
-            // If a classifier has no data for a specific cancer type we should remove it completely, see ACTIN-1057
+            // If a classifier has no data for a specific cancer type we should remove it completely.
             if(!Double.isNaN(convertedPrediction.likelihood()))
             {
                 convertedCuppaPredictions.add(convertedPrediction);

--- a/orange/src/test/java/com/hartwig/hmftools/orange/algo/cuppa/CuppaDataFactoryTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/algo/cuppa/CuppaDataFactoryTest.java
@@ -58,11 +58,12 @@ public class CuppaDataFactoryTest
                 .build();
 
         Map<String, CuppaPrediction> expectedPredictionsByCancerType = new HashMap<>();
-        expectedPredictionsByCancerType.put("Skin: Melanoma", expectedPredictionMelanoma);
-        expectedPredictionsByCancerType.put("Skin: Other", expectedPredictionSkinOther);
-        expectedPredictionsByCancerType.put("Prostate", expectedPredictionProstate);
+        expectedPredictionsByCancerType.put(expectedPredictionMelanoma.cancerType(), expectedPredictionMelanoma);
+        expectedPredictionsByCancerType.put(expectedPredictionSkinOther.cancerType(), expectedPredictionSkinOther);
+        expectedPredictionsByCancerType.put(expectedPredictionProstate.cancerType(), expectedPredictionProstate);
+        expectedPredictionsByCancerType.put("Bone/Soft tissue: Cartilaginous neoplasm", null);
 
-        assertCuppaPredictions(CUPPA_VIS_DATA_WITH_RNA_TSV, expectedPredictionsByCancerType);
+        assertCuppaPredictions(CUPPA_VIS_DATA_WITH_RNA_TSV, 33, expectedPredictionsByCancerType);
     }
 
     @Test
@@ -89,13 +90,21 @@ public class CuppaDataFactoryTest
                 .snvPairwiseClassifier(9.922426122823756e-16)
                 .featureClassifier(0.00012385594573787126)
                 .build();
+        CuppaPrediction expectedPredictionCartilaginousNeoplasm = ImmutableCuppaPrediction.builder()
+                .cancerType("Bone/Soft tissue: Cartilaginous neoplasm")
+                .likelihood(3.289402919513386e-05)
+                .genomicPositionClassifier(4.107161442240924e-10)
+                .snvPairwiseClassifier(4.414947168645547e-16)
+                .featureClassifier(1.4125023004735242e-09)
+                .build();
 
         Map<String, CuppaPrediction> expectedPredictionsByCancerType = new HashMap<>();
-        expectedPredictionsByCancerType.put("Skin: Melanoma", expectedPredictionMelanoma);
-        expectedPredictionsByCancerType.put("Skin: Other", expectedPredictionSkinOther);
-        expectedPredictionsByCancerType.put("Prostate", expectedPredictionProstate);
+        expectedPredictionsByCancerType.put(expectedPredictionMelanoma.cancerType(), expectedPredictionMelanoma);
+        expectedPredictionsByCancerType.put(expectedPredictionSkinOther.cancerType(), expectedPredictionSkinOther);
+        expectedPredictionsByCancerType.put(expectedPredictionProstate.cancerType(), expectedPredictionProstate);
+        expectedPredictionsByCancerType.put(expectedPredictionCartilaginousNeoplasm.cancerType(), expectedPredictionCartilaginousNeoplasm);
 
-        assertCuppaPredictions(CUPPA_VIS_DATA_WITHOUT_RNA_TSV, expectedPredictionsByCancerType);
+        assertCuppaPredictions(CUPPA_VIS_DATA_WITHOUT_RNA_TSV, 40, expectedPredictionsByCancerType);
     }
 
     @Test
@@ -117,12 +126,13 @@ public class CuppaDataFactoryTest
     }
 
     private static void assertCuppaPredictions(@NotNull String inputFileName,
+            int expectedPredictionSize,
             @NotNull Map<String, CuppaPrediction> expectedPredictionsByCancerType) throws Exception
     {
         CuppaData cuppaData = CuppaDataFactory.create(inputFileName);
         List<CuppaPrediction> predictionEntries = cuppaData.predictions();
 
-        assertEquals(40, predictionEntries.size());
+        assertEquals(expectedPredictionSize, predictionEntries.size());
         assertEquals("Skin: Melanoma", cuppaData.bestPrediction().cancerType());
 
         Map<String, CuppaPrediction> actualPredictionsByCancerType = new HashMap<>();
@@ -135,13 +145,19 @@ public class CuppaDataFactoryTest
         {
             CuppaPrediction expectedPrediction = expectedPredictionsByCancerType.get(cancerType);
             CuppaPrediction actualPrediction = actualPredictionsByCancerType.get(cancerType);
-
-            assertEquals(expectedPrediction.likelihood(), actualPrediction.likelihood(), EPSILON);
-            assertEqualsNullableDouble(expectedPrediction.genomicPositionClassifier(), actualPrediction.genomicPositionClassifier());
-            assertEqualsNullableDouble(expectedPrediction.snvPairwiseClassifier(), actualPrediction.snvPairwiseClassifier());
-            assertEqualsNullableDouble(expectedPrediction.featureClassifier(), actualPrediction.featureClassifier());
-            assertEqualsNullableDouble(expectedPrediction.expressionPairwiseClassifier(), actualPrediction.expressionPairwiseClassifier());
-            assertEqualsNullableDouble(expectedPrediction.altSjCohortClassifier(), actualPrediction.altSjCohortClassifier());
+            if(expectedPrediction == null)
+            {
+                assertNull(actualPrediction);
+            }
+            else
+            {
+                assertEquals(expectedPrediction.likelihood(), actualPrediction.likelihood(), EPSILON);
+                assertEqualsNullableDouble(expectedPrediction.genomicPositionClassifier(), actualPrediction.genomicPositionClassifier());
+                assertEqualsNullableDouble(expectedPrediction.snvPairwiseClassifier(), actualPrediction.snvPairwiseClassifier());
+                assertEqualsNullableDouble(expectedPrediction.featureClassifier(), actualPrediction.featureClassifier());
+                assertEqualsNullableDouble(expectedPrediction.expressionPairwiseClassifier(), actualPrediction.expressionPairwiseClassifier());
+                assertEqualsNullableDouble(expectedPrediction.altSjCohortClassifier(), actualPrediction.altSjCohortClassifier());
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <lilac.version>1.7</lilac.version>
         <linx.version>2.0</linx.version>
         <neo.version>1.2</neo.version>
-        <orange.version>3.5.1</orange.version>
+        <orange.version>3.6.0</orange.version>
         <orange-datamodel.version>2.6.0</orange-datamodel.version>
         <paddle.version>1.1</paddle.version>
         <patient-db.version>6.0</patient-db.version>


### PR DESCRIPTION
Have tested on data-vm and confirmed this ORANGE version creates a JSON file which can be ingested into ACTIN (no NaN exception anymore). 