### PR TITLE
Purple: DEV-4219: Always use best score in purity range plot

### DIFF
--- a/purple/src/main/resources/r/copyNumberPlots.R
+++ b/purple/src/main/resources/r/copyNumberPlots.R
@@ -16,7 +16,7 @@ purity_ploidy_range_plot <- function(bestFit, range) {
 
     bestPurity = bestFit[1, "purity"]
     bestPloidy = bestFit[1, "ploidy"]
-    bestScore = bestFit[1, "score"]
+    bestScore = min(range$score, na.rm = TRUE)
     
     range =  range %>%
         arrange(purity, ploidy) %>%


### PR DESCRIPTION
Currently the score of the chosen fit is used as the "best" score, but for somatic fits this score doesn't have to be optimal. This can lead to incorrect colouring in the plot.