### PR TITLE
INFRA-541 Build Orange Docker container

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,10 @@ steps:
     name: 'eu.gcr.io/hmf-build/jdk-mvn-python'
     entrypoint: 'python3'
     args: ['hmftools-build.py', '$TAG_NAME']
-
+  - id: 'Publish Docker image'
+    name: 'eu.gcr.io/hmf-build/docker-tag'
+    entrypoint: sh
+    args: ['/workspace/docker.sh']
 logsBucket: 'gs://hmf-build-logs'
 timeout: 1800s
 images:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'Fetch token for github'
-  - name: gcr.io/cloud-builders/gcloud
+    name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'
     args: [ '-c', "gcloud secrets versions access latest --secret=hmftools-github-release-token --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/github.token" ]
   - id: 'Tag, release, build'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,8 @@
 steps:
+  - id: 'Fetch token for github'
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: 'bash'
+    args: [ '-c', "gcloud secrets versions access latest --secret=hmftools-github-release-token --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/github.token" ]
   - id: 'Tag, release, build'
     name: 'eu.gcr.io/hmf-build/jdk-mvn-python'
     entrypoint: 'python3'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,10 @@ steps:
     name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'
     args: [ '-c', "gcloud secrets versions access latest --secret=hmftools-github-release-token --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/github.token" ]
+  - id: 'Fetch password for Dockerhub'
+    name: gcr.io/cloud-builders/gcloud
+    entrypoint: 'bash'
+    args: [ '-c', "gcloud secrets versions access latest --secret=hmftools-dockerhub-password --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/dockerhub.password" ]
   - id: 'Tag, release, build'
     name: 'eu.gcr.io/hmf-build/jdk-mvn-python'
     entrypoint: 'python3'

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -103,7 +103,7 @@ class Release:
         base_url="{}/{}/assets?name".format(self._construct_url("uploads"), id)
         response = requests.post(f"{base_url}={self.module}_v{self.version}.jar", 
                 headers = headers, 
-                data = this.artifact_file.read())
+                data = self.artifact_file.read())
         response.raise_for_status()
         print(f"Uploaded {artifact.name}")
 

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -70,7 +70,7 @@ class Release:
         self._upload_artifacts(id)
 
     def _create_release(self):
