### PR TITLE
Esvee: fix off by one error in calcTrimmedReadBaseLength()

### DIFF
--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/read/ReadUtils.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/read/ReadUtils.java
@@ -288,7 +288,7 @@ public final class ReadUtils
 
     public static int calcTrimmedReadBaseLength(final Read read, int indexStart, int indexEnd)
     {
-        byte[] readBases = Arrays.copyOfRange(read.getBases(), max(indexStart, 0), min(indexEnd, read.basesLength()));
+        byte[] readBases = Arrays.copyOfRange(read.getBases(), max(indexStart, 0), min(indexEnd + 1, read.basesLength()));
         List<RepeatInfo> repeats = RepeatInfo.findRepeats(readBases);
         return calcTrimmedBaseLength(0, readBases.length - 1, repeats);
     }


### PR DESCRIPTION
`indexEnd` in passed in as end-inclusive, but `Arrays.copyOfRange()` uses the end-exclusive convention.