### PR TITLE
PanelBuilder: Improve sample variant info output and improve sample variant code

### DIFF
--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/EvaluationResult.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/EvaluationResult.java
@@ -8,50 +8,42 @@ import java.util.function.Supplier;
 import org.jetbrains.annotations.Nullable;
 
 // Generic monad for representing the result of a check/filter that: accepts; or rejects with a reason.
-public record EvaluationResult(
+public record EvaluationResult<R>(
         // Null if accepted.
-        @Nullable String rejectionReason
+        @Nullable R rejectionInfo
 )
 {
-    public EvaluationResult
+    public static <R> EvaluationResult<R> accept()
     {
-        if(rejectionReason != null && rejectionReason.isBlank())
-        {
-            throw new IllegalArgumentException("rejectionReason should not be blank");
-        }
+        return new EvaluationResult<>(null);
     }
 
-    public static EvaluationResult accept()
+    public static <R> EvaluationResult<R> reject(final R rejectionInfo)
     {
-        return new EvaluationResult(null);
+        return new EvaluationResult<>(rejectionInfo);
     }
 
-    public static EvaluationResult reject(final String reason)
+    public static <R> EvaluationResult<R> condition(boolean cond, final R rejectionInfo)
     {
-        return new EvaluationResult(reason);
-    }
-
-    public static EvaluationResult condition(boolean cond, final String rejectionReason)
-    {
-        return cond ? EvaluationResult.accept() : EvaluationResult.reject(rejectionReason);
+        return cond ? EvaluationResult.accept() : EvaluationResult.reject(rejectionInfo);
     }
 
     public boolean accepted()
     {
-        return rejectionReason == null;
+        return rejectionInfo == null;
     }
 
     public boolean rejected()
     {
-        return rejectionReason != null;
+        return rejectionInfo != null;
     }
 
-    public <T> T map(final Supplier<T> onAccepted, final Function<String, T> onRejected)
+    public <T> T map(final Supplier<T> onAccepted, final Function<R, T> onRejected)
     {
-        return accepted() ? onAccepted.get() : onRejected.apply(rejectionReason);
+        return accepted() ? onAccepted.get() : onRejected.apply(rejectionInfo);
     }
 
-    public void unwrap(final Runnable onAccepted, final Consumer<String> onRejected)
+    public void unwrap(final Runnable onAccepted, final Consumer<R> onRejected)
     {
         map(
                 () ->
@@ -67,12 +59,12 @@ public record EvaluationResult(
         );
     }
 
-    public EvaluationResult then(final Supplier<EvaluationResult> filter)
+    public EvaluationResult<R> then(final Supplier<EvaluationResult<R>> filter)
     {
         return map(filter, reason -> this);
     }
 
-    public static EvaluationResult applyEvaluations(final List<Supplier<EvaluationResult>> filters)
+    public static <R> EvaluationResult<R> applyEvaluations(final List<Supplier<EvaluationResult<R>>> filters)
     {
         return filters.stream().reduce(EvaluationResult::accept, (f1, f2) -> () -> f1.get().then(f2)).get();
     }

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/OutputWriter.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/OutputWriter.java
@@ -453,7 +453,7 @@ public class OutputWriter implements AutoCloseable
     {
         row.set(SampleVariantInfoColumns.Variant, variantInfo.variant());
         row.set(SampleVariantInfoColumns.TargetType, variantInfo.targetType().name());
-        row.set(SampleVariantInfoColumns.FilterReason, variantInfo.filterReason() == null ? "PASS" : variantInfo.filterReason());
+        row.set(SampleVariantInfoColumns.FilterReason, variantInfo.filterReason() == null ? "PASS" : variantInfo.filterReason().name());
     }
 
     @Override

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/OutputWriter.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/OutputWriter.java
@@ -106,6 +106,7 @@ public class OutputWriter implements AutoCloseable
     private enum SampleVariantInfoColumns
     {
         Variant,
+        TargetType,
         FilterReason
     }
 
@@ -451,6 +452,7 @@ public class OutputWriter implements AutoCloseable
     private static void writeSampleVariantInfoRow(final SampleVariants.VariantInfo variantInfo, DelimFileWriter.Row row)
     {
         row.set(SampleVariantInfoColumns.Variant, variantInfo.variant());
+        row.set(SampleVariantInfoColumns.TargetType, variantInfo.targetType().name());
         row.set(SampleVariantInfoColumns.FilterReason, variantInfo.filterReason() == null ? "PASS" : variantInfo.filterReason());
     }
 

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/Probe.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/Probe.java
@@ -12,7 +12,7 @@ public record Probe(
         // null if the probe hasn't been evaluated yet.
         @Nullable ProbeEvaluator.Criteria evaluationCriteria,
         // null if the probe hasn't been evaluated yet.
-        @Nullable EvaluationResult evaluationResult,
+        @Nullable EvaluationResult<String> evaluationResult,
         // null if the probe hasn't been evaluated yet or the probe was rejected by another criteria.
         @Nullable Double qualityScore,
         // null if the probe hasn't been evaluated yet or the probe was rejected by another criteria.
@@ -81,7 +81,7 @@ public record Probe(
         return new Probe(definition, sequence, targetedRange, metadata, value, evaluationResult, qualityScore, gcContent);
     }
 
-    public Probe withEvaluationResult(final EvaluationResult value)
+    public Probe withEvaluationResult(final EvaluationResult<String> value)
     {
         if(evaluationResult != null)
         {

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/GermlineMutation.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/GermlineMutation.java
@@ -80,7 +80,11 @@ public class GermlineMutation implements Variant
             throw new RuntimeException(format("Failed to load germline variants from file: %s", vcfFile));
         }
 
-        List<GermlineMutation> variants = germlineVariants.stream().map(GermlineMutation::new).toList();
+        List<GermlineMutation> variants = germlineVariants.stream()
+                .map(GermlineMutation::new)
+                // We only support driver germline SNV/INDEL, so filter out nondrivers now.
+                .filter(GermlineMutation::isDriver)
+                .toList();
 
         LOGGER.debug("Loaded {} germline mutations", sampleId);
         variants.forEach(variant -> LOGGER.trace("GermlineMutation: {}", variant));

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/GermlineSv.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/GermlineSv.java
@@ -120,6 +120,8 @@ public class GermlineSv implements StructuralVariant
                             .toList();
                     return new GermlineSv(germlineSv, svBreakends);
                 })
+                // We only support driver germline structural variants, so filter out nondrivers now.
+                .filter(GermlineSv::isDriver)
                 .toList();
 
         LOGGER.debug("Loaded {} germline structural variants", variants.size());

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SampleVariants.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SampleVariants.java
@@ -3,28 +3,24 @@ package com.hartwig.hmftools.panelbuilder.samplevariants;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_DRIVER_GC_TARGET;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_DRIVER_GC_TOLERANCE;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_DRIVER_QUALITY_MIN;
-import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_FRAGMENT_COUNT_MIN;
-import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_INDEL_LENGTH_MAX;
-import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_INSERT_SEQUENCE_LENGTH_MAX;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_NONDRIVER_GC_TARGET;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_NONDRIVER_GC_TOLERANCE;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_NONDRIVER_QUALITY_MIN;
-import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_REPEAT_COUNT_MAX;
-import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_SV_BREAKENDS_PER_GENE_MAX;
-import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_VAF_MIN;
+import static com.hartwig.hmftools.panelbuilder.samplevariants.VariantSelector.getDriverVariantCandidates;
+import static com.hartwig.hmftools.panelbuilder.samplevariants.VariantSelector.getNondriverVariantCandidates;
+import static com.hartwig.hmftools.panelbuilder.samplevariants.VariantSelector.markUnevaluatedCandidates;
+import static com.hartwig.hmftools.panelbuilder.samplevariants.VariantSelector.selectDriverVariants;
+import static com.hartwig.hmftools.panelbuilder.samplevariants.VariantSelector.selectNondriverVariants;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import com.hartwig.hmftools.common.purple.GermlineStatus;
 import com.hartwig.hmftools.panelbuilder.EvaluationResult;
 import com.hartwig.hmftools.panelbuilder.PanelData;
 import com.hartwig.hmftools.panelbuilder.ProbeEvaluator;
@@ -61,7 +57,7 @@ public class SampleVariants
     public record VariantInfo(
             String variant,
             TargetMetadata.Type targetType,
-            @Nullable String filterReason
+            @Nullable VariantFilter filterReason
     )
     {
     }
@@ -78,7 +74,7 @@ public class SampleVariants
         variants.addAll(SomaticSv.load(config.sampleId(), config.purpleDir(), config.linxDir()));
         variants.addAll(GermlineSv.load(config.sampleId(), config.linxGermlineDir()));
 
-        Map<Variant, EvaluationResult> variantFilters = new HashMap<>();
+        Map<Variant, EvaluationResult<VariantFilter>> variantFilters = new HashMap<>();
         generateProbes(variants, config.maxProbes(), config.prioritiseSmallIndels(), probeGenerator, panelData, variantFilters);
 
         List<VariantInfo> variantInfos = createVariantInfos(variants, variantFilters);
@@ -101,16 +97,24 @@ public class SampleVariants
     }
 
     public static void generateProbes(final List<Variant> variants, int maxProbes, boolean prioritiseSmallIndels,
-            final ProbeGenerator probeGenerator, PanelData panelData, Map<Variant, EvaluationResult> variantFilters)
+            final ProbeGenerator probeGenerator, PanelData panelData, Map<Variant, EvaluationResult<VariantFilter>> variantFilters)
     {
+        // Variants which can be considered for probe generation.
+        List<Variant> driverVariantCandidates = getDriverVariantCandidates(variants);
+        List<SomaticMutation> nonDriverVariantCandidates = getNondriverVariantCandidates(variants, prioritiseSmallIndels);
+
         int generatedProbes = 0;
         Map<String, Integer> geneDisruptions = new HashMap<>();
         generatedProbes += generateProbes(
-                remainingProbes -> selectDriverVariants(variants, geneDisruptions, variantFilters, remainingProbes),
+                remainingProbes -> selectDriverVariants(driverVariantCandidates, geneDisruptions, variantFilters, remainingProbes),
                 maxProbes - generatedProbes, probeGenerator, panelData);
         generatedProbes += generateProbes(
-                remainingProbes -> selectNondriverVariants(variants, variantFilters, remainingProbes, prioritiseSmallIndels),
+                remainingProbes -> selectNondriverVariants(nonDriverVariantCandidates, variantFilters, remainingProbes),
                 maxProbes - generatedProbes, probeGenerator, panelData);
+
+        // At this point, candidates are either evaluated (accepted or rejected) or couldn't be evaluated due to the max probe count.
+        markUnevaluatedCandidates(driverVariantCandidates, variantFilters);
+        markUnevaluatedCandidates(nonDriverVariantCandidates, variantFilters);
     }
 
     private static int generateProbes(final Function<Integer, List<Variant>> variantSelector, int maxProbes,
@@ -142,207 +146,6 @@ public class SampleVariants
         return generatedProbes;
     }
 
-    private static List<Variant> selectDriverVariants(final List<Variant> variants, Map<String, Integer> geneDisruptions,
-            Map<Variant, EvaluationResult> variantFilters, int maxCount)
-    {
-        LOGGER.debug("Selecting up to {} driver variants", maxCount);
-
-        List<Variant> candidateVariants = variants.stream()
-                .filter(variant -> !hasBeenConsidered(variant, variantFilters))
-                .filter(Variant::isDriver)
-                .toList();
-
-        List<Variant> selectedVariants = new ArrayList<>();
-        for(Variant variant : candidateVariants)
-        {
-            if(selectedVariants.size() >= maxCount)
-            {
-                // We assume that there will be enough probes to cover all the driver variants.
-                // If not, then we randomly(?) discarded some drivers, which may be important to handle.
-                // Potentially, there should be a variant prioritisation scheme to avoid this scenario.
-                LOGGER.warn("Filled sample variant probe quota without including all driver variants!");
-                break;
-            }
-            EvaluationResult filterResult = driverFilters(variant, geneDisruptions);
-            variantFilters.put(variant, filterResult);
-            filterResult.unwrap(
-                    () ->
-                    {
-                        registerDisruptedGenes(variant, geneDisruptions);
-                        selectedVariants.add(variant);
-                    },
-                    failReason -> LOGGER.trace("Variant failed filter: {{}} reason=\"{}\"", variant, failReason)
-            );
-        }
-        return selectedVariants;
-    }
-
-    private static List<Variant> selectNondriverVariants(final List<Variant> variants, Map<Variant, EvaluationResult> variantFilters,
-            int maxCount, boolean prioritiseSmallIndels)
-    {
-        LOGGER.debug("Selecting up to {} nondriver variants", maxCount);
-
-        // For nondrivers, we are only interested in somatic SNV/INDEL.
-        // Also, some variants are prioritised over others.
-        List<SomaticMutation> candidateVariants = variants.stream()
-                .filter(variant -> !hasBeenConsidered(variant, variantFilters))
-                .filter(variant -> variant instanceof SomaticMutation)
-                .filter(variant -> !variant.isDriver())
-                .map(variant -> (SomaticMutation) variant)
-                .sorted(new NondriverVariantComparator(prioritiseSmallIndels))
-                .toList();
-
-        List<Variant> selectedVariants = new ArrayList<>();
-        for(SomaticMutation variant : candidateVariants)
-        {
-            if(selectedVariants.size() >= maxCount)
-            {
-                break;
-            }
-
-            EvaluationResult filterResult = nondriverFilters(variant);
-            variantFilters.put(variant, filterResult);
-            filterResult.unwrap(
-                    () -> selectedVariants.add(variant),
-                    failReason -> LOGGER.trace("Variant failed filter: {{}} reason=\"{}\"", variant, failReason)
-            );
-        }
-        return selectedVariants;
-    }
-
-    private static boolean hasBeenConsidered(final Variant variant, final Map<Variant, EvaluationResult> variantFilters)
-    {
-        return variantFilters.containsKey(variant);
-    }
-
-    private static EvaluationResult commonFilters(final Variant variant)
-    {
-        List<Supplier<EvaluationResult>> filters = new ArrayList<>();
-
-        if(variant instanceof StructuralVariant sv)
-        {
-            filters.add(() -> insertSequenceLengthFilter(sv.insertSequenceLength()));
-        }
-
-        return EvaluationResult.applyEvaluations(filters);
-    }
-
-    private static EvaluationResult driverFilters(final Variant variant, Map<String, Integer> geneDisruptions)
-    {
-        return EvaluationResult.applyEvaluations(List.of(
-                () -> commonFilters(variant),
-                () -> driverOnlyFilters(variant, geneDisruptions)));
-    }
-
-    private static EvaluationResult driverOnlyFilters(final Variant variant, Map<String, Integer> geneDisruptions)
-    {
-        List<Supplier<EvaluationResult>> filters = new ArrayList<>();
-
-        if(variant instanceof SomaticSv sv)
-        {
-            if(sv.isReportedDisruption())
-            {
-                filters.add(() -> vafFilter(sv.vaf()));
-                filters.add(() -> tumorFragmentsFilter(sv.tumorFragments()));
-            }
-        }
-
-        filters.add(() -> geneDisruptionFilter(variant, geneDisruptions));
-
-        return EvaluationResult.applyEvaluations(filters);
-    }
-
-    private record NondriverVariantComparator(
-            boolean prioritiseSmallerVariants
-    )
-            implements Comparator<SomaticMutation>
-    {
-        @Override
-        public int compare(final SomaticMutation v1, final SomaticMutation v2)
-        {
-            if(prioritiseSmallerVariants && v1.indelLength() != v2.indelLength())
-            {
-                return v1.indelLength() < v2.indelLength() ? -1 : 1;
-            }
-            if(v1.isCoding() != v2.isCoding())
-            {
-                return v1.isCoding() ? -1 : 1;
-            }
-            if(v1.isClonal() != v2.isClonal())
-            {
-                return v1.isClonal() ? -1 : 1;
-            }
-            // Otherwise random but deterministic ordering.
-            return Integer.compare(v1.deterministicHash(), v2.deterministicHash());
-        }
-    }
-
-    private static EvaluationResult nondriverFilters(final SomaticMutation variant)
-    {
-        return EvaluationResult.applyEvaluations(List.of(
-                () -> commonFilters(variant),
-                () -> nondriverOnlyFilters(variant)));
-    }
-
-    private static EvaluationResult nondriverOnlyFilters(final SomaticMutation variant)
-    {
-        return EvaluationResult.applyEvaluations(List.of(
-                () -> vafFilter(variant.vaf()),
-                () -> tumorFragmentsFilter(variant.tumorFragments()),
-                () -> indelLengthFilter(variant.indelLength()),
-                () -> repeatCountFilter(variant.repeatCount()),
-                () -> germlineStatusFilter(variant.germlineStatus())));
-    }
-
-    private static EvaluationResult insertSequenceLengthFilter(int insertSequenceLength)
-    {
-        return EvaluationResult.condition(insertSequenceLength <= SAMPLE_INSERT_SEQUENCE_LENGTH_MAX, "insert sequence length");
-    }
-
-    private static EvaluationResult vafFilter(double vaf)
-    {
-        return EvaluationResult.condition(vaf >= SAMPLE_VAF_MIN, "VAF");
-    }
-
-    private static EvaluationResult tumorFragmentsFilter(int tumorFragments)
-    {
-        return EvaluationResult.condition(tumorFragments >= SAMPLE_FRAGMENT_COUNT_MIN, "tumor fragments");
-    }
-
-    private static EvaluationResult indelLengthFilter(int indelLength)
-    {
-        return EvaluationResult.condition(indelLength <= SAMPLE_INDEL_LENGTH_MAX, "indel length");
-    }
-
-    private static EvaluationResult repeatCountFilter(int repeatCount)
-    {
-        return EvaluationResult.condition(repeatCount <= SAMPLE_REPEAT_COUNT_MAX, "repeat count");
-    }
-
-    private static EvaluationResult germlineStatusFilter(final GermlineStatus germlineStatus)
-    {
-        return EvaluationResult.condition(germlineStatus == GermlineStatus.DIPLOID, "germline status");
-    }
-
-    private static EvaluationResult geneDisruptionFilter(final Variant variant, final Map<String, Integer> geneDisruptions)
-    {
-        if(variant instanceof SomaticSv sv)
-        {
-            boolean pass = sv.disruptedGenes().stream()
-                    .allMatch(gene -> geneDisruptions.getOrDefault(gene, 0) + 1 <= SAMPLE_SV_BREAKENDS_PER_GENE_MAX);
-            return EvaluationResult.condition(pass, "gene disruptions");
-        }
-        return EvaluationResult.accept();
-    }
-
-    private static void registerDisruptedGenes(final Variant variant, Map<String, Integer> geneDisruptions)
-    {
-        if(variant instanceof SomaticSv sv)
-        {
-            sv.disruptedGenes().forEach(gene -> geneDisruptions.put(gene, geneDisruptions.getOrDefault(gene, 0) + 1));
-        }
-    }
-
     private static ProbeGenerationSpec createProbeGenerationSpec(final Variant variant)
     {
         LOGGER.trace("Generating probe for variant: {}", variant);
@@ -360,15 +163,15 @@ public class SampleVariants
         return new TargetMetadata(variant.targetType(), variant.toString());
     }
 
-    private static List<VariantInfo> createVariantInfos(final List<Variant> variants, final Map<Variant, EvaluationResult> variantFilters)
+    private static List<VariantInfo> createVariantInfos(final List<Variant> variants,
+            final Map<Variant, EvaluationResult<VariantFilter>> variantFilters)
     {
         return variants.stream()
                 .map(variant ->
                 {
-                    EvaluationResult filterResult = variantFilters.get(variant);
-                    // TODO: wrong, could be because that variant type is not considerable due to its type (e.g. germline nondriver)
-                    // If we didn't even attempt to filter the variant, it must have been because we encountered the probe limit first.
-                    String filterReason = filterResult == null ? "max probe count" : filterResult.rejectionReason();
+                    EvaluationResult<VariantFilter> filterResult = variantFilters.get(variant);
+                    // If we didn't even attempt to filter the variant, it must have been because it was never a candidate.
+                    VariantFilter filterReason = filterResult == null ? VariantFilter.NotCandidate : filterResult.rejectionInfo();
                     return new VariantInfo(variant.toString(), variant.targetType(), filterReason);
                 })
                 .toList();

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SampleVariants.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SampleVariants.java
@@ -60,6 +60,7 @@ public class SampleVariants
 
     public record VariantInfo(
             String variant,
+            TargetMetadata.Type targetType,
             @Nullable String filterReason
     )
     {
@@ -147,7 +148,7 @@ public class SampleVariants
         LOGGER.debug("Selecting up to {} driver variants", maxCount);
 
         List<Variant> candidateVariants = variants.stream()
-                .filter(variant -> !variantFilters.containsKey(variant))
+                .filter(variant -> !hasBeenConsidered(variant, variantFilters))
                 .filter(Variant::isDriver)
                 .toList();
 
@@ -184,7 +185,7 @@ public class SampleVariants
         // For nondrivers, we are only interested in somatic SNV/INDEL.
         // Also, some variants are prioritised over others.
         List<SomaticMutation> candidateVariants = variants.stream()
-                .filter(variant -> !variantFilters.containsKey(variant))
+                .filter(variant -> !hasBeenConsidered(variant, variantFilters))
                 .filter(variant -> variant instanceof SomaticMutation)
                 .filter(variant -> !variant.isDriver())
                 .map(variant -> (SomaticMutation) variant)
@@ -207,6 +208,11 @@ public class SampleVariants
             );
         }
         return selectedVariants;
+    }
+
+    private static boolean hasBeenConsidered(final Variant variant, final Map<Variant, EvaluationResult> variantFilters)
+    {
+        return variantFilters.containsKey(variant);
     }
 
     private static EvaluationResult commonFilters(final Variant variant)