-        print(f"Creating release {self.release_name}")
+        print(f"Creating release [{self.release_name}]")
         request = {"tag_name": self.release_name,
                 "target_commitish": "master",
                 "name": self.release_name,
@@ -86,6 +86,7 @@ class Release:
         response = requests.post(self._construct_url("api"),
                 json = request,
                 headers = headers)
+        print(f"Response: {response.text}")
         response.raise_for_status()
         return response.json()["id"]
 
@@ -166,7 +167,7 @@ def build_and_release(raw_tag: str):
     Maven.deploy_all(module_pom, *dependencies_pom)
 
     Docker(module, version).build()
-    Release(f"{module} v{tag}", [open(f"/workspace/{module}/target/{module}-{version}-jar-with-dependencies.jar", "rb")], 
+    Release(f"{module} v{version}", [open(f"/workspace/{module}/target/{module}-{version}-jar-with-dependencies.jar", "rb")], 
             open("/workspace/github.token", "r").read()).create()
 
 if __name__ == '__main__':

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -16,6 +16,8 @@ Example:
 """
 import re
 import subprocess
+import requests
+import os.path
 from xml.etree import ElementTree
 from argparse import ArgumentParser
 

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -105,7 +105,7 @@ class Release:
                 headers = headers, 
                 data = self.artifact_file.read())
         response.raise_for_status()
-        print(f"Uploaded {artifact.name}")
+        print(f"Uploaded {self.artifact_file.name}")
 
     def _construct_url(self, prefix):
         return f"https://{prefix}.github.com/repos/hartwigmedical/hmftools/releases"

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -79,7 +79,7 @@ class GithubRelease:
                 "target_commitish": "master",
                 "name": self.release_name,
                 "body": f"Description of release {self.release_name}",
-                "prerelease": False,
+                "prerelease": True,
                 "generate_release_notes": True
         }
         headers = {"Accept": "application/vnd.github+json",

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -164,9 +164,8 @@ def build_and_release(raw_tag: str):
     Maven.deploy_all(module_pom, *dependencies_pom)
 
     Docker(module, version).build()
-    token = open("/workspace/github.token", "r").read()
-    Release(f"{module} v{tag}", [open(f"target/{module}-{version}-jar-with-dependencies.jar", "rb")], token).create()
-
+    Release(f"{module} v{tag}", [open(f"/workspace/{module}/target/{module}-{version}-jar-with-dependencies.jar", "rb")], 
+            open("/workspace/github.token", "r").read()).create()
 
 if __name__ == '__main__':
     main()

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -49,13 +49,14 @@ class Docker:
     def __init__(self, module, version):
         self.module = module
         self.version = version
-        self.internal_image = f'europe-west4-docker.pkg.dev/hmf-build/hmf-docker/{self.module}:{self.version}'
-        self.external_image = f'europe-west4-docker.pkg.dev/hmf-build/build-registry-docker/{self.module}:{self.version}'
+        self.private_image = f'europe-west4-docker.pkg.dev/hmf-build/hmf-docker/{self.module}:{self.version}'
+        self.public_image = f'hartwigmedicalfoundation/{self.module}:{self.version}'
 
     def build(self):
         with open("/workspace/docker.sh", "w") as output:
-            output.write(f'docker build {self.module} -t {self.internal_image} --build-arg VERSION={self.version}\n')
-            output.write(f'docker push {self.internal_image}\n')
+            output.write(f'docker build {self.module} -t {self.private_image} -t {self.public_image} --build-arg VERSION={self.version}\n')
+            output.write(f'docker push {self.private_image}\n')
+            output.write(f'docker push {self.public_image}\n')
 
 
 class Release:

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -101,7 +101,9 @@ class Release:
                 "Content-Type": "application/octet-stream"
         }
         base_url="{}/{}/assets?name".format(self._construct_url("uploads"), id)
-        response = requests.post(f"{base_url}={self.module}_v{self.version}.jar", headers = headers, data = artifact_file.read())
+        response = requests.post(f"{base_url}={self.module}_v{self.version}.jar", 
+                headers = headers, 
+                data = this.artifact_file.read())
         response.raise_for_status()
         print(f"Uploaded {artifact.name}")
 

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -59,10 +59,13 @@ class Docker:
 
 
 class Release:
-    def __init__(self, release_name, artifact_files, token):
-        self.release_name = release_name
+    def __init__(self, tag_name, module, version, artifact_files, token):
+        self.tag_name = tag_name
+        self.module = module
+        self.version = version
         self.artifact_files = artifact_files
         self.token = token
+        self.release_name = f"{module} v{version}"
 
     def create(self):
         id = self._create_release()
@@ -71,7 +74,7 @@ class Release:
 
     def _create_release(self):
         print(f"Creating release [{self.release_name}]")
-        request = {"tag_name": self.release_name,
+        request = {"tag_name": self.tag_name,
                 "target_commitish": "master",
                 "name": self.release_name,
                 "body": f"Description of release {self.release_name}",
@@ -167,7 +170,7 @@ def build_and_release(raw_tag: str):
     Maven.deploy_all(module_pom, *dependencies_pom)
 
     Docker(module, version).build()
-    Release(f"{module} v{version}", [open(f"/workspace/{module}/target/{module}-{version}-jar-with-dependencies.jar", "rb")], 
+    Release(raw_tag, module, version, [open(f"/workspace/{module}/target/{module}-{version}-jar-with-dependencies.jar", "rb")], 
             open("/workspace/github.token", "r").read()).create()
 
 if __name__ == '__main__':

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -102,7 +102,7 @@ class Release:
         }
         base_url="{}/{}/assets?name".format(self._construct_url("uploads"), id)
         for artifact in self.artifact_files:
-            response = requests.post(f"{base_url}={os.path.basename(artifact.name)}",
+            response = requests.post(f"{base_url}={self.module}_v{self.version}.jar",
                     headers = headers,
                     data = artifact.read())
             response.raise_for_status()

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -56,6 +56,7 @@ class Docker:
         with open("/workspace/docker.sh", "w") as output:
             output.write(f'docker build {self.module} -t {self.private_image} -t {self.public_image} --build-arg VERSION={self.version}\n')
             output.write(f'docker push {self.private_image}\n')
+            output.write(f'docker login -u hartwigmedicalfoundation -p $(cat /workspace/dockerhub.password)\n')
             output.write(f'docker push {self.public_image}\n')
 
 

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -77,7 +77,7 @@ class Release:
                 "generate_release_notes": True
         }
         headers = {"Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {token}",
+                "Authorization": f"Bearer {self.token}",
                 "X-GitHub-Api-Version": "2022-11-28"
         }
 
@@ -90,7 +90,7 @@ class Release:
     def _upload_artifacts(self, id):
         print(f"Uploading artifacts to release {id}")
         headers = {"Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {token}",
+                "Authorization": f"Bearer {self.token}",
                 "X-GitHub-Api-Version": "2022-11-28",
                 "Content-Type": "application/octet-stream"
         }

--- a/orange/Dockerfile
+++ b/orange/Dockerfile
@@ -4,4 +4,4 @@ RUN mkdir /usr/share/hartwig
 ARG VERSION
 ADD target/orange-$VERSION-jar-with-dependencies.jar /usr/share/hartwig/orange.jar
 
-ENTRYPOINT ["java", "-jar", "/usr/share/hartwig/orange.jar"]
+ENTRYPOINT ["sleep", "3600"]

--- a/orange/Dockerfile
+++ b/orange/Dockerfile
@@ -4,4 +4,4 @@ RUN mkdir /usr/share/hartwig
 ARG VERSION
 ADD target/orange-$VERSION-jar-with-dependencies.jar /usr/share/hartwig/orange.jar
 
-ENTRYPOINT ["sleep", "3600"]
+ENTRYPOINT ["java", "-jar", "/usr/share/hartwig/orange.jar"]

--- a/orange/Dockerfile
+++ b/orange/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:17-alpine
+
+RUN mkdir /usr/share/hartwig
+ARG VERSION
+ADD target/orange-$VERSION-jar-with-dependencies.jar /usr/share/hartwig/orange.jar
+
+ENTRYPOINT ["java", "-jar", "/usr/share/hartwig/orange.jar"]


### PR DESCRIPTION
Add the creation of a Docker container to the building of `hmftools` modules. Does not do the Docker part if there is no Dockerfile for the module.

I've leveraged the Python script to do the heavy lifting but since the containers used in the build environment are quite modular I opted to generate the Docker-related commands for execution by a subsequent stage. I feel given the simplicity of the build overall this is acceptable.