### PR TITLE
Esvee: DEV-4113: Make sample argument optional in Caller config again

### DIFF
--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/caller/CallerConfig.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/caller/CallerConfig.java
@@ -100,7 +100,7 @@ public class CallerConfig
 
     public static void registerConfig(final ConfigBuilder configBuilder)
     {
-        configBuilder.addConfigItem(SAMPLE, true, SAMPLE_DESC);
+        configBuilder.addConfigItem(SAMPLE, SAMPLE_DESC);
         configBuilder.addConfigItem(REFERENCE, REFERENCE_DESC);
         configBuilder.addPath(INPUT_VCF, false, INPUT_VCF_DESC);
         configBuilder.addInteger(MANUAL_REF_DEPTH, "Manually set ref depth for testing", 0);


### PR DESCRIPTION
Needed to make germline-only runs work. Germline-only runs used to work, but then this argument was set back to required.