### PR TITLE
Esvee: fix PhaseGroupId in breakend TSV

### DIFF
--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/output/BreakendWriter.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/output/BreakendWriter.java
@@ -138,7 +138,7 @@ public class BreakendWriter
                 StringJoiner sj = new StringJoiner(TSV_DELIM);
 
                 sj.add(String.valueOf(breakend.id()));
-                sj.add(String.valueOf(firstAssembly.id()));
+                sj.add(String.valueOf(phaseGroup.id()));
                 sj.add(String.valueOf(assemblyAlignment.phaseSet() != null ? assemblyAlignment.phaseSet().id() : firstAssembly.nonPhaseSetId()));
                 sj.add(String.valueOf(assemblyAlignment.id()));
                 sj.add(!breakend.isSingle() ? String.valueOf(breakend.otherBreakend().id()) : "");


### PR DESCRIPTION
Seems like there was a typo and it was accidentally setting the junction assembly ID rather than the phase group ID, brought about with the recent changes to improve the phase set ID.