### PR TITLE
ACTIN-1142: Ensure only exonic variants that are phased with reported variants are shown in ORANGE

### DIFF
--- a/orange/README.md
+++ b/orange/README.md
@@ -135,7 +135,7 @@ interesting and added to the report:
 
 - Other potentially relevant variants:
     1. Variants that are hotspots or near hotspots but not part of the reporting gene panel.
-    2. Variants that are not reported but are phased with variants that are reported.
+    2. Exonic variants that are not reported but are phased with variants that are reported.
     3. Variants that are considered relevant for tumor type classification according to Cuppa.
     4. Variants with synonymous impact on the canonical transcript of a reporting gene but with a reportable worst impact
     5. Variants in splice regions that are not reported in genes with splice variant reporting enabled.

--- a/orange/README.md
+++ b/orange/README.md
@@ -263,6 +263,7 @@ investigate potential causes for QC failure.
 
 - Upcoming:
     - Add presence of tumor stats to quality control page and to orange-datamodel
+    - Ensure only exonic variants that are phased with reported variants are shown in 'potentially interesting' section
 - [3.7.0](https://github.com/hartwigmedical/hmftools/releases/tag/orange-v3.7.0):
     - Add unreported reason to fusions in ORANGE
     - Add etiology information to signatures and sort by allocation

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/purple/SomaticVariantSelector.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/purple/SomaticVariantSelector.java
@@ -28,13 +28,13 @@ final class SomaticVariantSelector
             if(!variant.reported())
             {
                 boolean isAtLeastNearHotspot = variant.hotspot() == HotspotType.HOTSPOT || variant.hotspot() == HotspotType.NEAR_HOTSPOT;
-                boolean affectsGeneAndHasPhasedReportedVariant =
-                        !variant.gene().isEmpty() && hasReportedVariantWithPhase(reportedSomaticVariants, variant.localPhaseSets());
+                boolean isExonicAndHasPhasedReportedVariant =
+                        !variant.gene().isEmpty() && isExonic(variant) && hasReportedVariantWithPhase(reportedSomaticVariants, variant.localPhaseSets());
                 boolean isCuppaRelevantVariant = isRelevantForCuppa(variant);
                 boolean isSynonymousButReportable = isSynonymousWithReportableWorstImpact(variant, driverGenes);
                 boolean isUnreportedSpliceVariant = isUnreportedSpliceVariant(variant, driverGenes);
 
-                if(isAtLeastNearHotspot || affectsGeneAndHasPhasedReportedVariant || isCuppaRelevantVariant || isSynonymousButReportable
+                if(isAtLeastNearHotspot || isExonicAndHasPhasedReportedVariant || isCuppaRelevantVariant || isSynonymousButReportable
                         || isUnreportedSpliceVariant)
                 {
                     filtered.add(variant);
@@ -74,6 +74,10 @@ final class SomaticVariantSelector
             }
         }
         return false;
+    }
+
+    private static boolean isExonic(@NotNull PurpleVariant variant) {
+        return variant.canonicalImpact().affectedExon() != null && variant.canonicalImpact().affectedExon() > 0;
     }
 
     private static boolean isRelevantForCuppa(@NotNull PurpleVariant variant)

--- a/orange/src/main/java/com/hartwig/hmftools/orange/algo/purple/SomaticVariantSelector.java
+++ b/orange/src/main/java/com/hartwig/hmftools/orange/algo/purple/SomaticVariantSelector.java
@@ -77,7 +77,7 @@ final class SomaticVariantSelector
     }
 
     private static boolean isExonic(@NotNull PurpleVariant variant) {
-        return variant.canonicalImpact().affectedExon() != null && variant.canonicalImpact().affectedExon() > 0;
+        return variant.canonicalImpact().affectedExon() != null;
     }
 
     private static boolean isRelevantForCuppa(@NotNull PurpleVariant variant)

--- a/orange/src/test/java/com/hartwig/hmftools/orange/algo/purple/SomaticVariantSelectorTest.java
+++ b/orange/src/test/java/com/hartwig/hmftools/orange/algo/purple/SomaticVariantSelectorTest.java
@@ -35,22 +35,23 @@ public class SomaticVariantSelectorTest
     }
 
     @Test
-    public void canSelectVariantsWithReportedPhaseSet()
+    public void canSelectExonicVariantsWithReportedPhaseSet()
     {
-        PurpleVariant withMatch = TestPurpleVariantFactory.builder().gene("gene").addLocalPhaseSets(1).build();
-        PurpleVariant withoutMatch = TestPurpleVariantFactory.builder().gene("gene").addLocalPhaseSets(2).build();
+        PurpleVariant exonicWithPhaseMatch = TestPurpleVariantFactory.builder().gene("gene").canonicalImpact(TestPurpleVariantFactory.impactBuilder().affectedExon(1).build()).addLocalPhaseSets(1).build();
+        PurpleVariant exonicWithoutPhaseMatch = TestPurpleVariantFactory.builder().gene("gene").canonicalImpact(TestPurpleVariantFactory.impactBuilder().affectedExon(1).build()).addLocalPhaseSets(2).build();
+        PurpleVariant intronicWithPhaseMatch = TestPurpleVariantFactory.builder().gene("gene").canonicalImpact(TestPurpleVariantFactory.impactBuilder().affectedExon(null).build()).addLocalPhaseSets(1).build();
         PurpleVariant withoutPhase = TestPurpleVariantFactory.builder().gene("gene").build();
 
         PurpleVariant withPhase = TestPurpleVariantFactory.builder().addLocalPhaseSets(1).build();
         PurpleVariant noPhase = TestPurpleVariantFactory.builder().localPhaseSets(null).build();
 
         List<PurpleVariant> variants =
-                SomaticVariantSelector.selectInterestingUnreportedVariants(Lists.newArrayList(withMatch, withoutMatch, withoutPhase),
+                SomaticVariantSelector.selectInterestingUnreportedVariants(Lists.newArrayList(exonicWithPhaseMatch, exonicWithoutPhaseMatch, intronicWithPhaseMatch, withoutPhase),
                         Lists.newArrayList(withPhase, noPhase),
                         Lists.newArrayList());
 
         assertEquals(1, variants.size());
-        assertTrue(variants.contains(withMatch));
+        assertTrue(variants.contains(exonicWithPhaseMatch));
     }
 
     @Test


### PR DESCRIPTION
A few weeks ago I noticed (due to an ORANGE report I was reviewing before sharing) that we were stating in the README in the “Other potentially relevant variants” section: _"**Exonic** variants that are not reported but are phased with variants that are reported"_, but in code we were actually not checking for exonic/intronic. Therefore I removed "Exonic" from the README to be in line with our code, but I do think it would be better to only show exonic variants on the report, so I added this logic now