### PR TITLE
INFRA-653 Switch to Github app authentication

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - id: 'Fetch token for github'
     name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'
-    args: [ '-c', "gcloud secrets versions access latest --secret=hmftools-github-release-token --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/github.token" ]
+    args: [ '-c', "gcloud secrets versions access latest --secret=hmftools-github-private-key --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/github.key" ]
   - id: 'Fetch password for Dockerhub'
     name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'
@@ -10,7 +10,7 @@ steps:
   - id: 'Tag, release, build'
     name: 'eu.gcr.io/hmf-build/jdk-mvn-python'
     entrypoint: 'python3'
-    args: ['hmftools-build.py', '$TAG_NAME']
+    args: ['hmftools-build.py', '$TAG_NAME', '/workspace/github.key', '${_GITHUB_CLIENT_ID}', '${_GITHUB_INSTALLATION_ID}']
   - id: 'Publish Docker image'
     name: 'eu.gcr.io/hmf-build/docker-tag'
     entrypoint: sh

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -130,7 +130,7 @@ class GithubRelease:
         response.raise_for_status()
         return response.json()["token"]
 
-    def _headers(self, jwt: str):
+    def _headers(self, token: str):
         return {"Accept": "application/vnd.github+json",
                 "Authorization": f"Bearer {token}",
                 "X-GitHub-Api-Version": "2022-11-28"

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -120,7 +120,7 @@ class GithubRelease:
             'iat': int(time.time()),
             # JWT expiration time (10 minutes maximum)
             'exp': int(time.time()) + 600,
-            'iss': self.client_id
+            'iss': self.github_client_id
         }
         return jwt.encode(payload, self.private_key, algorithm='RS256')
 

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -159,15 +159,15 @@ def main():
     parser = ArgumentParser(
         description="A tool for automatically building and deploying individual modules in HMF-tools.")
     parser.add_argument('tag', help="The semantic versioning tag in the following format: <tool-name>-<version>")
-    parser.add_argument('github-key-path', help="Path to private key for the Github deployment bot")
-    parser.add_argument('github-client-id', help="Client id for the deployment bot")
-    parser.add_argument('github-installation-id', help="Installation id of the deployment bot")
+    parser.add_argument('github_key_path', help="Path to private key for the Github deployment bot")
+    parser.add_argument('github_client_id', help="Client id for the deployment bot")
+    parser.add_argument('github_installation_id', help="Installation id of the deployment bot")
     args = parser.parse_args()
 
-    build_and_release(args.tag, args.github-key-path, args.github-client-id, args.github-installation-id)
+    build_and_release(args.tag, args.github_key_path, args.github_client_id, args.github_installation_id)
 
 
-def build_and_release(raw_tag: str, github-key: str, github-client-id: str, github-installation-id: str):
+def build_and_release(raw_tag: str, github_key: str, github_client-id: str, github_installation-id: str):
     match = SEMVER_REGEX.match(raw_tag)
     if not match:
         print(f"Invalid tag: '{raw_tag}' (it does not match the regex pattern: '{SEMVER_REGEX.pattern}')")
@@ -198,7 +198,7 @@ def build_and_release(raw_tag: str, github-key: str, github-client-id: str, gith
 
     Docker(module, version).build()
     GithubRelease(raw_tag, module, version, open(f"/workspace/{module}/target/{module}-{version}-jar-with-dependencies.jar", "rb"), 
-            open(github-key, "r").read(), github-client-id, github-installation-id).create()
+            open(github_key, "r").read(), github_client_id, github_installation_id).create()
 
 if __name__ == '__main__':
     main()

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -167,7 +167,7 @@ def main():
     build_and_release(args.tag, args.github_key_path, args.github_client_id, args.github_installation_id)
 
 
-def build_and_release(raw_tag: str, github_key: str, github_client-id: str, github_installation-id: str):
+def build_and_release(raw_tag: str, github_key: str, github_client_id: str, github_installation_id: str):
     match = SEMVER_REGEX.match(raw_tag)
     if not match:
         print(f"Invalid tag: '{raw_tag}' (it does not match the regex pattern: '{SEMVER_REGEX.pattern}')")

--- a/hmftools-build.py
+++ b/hmftools-build.py
@@ -125,7 +125,7 @@ class GithubRelease:
         return jwt.encode(payload, self.private_key, algorithm='RS256')
 
     def _refresh_token(self, jwt: str):
-        response = requests.post(f"https://api.github.com/app/installations/${self.github_installation_id}/access_tokens",
+        response = requests.post(f"https://api.github.com/app/installations/{self.github_installation_id}/access_tokens",
                 headers = self._headers(jwt))
         response.raise_for_status()
         return response.json()["token"]


### PR DESCRIPTION
Rather than the PAT (personal access token) linked to my account, switch to using this flow meant for the Github "app" capability.

For testing I configured an app in Github and granted it the required permissions on one of my personal repositories. I generated a private key for it and used the client id and installation id metadata to test the flow implemented in the code.

In the code there is a change to read the private key rather than the PAT, and this has been parameterised instead of hardcoded. The client and installation ids are also passed in are used in conjunction with the private key to generate a JWT, which is then used to fetch a short-lived token. That token can then be used in the same way as the PAT.

I have also modified the cloudbuild file, a new secret will have to be made and the given parameters added to the build. Finally there is a separate PR for the build-tools container to add the required JWT library to the Python environment.

This exact code has not been tested but a pretty close analogue has been against my personal Github from my PC. I expect to find some little problems when I actually install it in production on the hmftools repository.