### PR TITLE
Patient-db: fix amber concurrent loading race condition

### DIFF
--- a/patient-db/src/main/java/com/hartwig/hmftools/patientdb/amber/LoadAmberData.java
+++ b/patient-db/src/main/java/com/hartwig/hmftools/patientdb/amber/LoadAmberData.java
@@ -133,7 +133,6 @@ public class LoadAmberData
         {
             LOGGER.info("releasing Amber table locks for sample {}", sample.sampleId());
             dbAccess.context().execute("UNLOCK TABLES");
-            LOGGER.info("Amber table locks released");
         }
     }
 


### PR DESCRIPTION
This PR aims to fix a race condition bug when loading Amber samples concurrently using PatientDb.
The bug was caused by the way how the next amber patient id is generated. To generate the next patient id, we count all existing patients and add 1 to find the next id, which is vulnerable to race conditions when you load samples currently. A simple fix is to lock all Amber-related tables during loading, which is what this PR did.