@@ -360,9 +366,10 @@ public class SampleVariants
                 .map(variant ->
                 {
                     EvaluationResult filterResult = variantFilters.get(variant);
+                    // TODO: wrong, could be because that variant type is not considerable due to its type (e.g. germline nondriver)
                     // If we didn't even attempt to filter the variant, it must have been because we encountered the probe limit first.
                     String filterReason = filterResult == null ? "max probe count" : filterResult.rejectionReason();
-                    return new VariantInfo(variant.toString(), filterReason);
+                    return new VariantInfo(variant.toString(), variant.targetType(), filterReason);
                 })
                 .toList();
     }

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SomaticSv.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SomaticSv.java
@@ -362,6 +362,9 @@ public class SomaticSv implements StructuralVariant
             }
         }
 
+        // We only support driver somatic structural variants, so filter out nondrivers now.
+        variants = variants.stream().filter(SomaticSv::isDriver).toList();
+
         LOGGER.debug("Loaded {} somatic structural variants", variants.size());
         variants.forEach(variant -> LOGGER.trace("SomaticSv: {}", variant));
 

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SomaticSv.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/SomaticSv.java
@@ -50,17 +50,18 @@ public class SomaticSv implements StructuralVariant
 {
     private final StructuralVariantData mVariant;
     private final List<LinxBreakend> mBreakends;
-    private final List<LinxFusion> mFusions;
+    @Nullable
+    private final LinxFusion mFusion;
     private boolean mIsAmpDriver;
     private boolean mIsDelDriver;
 
     private static final Logger LOGGER = LogManager.getLogger(SomaticSv.class);
 
-    public SomaticSv(final StructuralVariantData variant, final List<LinxBreakend> breakends, final List<LinxFusion> fusions)
+    public SomaticSv(final StructuralVariantData variant, final List<LinxBreakend> breakends, @Nullable final LinxFusion fusion)
     {
         mVariant = variant;
         mBreakends = breakends;
-        mFusions = fusions;
+        mFusion = fusion;
         mIsAmpDriver = false;
         mIsDelDriver = false;
     }
@@ -78,7 +79,7 @@ public class SomaticSv implements StructuralVariant
 
     private boolean isFusion()
     {
-        return !mFusions.isEmpty();
+        return mFusion != null;
     }
 
     private boolean isAmpDriver()
@@ -109,9 +110,9 @@ public class SomaticSv implements StructuralVariant
     @Nullable
     private String gene()
     {
-        if(!mFusions.isEmpty())
+        if(mFusion != null)
         {
-            return mFusions.get(0).name();
+            return mFusion.name();
         }
 
         Optional<LinxBreakend> breakend = mBreakends.stream().filter(x -> x.reportedStatus() == ReportedStatus.REPORTED).findFirst();
@@ -127,7 +128,7 @@ public class SomaticSv implements StructuralVariant
     public boolean isDriver()
     {
         return isAmpDriver() || isDelDriver()
-                || mFusions.stream().anyMatch(LinxFusion::reported)
+                || (mFusion != null && mFusion.reported())
                 || isReportedDisruption();
     }
 
@@ -285,6 +286,13 @@ public class SomaticSv implements StructuralVariant
                     .filter(fusion -> svBreakends.stream().anyMatch(
                             breakend -> breakend.id() == fusion.fivePrimeBreakendId() || breakend.id() == fusion.threePrimeBreakendId()))
                     .toList();
+            if(svFusions.size() > 1)
+            {
+                // We think this can't happen in practice because 1 SV should be resolved to at most 1 fusion in Linx.
+                LOGGER.warn("Multiple reported fusions for SV {} {}. Will use first fusion", variant.id(), variant);
+            }
+            @Nullable
+            final LinxFusion svFusion = svFusions.isEmpty() ? null : svFusions.get(0);
 
             // only use SGLs if in a reportable fusion
             if(variant.type() == StructuralVariantType.SGL && svFusions.isEmpty())
@@ -303,7 +311,7 @@ public class SomaticSv implements StructuralVariant
 
             StructuralVariantData variantData = convertSvData(variant, annotation.svId());
 
-            SomaticSv sv = new SomaticSv(variantData, svBreakends, svFusions);
+            SomaticSv sv = new SomaticSv(variantData, svBreakends, svFusion);
             variants.add(sv);
 
             if(clusterSVs.containsKey(cluster.clusterId()))

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/VariantFilter.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/VariantFilter.java
@@ -1,0 +1,14 @@
+package com.hartwig.hmftools.panelbuilder.samplevariants;
+
+public enum VariantFilter
+{
+    NotCandidate,
+    ProbeLimit,
+    InsertSeqLength,
+    VAF,
+    TumorFragments,
+    IndelLength,
+    RepeatCount,
+    GermlineStatus,
+    GeneDisruption
+}

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/VariantSelector.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/samplevariants/VariantSelector.java
@@ -1,0 +1,258 @@
+package com.hartwig.hmftools.panelbuilder.samplevariants;
+
+import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_FRAGMENT_COUNT_MIN;
+import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_INDEL_LENGTH_MAX;
+import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_INSERT_SEQUENCE_LENGTH_MAX;
+import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_REPEAT_COUNT_MAX;
+import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_SV_BREAKENDS_PER_GENE_MAX;
+import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.SAMPLE_VAF_MIN;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import com.hartwig.hmftools.common.purple.GermlineStatus;
+import com.hartwig.hmftools.panelbuilder.EvaluationResult;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class VariantSelector
+{
+    private static final Logger LOGGER = LogManager.getLogger(VariantSelector.class);
+
+    public static List<Variant> selectDriverVariants(final List<Variant> candidateVariants, Map<String, Integer> geneDisruptions,
+            Map<Variant, EvaluationResult<VariantFilter>> variantFilters, int maxCount)
+    {
+        LOGGER.debug("Selecting up to {} driver variants", maxCount);
+
+        List<Variant> selectedVariants = new ArrayList<>();
+        for(Variant variant : candidateVariants)
+        {
+            if(hasBeenEvaluated(variant, variantFilters))
+            {
+                continue;
+            }
+
+            if(selectedVariants.size() >= maxCount)
+            {
+                // We assume that there will be enough probes to cover all the driver variants.
+                // If not, then we randomly(?) discarded some drivers, which may be important to handle.
+                // Potentially, there should be a variant prioritisation scheme to avoid this scenario.
+                LOGGER.warn("Filled sample variant probe quota without including all driver variants!");
+                break;
+            }
+
+            EvaluationResult<VariantFilter> filterResult = driverFilters(variant, geneDisruptions);
+            variantFilters.put(variant, filterResult);
+            filterResult.unwrap(
+                    () ->
+                    {
+                        registerDisruptedGenes(variant, geneDisruptions);
+                        selectedVariants.add(variant);
+                    },
+                    failReason -> LOGGER.trace("Variant failed filter: {{}} reason=\"{}\"", variant, failReason)
+            );
+        }
+        return selectedVariants;
+    }
+
+    public static List<Variant> getDriverVariantCandidates(final List<Variant> variants)
+    {
+        List<Variant> candidates = variants.stream()
+                .filter(Variant::isDriver)
+                .toList();
+        LOGGER.debug("{} driver variant candidates out of {} variants", candidates.size(), variants.size());
+        return candidates;
+    }
+
+    public static List<Variant> selectNondriverVariants(final List<SomaticMutation> candidateVariants,
+            Map<Variant, EvaluationResult<VariantFilter>> variantFilters, int maxCount)
+    {
+        LOGGER.debug("Selecting up to {} nondriver variants", maxCount);
+
+        List<Variant> selectedVariants = new ArrayList<>();
+        for(SomaticMutation variant : candidateVariants)
+        {
+            if(selectedVariants.size() >= maxCount)
+            {
+                break;
+            }
+
+            if(hasBeenEvaluated(variant, variantFilters))
+            {
+                continue;
+            }
+
+            EvaluationResult<VariantFilter> filterResult = nondriverFilters(variant);
+            variantFilters.put(variant, filterResult);
+            filterResult.unwrap(
+                    () -> selectedVariants.add(variant),
+                    failReason -> LOGGER.trace("Variant failed filter: {{}} reason=\"{}\"", variant, failReason)
+            );
+        }
+        return selectedVariants;
+    }
+
+    public static List<SomaticMutation> getNondriverVariantCandidates(final List<Variant> variants, boolean prioritiseSmallIndels)
+    {
+        // For nondrivers, we are only interested in somatic SNV/INDEL.
+        // Also, some variants are prioritised over others.
+        List<SomaticMutation> candidates = variants.stream()
+                .filter(variant -> variant instanceof SomaticMutation)
+                .filter(variant -> !variant.isDriver())
+                .map(variant -> (SomaticMutation) variant)
+                .sorted(new NondriverVariantComparator(prioritiseSmallIndels))
+                .toList();
+        LOGGER.debug("{} nondriver variant candidates out of {} variants", candidates.size(), variants.size());
+        return candidates;
+    }
+
+    private record NondriverVariantComparator(
+            boolean prioritiseSmallerVariants
+    )
+            implements Comparator<SomaticMutation>
+    {
+        @Override
+        public int compare(final SomaticMutation v1, final SomaticMutation v2)
+        {
+            if(prioritiseSmallerVariants && v1.indelLength() != v2.indelLength())
+            {
+                return v1.indelLength() < v2.indelLength() ? -1 : 1;
+            }
+            if(v1.isCoding() != v2.isCoding())
+            {
+                return v1.isCoding() ? -1 : 1;
+            }
+            if(v1.isClonal() != v2.isClonal())
+            {
+                return v1.isClonal() ? -1 : 1;
+            }
+            // Otherwise random but deterministic ordering.
+            return Integer.compare(v1.deterministicHash(), v2.deterministicHash());
+        }
+    }
+
+    private static boolean hasBeenEvaluated(final Variant variant, final Map<Variant, EvaluationResult<VariantFilter>> variantFilters)
+    {
+        return variantFilters.containsKey(variant);
+    }
+
+    private static EvaluationResult<VariantFilter> commonFilters(final Variant variant)
+    {
+        List<Supplier<EvaluationResult<VariantFilter>>> filters = new ArrayList<>();
+
+        if(variant instanceof StructuralVariant sv)
+        {
+            filters.add(() -> insertSequenceLengthFilter(sv.insertSequenceLength()));
+        }
+
+        return EvaluationResult.applyEvaluations(filters);
+    }
+
+    private static EvaluationResult<VariantFilter> driverFilters(final Variant variant, Map<String, Integer> geneDisruptions)
+    {
+        return EvaluationResult.applyEvaluations(List.of(
+                () -> commonFilters(variant),
+                () -> driverOnlyFilters(variant, geneDisruptions)));
+    }
+
+    private static EvaluationResult<VariantFilter> driverOnlyFilters(final Variant variant, Map<String, Integer> geneDisruptions)
+    {
+        List<Supplier<EvaluationResult<VariantFilter>>> filters = new ArrayList<>();
+
+        if(variant instanceof SomaticSv sv)
+        {
+            if(sv.isReportedDisruption())
+            {
+                filters.add(() -> vafFilter(sv.vaf()));
+                filters.add(() -> tumorFragmentsFilter(sv.tumorFragments()));
+            }
+        }
+
+        filters.add(() -> geneDisruptionFilter(variant, geneDisruptions));
+
+        return EvaluationResult.applyEvaluations(filters);
+    }
+
+    private static EvaluationResult<VariantFilter> nondriverFilters(final SomaticMutation variant)
+    {
+        return EvaluationResult.applyEvaluations(List.of(
+                () -> commonFilters(variant),
+                () -> nondriverOnlyFilters(variant)));
+    }
+
+    private static EvaluationResult<VariantFilter> nondriverOnlyFilters(final SomaticMutation variant)
+    {
+        return EvaluationResult.applyEvaluations(List.of(
+                () -> vafFilter(variant.vaf()),
+                () -> tumorFragmentsFilter(variant.tumorFragments()),
+                () -> indelLengthFilter(variant.indelLength()),
+                () -> repeatCountFilter(variant.repeatCount()),
+                () -> germlineStatusFilter(variant.germlineStatus())));
+    }
+
+    private static EvaluationResult<VariantFilter> insertSequenceLengthFilter(int insertSequenceLength)
+    {
+        return EvaluationResult.condition(insertSequenceLength <= SAMPLE_INSERT_SEQUENCE_LENGTH_MAX, VariantFilter.InsertSeqLength);
+    }
+
+    private static EvaluationResult<VariantFilter> vafFilter(double vaf)
+    {
+        return EvaluationResult.condition(vaf >= SAMPLE_VAF_MIN, VariantFilter.VAF);
+    }
+
+    private static EvaluationResult<VariantFilter> tumorFragmentsFilter(int tumorFragments)
+    {
+        return EvaluationResult.condition(tumorFragments >= SAMPLE_FRAGMENT_COUNT_MIN, VariantFilter.TumorFragments);
+    }
+
+    private static EvaluationResult<VariantFilter> indelLengthFilter(int indelLength)
+    {
+        return EvaluationResult.condition(indelLength <= SAMPLE_INDEL_LENGTH_MAX, VariantFilter.IndelLength);
+    }
+
+    private static EvaluationResult<VariantFilter> repeatCountFilter(int repeatCount)
+    {
+        return EvaluationResult.condition(repeatCount <= SAMPLE_REPEAT_COUNT_MAX, VariantFilter.RepeatCount);
+    }
+
+    private static EvaluationResult<VariantFilter> germlineStatusFilter(final GermlineStatus germlineStatus)
+    {
+        return EvaluationResult.condition(germlineStatus == GermlineStatus.DIPLOID, VariantFilter.GermlineStatus);
+    }
+
+    private static EvaluationResult<VariantFilter> geneDisruptionFilter(final Variant variant,
+            final Map<String, Integer> geneDisruptions)
+    {
+        if(variant instanceof SomaticSv sv)
+        {
+            boolean pass = sv.disruptedGenes().stream()
+                    .allMatch(gene -> geneDisruptions.getOrDefault(gene, 0) + 1 <= SAMPLE_SV_BREAKENDS_PER_GENE_MAX);
+            return EvaluationResult.condition(pass, VariantFilter.GeneDisruption);
+        }
+        return EvaluationResult.accept();
+    }
+
+    private static void registerDisruptedGenes(final Variant variant, Map<String, Integer> geneDisruptions)
+    {
+        if(variant instanceof SomaticSv sv)
+        {
+            sv.disruptedGenes().forEach(gene -> geneDisruptions.put(gene, geneDisruptions.getOrDefault(gene, 0) + 1));
+        }
+    }
+
+    public static <T extends Variant> void markUnevaluatedCandidates(final List<T> candidates,
+            Map<Variant, EvaluationResult<VariantFilter>> filters)
+    {
+        List<T> unevaluated = candidates.stream()
+                .filter(candidate -> !hasBeenEvaluated(candidate, filters))
+                .toList();
+        for(Variant variant : unevaluated)
+        {
+            filters.put(variant, EvaluationResult.reject(VariantFilter.ProbeLimit));
+        }
+    }
+}


### PR DESCRIPTION
- Fix the variant filter reason when the variant is not considered at all.
- Output the variant probe target type.
- Generally, don't output variants which can never satisfy any filter criteria.
- Warn when an SV is part of >1 fusion.
- Decouple and improve sample variants code.