### PR TITLE
Bam metrics add exon stats

### DIFF
--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/ExonCoverage.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/ExonCoverage.java
@@ -48,6 +48,38 @@ public class ExonCoverage extends GeneRegion
         return depths.get(medianIndex);
     }
 
+    public double meanDepth()
+    {
+        double totalCoverage = 0;
+        for(int coverage : mBaseCoverage)
+        {
+            totalCoverage += coverage;
+        }
+
+        return totalCoverage / mBaseCoverage.length;
+    }
+
+    public double[] propBasesAboveDepth(int[] depthThresholds)
+    {
+        int[] depthCounts = new int[depthThresholds.length];
+        for(int coverage : mBaseCoverage)
+        {
+            for(int i = 0; i < depthThresholds.length; ++i)
+            {
+                if(coverage >= depthThresholds[i])
+                    depthCounts[i] += 1;
+            }
+        }
+
+        double[] depthProportions = new double[depthThresholds.length];
+        for(int i = 0; i < depthThresholds.length; ++i)
+        {
+            depthProportions[i] = (double)depthCounts[i] / mBaseCoverage.length;
+        }
+
+        return depthProportions;
+    }
+
     private int index(int position) { return position - start(); }
 
     public String toString() { return format("rank(%d) region(%s)", ExonRank, ((ChrBaseRegion)this)); }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/GeneCoverage.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/GeneCoverage.java
@@ -40,6 +40,7 @@ public class GeneCoverage
     private static final List<Integer> DEPTH_BUCKETS = Lists.newArrayList();
     public static final int MAX_DEPTH_BUCKET = 10000;
     protected static final int GENE_COVERAGE_MIN_MAP_QUALITY = 10;
+    private final int[] EXON_DEPTH_THRESHOLDS = { 10, 20, 30, 60, 100, 250 };
 
     public GeneCoverage(final ConfigBuilder configBuilder)
     {
@@ -102,7 +103,13 @@ public class GeneCoverage
 
             StringJoiner sj = new StringJoiner(TSV_DELIM);
 
-            sj.add("gene").add("chromosome").add("posStart").add("posEnd").add("exonRank").add("medianDepth");
+            sj.add("gene").add("chromosome").add("posStart").add("posEnd").add("exonRank").add("medianDepth").add("meanDepth");
+
+            for(int threshold : EXON_DEPTH_THRESHOLDS)
+            {
+                sj.add(format("propAboveDepth_%d", threshold));
+            }
+
             writer.write(sj.toString());
             writer.newLine();
 
@@ -117,6 +124,14 @@ public class GeneCoverage
                     data.add(String.valueOf(exonCoverage.end()));
                     data.add(String.valueOf(exonCoverage.ExonRank));
                     data.add(format("%.0f", exonCoverage.medianDepth()));
+                    data.add(format("%.2f", exonCoverage.meanDepth()));
+
+                    double[] propBasesAboveDepth = exonCoverage.propBasesAboveDepth(EXON_DEPTH_THRESHOLDS);
+                    for(double value : propBasesAboveDepth)
+                    {
+                        data.add(format("%.2f", value));
+                    }
+
                     writer.write(data.toString());
                     writer.newLine();
                 }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/GeneCoverage.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/GeneCoverage.java
@@ -6,7 +6,7 @@ import static com.hartwig.hmftools.bamtools.common.CommonUtils.BT_LOGGER;
 import static com.hartwig.hmftools.common.driver.panel.DriverGenePanelConfig.DRIVER_GENE_PANEL;
 import static com.hartwig.hmftools.common.driver.panel.DriverGeneRegions.buildDriverGeneRegions;
 import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.ENSEMBL_DATA_DIR;
-import static com.hartwig.hmftools.common.metrics.GeneDepthFile.generateExonMediansFilename;
+import static com.hartwig.hmftools.common.metrics.GeneDepthFile.generateExonCoverageFilename;
 import static com.hartwig.hmftools.common.metrics.GeneDepthFile.generateGeneCoverageFilename;
 import static com.hartwig.hmftools.common.utils.file.FileDelimiters.TSV_DELIM;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBufferedWriter;
@@ -89,7 +89,7 @@ public class GeneCoverage
             return;
 
         String geneFilename = generateGeneCoverageFilename(outputDir, sampleId);
-        String exonFilename = generateExonMediansFilename(outputDir, sampleId);
+        String exonFilename = generateExonCoverageFilename(outputDir, sampleId);
 
         writeExonCoverage(exonFilename);
         writeGeneCoverage(geneFilename);

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/metrics/GeneDepthFile.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/metrics/GeneDepthFile.java
@@ -29,9 +29,9 @@ public final class GeneDepthFile
         return checkAddDirSeparator(basePath) + sample + BAM_METRICS_FILE_ID + ".gene_coverage.tsv";
     }
 
-    public static String generateExonMediansFilename(final String basePath, final String sample)
+    public static String generateExonCoverageFilename(final String basePath, final String sample)
     {
-        return checkAddDirSeparator(basePath) + sample + BAM_METRICS_FILE_ID + ".exon_medians.tsv";
+        return checkAddDirSeparator(basePath) + sample + BAM_METRICS_FILE_ID + ".exon_coverage.tsv";
     }
 
     public static void write(final String filename, final List<GeneDepth> depths, final List<Integer> depthBuckets) throws IOException


### PR DESCRIPTION
Added columns meanDepth and propAboveDepth_* to the exon coverage file. This is the output for the colo_mini tumor REDUX BAM:

```
gene	chromosome	posStart	posEnd	exonRank	medianDepth	meanDepth	propAboveDepth_10	propAboveDepth_20	propAboveDepth_30	propAboveDepth_60	propAboveDepth_100	propAboveDepth_250
CDKN2A	chr9	21970892	21971218	2	94	79.33	1.00	1.00	1.00	0.70	0.36	0.00
```