### PR TITLE
REDUX: RNA Transcript Fusion & Lift Back

### DIFF
--- a/redux/SPLICE_PROTOTYPE_README.md
+++ b/redux/SPLICE_PROTOTYPE_README.md
@@ -1,0 +1,36 @@
+# Splice-aware alignment prototype
+
+Experimental helpers under `com.hartwig.hmftools.redux.splice` that make `bwa-mem2` splice-aware in an effort to replace STAR.
+
+The flow is:
+
+1. **SpliceFastaBuilder**: offline, run once per ensembl release. Emits a FASTA of synthetic per-transcript contigs (concatenated exon sequences) plus a sidecar TSV mapping each contig back to gene / transcript / chromosome / exon spans.
+2. Append the synthetic contigs to the genome FASTA and re-index with `bwa-mem2`.
+3. Align reads with `bwa-mem2` against the combined FASTA.
+4. **SpliceLiftBack**: per sample. Reads the sidecar, translates transcript-coordinate alignments back to genome coordinates (CIGAR with `N` gaps across introns).
+
+## Tool 1: SpliceFastaBuilder (offline, one-time per ensembl)
+
+```
+java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
+    com.hartwig.hmftools.redux.splice.SpliceFastaBuilder \
+    -ensembl_data_dir ~/Documents/hartwig/common-resources-public/ensembl_data_cache/38 \
+    -ref_genome ~/Documents/hartwig/data/rna/ref_genome/38/GRCh38_masked_exclusions_alts_hlas.fasta \
+    -ref_genome_version V38 \
+    -output_dir ~/Documents/hartwig/temp-output
+```
+
+Outputs `splice.transcript_contigs.fasta` + `splice.transcript_contigs.sidecar.tsv` in the output dir.
+
+## Tool 2: SpliceLiftBack (per sample, after bwa-mem2 mapping)
+
+```
+java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
+    com.hartwig.hmftools.redux.splice.SpliceLiftBack \
+    -input_bam <path-to-bwa-mem2-output.bam> \
+    -ref_genome ~/Documents/hartwig/data/rna/ref_genome/38/ref_genome_v38_rna_contigs.fasta \
+    -contig_sidecar ~/Documents/hartwig/temp-output/splice.transcript_contigs.sidecar.tsv \
+    -output_dir ~/Documents/hartwig/temp-output
+```
+
+Outputs `splice_lifted.bam` (default) in the output dir. Pass `-output_id mysample` for a custom id.

--- a/redux/SPLICE_PROTOTYPE_README.md
+++ b/redux/SPLICE_PROTOTYPE_README.md
@@ -20,7 +20,7 @@ java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
     -output_dir ~/Documents/hartwig/temp-output
 ```
 
-Outputs `splice.transcript_contigs.fasta` + `splice.transcript_contigs.sidecar.tsv` in the output dir.
+Outputs `ref_genome_v38_rna_contigs.fasta` + `ref_genome_v38_rna_contigs.sidecar.tsv` in the output dir.
 
 ## Tool 2: SpliceLiftBack (per sample, after bwa-mem2 mapping)
 
@@ -29,7 +29,7 @@ java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
     com.hartwig.hmftools.redux.splice.SpliceLiftBack \
     -input_bam <path-to-bwa-mem2-output.bam> \
     -ref_genome ~/Documents/hartwig/data/rna/ref_genome/38/ref_genome_v38_rna_contigs.fasta \
-    -contig_sidecar ~/Documents/hartwig/temp-output/splice.transcript_contigs.sidecar.tsv \
+    -contig_sidecar ~/Documents/hartwig/temp-output/ref_genome_v38_rna_contigs.sidecar.tsv \
     -output_dir ~/Documents/hartwig/temp-output
 ```
 

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
@@ -1,0 +1,37 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+public class ContigEntry
+{
+    public final String ContigName;
+    public final String GeneId;
+    public final String GeneName;
+    public final String TransName;
+    public final String Chromosome;
+
+    // exon spans on the forward genomic strand, sorted ascending. Each span is 1-based, inclusive.
+    public final List<BaseRegion> ExonSpans;
+
+    public ContigEntry(
+            final String contigName, final String geneId, final String geneName, final String transName,
+            final String chromosome, final List<BaseRegion> exonSpans)
+    {
+        ContigName = contigName;
+        GeneId = geneId;
+        GeneName = geneName;
+        TransName = transName;
+        Chromosome = chromosome;
+        ExonSpans = exonSpans;
+    }
+
+    public int contigLength()
+    {
+        int length = 0;
+        for(BaseRegion span : ExonSpans)
+            length += span.baseLength();
+        return length;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
@@ -4,34 +4,17 @@ import java.util.List;
 
 import com.hartwig.hmftools.common.region.BaseRegion;
 
-public class ContigEntry
+public record ContigEntry(
+        String contigName,
+        String geneId,
+        String geneName,
+        String transName,
+        String chromosome,
+        // exon spans on the forward genomic strand, sorted ascending. Each span is 1-based, inclusive.
+        List<BaseRegion> exonSpans)
 {
-    public final String ContigName;
-    public final String GeneId;
-    public final String GeneName;
-    public final String TransName;
-    public final String Chromosome;
-
-    // exon spans on the forward genomic strand, sorted ascending. Each span is 1-based, inclusive.
-    public final List<BaseRegion> ExonSpans;
-
-    public ContigEntry(
-            final String contigName, final String geneId, final String geneName, final String transName,
-            final String chromosome, final List<BaseRegion> exonSpans)
-    {
-        ContigName = contigName;
-        GeneId = geneId;
-        GeneName = geneName;
-        TransName = transName;
-        Chromosome = chromosome;
-        ExonSpans = exonSpans;
-    }
-
     public int contigLength()
     {
-        int length = 0;
-        for(BaseRegion span : ExonSpans)
-            length += span.baseLength();
-        return length;
+        return exonSpans.stream().mapToInt(BaseRegion::baseLength).sum();
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
@@ -13,29 +13,29 @@ import com.hartwig.hmftools.common.utils.file.DelimFileWriter;
 
 public final class ContigSidecar
 {
-    public static final String COL_CONTIG_NAME = "ContigName";
-    public static final String COL_GENE_ID = "GeneId";
-    public static final String COL_GENE_NAME = "GeneName";
-    public static final String COL_TRANS_NAME = "TransName";
-    public static final String COL_CHROMOSOME = "Chromosome";
-    public static final String COL_EXON_SPANS = "ExonSpans";
-
-    private static final List<String> COLUMNS = List.of(
-            COL_CONTIG_NAME, COL_GENE_ID, COL_GENE_NAME, COL_TRANS_NAME, COL_CHROMOSOME, COL_EXON_SPANS);
+    public enum Column
+    {
+        ContigName,
+        GeneId,
+        GeneName,
+        TransName,
+        Chromosome,
+        ExonSpans
+    }
 
     // matches the convention in SpecificRegions: ITEM_DELIM separates spans, '-' separates start from end (BaseRegion.toString)
     private static final String SPAN_DELIM = "-";
 
     public static void write(final String filename, final List<ContigEntry> entries)
     {
-        try(DelimFileWriter<ContigEntry> writer = new DelimFileWriter<>(filename, COLUMNS, (entry, row) ->
+        try(DelimFileWriter<ContigEntry> writer = new DelimFileWriter<>(filename, Column.values(), (entry, row) ->
         {
-            row.set(COL_CONTIG_NAME, entry.ContigName);
-            row.set(COL_GENE_ID, entry.GeneId);
-            row.set(COL_GENE_NAME, entry.GeneName);
-            row.set(COL_TRANS_NAME, entry.TransName);
-            row.set(COL_CHROMOSOME, entry.Chromosome);
-            row.set(COL_EXON_SPANS, entry.ExonSpans.stream().map(BaseRegion::toString).collect(Collectors.joining(ITEM_DELIM)));
+            row.set(Column.ContigName, entry.contigName());
+            row.set(Column.GeneId, entry.geneId());
+            row.set(Column.GeneName, entry.geneName());
+            row.set(Column.TransName, entry.transName());
+            row.set(Column.Chromosome, entry.chromosome());
+            row.set(Column.ExonSpans, entry.exonSpans().stream().map(BaseRegion::toString).collect(Collectors.joining(ITEM_DELIM)));
         }))
         {
             for(ContigEntry entry : entries)
@@ -54,12 +54,12 @@ public final class ContigSidecar
             for(DelimFileReader.Row row : reader)
             {
                 entries.add(new ContigEntry(
-                        row.get(COL_CONTIG_NAME),
-                        row.get(COL_GENE_ID),
-                        row.get(COL_GENE_NAME),
-                        row.get(COL_TRANS_NAME),
-                        row.get(COL_CHROMOSOME),
-                        decodeSpans(row.get(COL_EXON_SPANS))));
+                        row.get(Column.ContigName),
+                        row.get(Column.GeneId),
+                        row.get(Column.GeneName),
+                        row.get(Column.TransName),
+                        row.get(Column.Chromosome),
+                        decodeSpans(row.get(Column.ExonSpans))));
             }
         }
 

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
@@ -1,0 +1,81 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.utils.file.FileDelimiters.ITEM_DELIM;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+import com.hartwig.hmftools.common.utils.file.DelimFileReader;
+import com.hartwig.hmftools.common.utils.file.DelimFileWriter;
+
+public final class ContigSidecar
+{
+    public static final String COL_CONTIG_NAME = "ContigName";
+    public static final String COL_GENE_ID = "GeneId";
+    public static final String COL_GENE_NAME = "GeneName";
+    public static final String COL_TRANS_NAME = "TransName";
+    public static final String COL_CHROMOSOME = "Chromosome";
+    public static final String COL_EXON_SPANS = "ExonSpans";
+
+    private static final List<String> COLUMNS = List.of(
+            COL_CONTIG_NAME, COL_GENE_ID, COL_GENE_NAME, COL_TRANS_NAME, COL_CHROMOSOME, COL_EXON_SPANS);
+
+    // matches the convention in SpecificRegions: ITEM_DELIM separates spans, '-' separates start from end (BaseRegion.toString)
+    private static final String SPAN_DELIM = "-";
+
+    public static void write(final String filename, final List<ContigEntry> entries)
+    {
+        try(DelimFileWriter<ContigEntry> writer = new DelimFileWriter<>(filename, COLUMNS, (entry, row) ->
+        {
+            row.set(COL_CONTIG_NAME, entry.ContigName);
+            row.set(COL_GENE_ID, entry.GeneId);
+            row.set(COL_GENE_NAME, entry.GeneName);
+            row.set(COL_TRANS_NAME, entry.TransName);
+            row.set(COL_CHROMOSOME, entry.Chromosome);
+            row.set(COL_EXON_SPANS, entry.ExonSpans.stream().map(BaseRegion::toString).collect(Collectors.joining(ITEM_DELIM)));
+        }))
+        {
+            for(ContigEntry entry : entries)
+                writer.writeRow(entry);
+        }
+
+        RD_LOGGER.info("wrote {} contig entries to {}", entries.size(), filename);
+    }
+
+    public static List<ContigEntry> read(final String filename)
+    {
+        List<ContigEntry> entries = new ArrayList<>();
+
+        try(DelimFileReader reader = new DelimFileReader(filename))
+        {
+            for(DelimFileReader.Row row : reader)
+            {
+                entries.add(new ContigEntry(
+                        row.get(COL_CONTIG_NAME),
+                        row.get(COL_GENE_ID),
+                        row.get(COL_GENE_NAME),
+                        row.get(COL_TRANS_NAME),
+                        row.get(COL_CHROMOSOME),
+                        decodeSpans(row.get(COL_EXON_SPANS))));
+            }
+        }
+
+        RD_LOGGER.info("loaded {} contig entries from {}", entries.size(), filename);
+        return entries;
+    }
+
+    private static List<BaseRegion> decodeSpans(final String encoded)
+    {
+        List<BaseRegion> spans = new ArrayList<>();
+        for(String token : encoded.split(ITEM_DELIM))
+        {
+            String[] parts = token.split(SPAN_DELIM);
+            spans.add(new BaseRegion(Integer.parseInt(parts[0]), Integer.parseInt(parts[1])));
+        }
+        return spans;
+    }
+
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
@@ -1,0 +1,104 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+
+public final class ContigTranslator
+{
+    public static TranslationResult translate(final ContigEntry contig, int contigPos, final Cigar contigCigar)
+    {
+        final List<BaseRegion> spans = contig.ExonSpans;
+        if(spans.isEmpty() || contigPos < 1)
+            return null;
+
+        // locate the span that contains the read's leftmost mapped contig position
+        int curSpanIdx = -1;
+        int curGenomicPos = -1;
+        int cumOffset = 0;
+        for(int i = 0; i < spans.size(); ++i)
+        {
+            BaseRegion span = spans.get(i);
+            if(contigPos <= cumOffset + span.baseLength())
+            {
+                curSpanIdx = i;
+                curGenomicPos = span.start() + (contigPos - cumOffset - 1);
+                break;
+            }
+            cumOffset += span.baseLength();
+        }
+
+        if(curSpanIdx < 0)
+            return null; // read starts past the end of the contig
+
+        int genomicStart = curGenomicPos;
+        List<CigarElement> outElements = new ArrayList<>();
+        List<BaseRegion> impliedIntrons = new ArrayList<>();
+
+        for(CigarElement element : contigCigar.getCigarElements())
+        {
+            CigarOperator op = element.getOperator();
+            int remaining = element.getLength();
+
+            if(!op.consumesReferenceBases())
+            {
+                outElements.add(new CigarElement(remaining, op));
+                continue;
+            }
+
+            while(remaining > 0)
+            {
+                BaseRegion currentSpan = spans.get(curSpanIdx);
+
+                // if we've stepped past the current span, insert an intron and advance into the next span
+                if(curGenomicPos > currentSpan.end())
+                {
+                    if(curSpanIdx + 1 >= spans.size())
+                        return null; // read extends past last span — un-liftable
+
+                    BaseRegion nextSpan = spans.get(curSpanIdx + 1);
+                    int intronStart = currentSpan.end() + 1;
+                    int intronEnd = nextSpan.start() - 1;
+
+                    outElements.add(new CigarElement(intronEnd - intronStart + 1, CigarOperator.N));
+                    impliedIntrons.add(new BaseRegion(intronStart, intronEnd));
+
+                    ++curSpanIdx;
+                    currentSpan = nextSpan;
+                    curGenomicPos = currentSpan.start();
+                }
+
+                int remainInSpan = currentSpan.end() - curGenomicPos + 1;
+                int take = Math.min(remaining, remainInSpan);
+
+                outElements.add(new CigarElement(take, op));
+                curGenomicPos += take;
+                remaining -= take;
+            }
+        }
+
+        return new TranslationResult(contig.Chromosome, genomicStart, new Cigar(outElements), impliedIntrons);
+    }
+
+    public static final class TranslationResult
+    {
+        public final String Chromosome;
+        public final int GenomicStart;
+        public final Cigar GenomicCigar;
+        public final List<BaseRegion> ImpliedIntrons;
+
+        public TranslationResult(
+                final String chromosome, int genomicStart, final Cigar genomicCigar, final List<BaseRegion> impliedIntrons)
+        {
+            Chromosome = chromosome;
+            GenomicStart = genomicStart;
+            GenomicCigar = genomicCigar;
+            ImpliedIntrons = impliedIntrons;
+        }
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
@@ -13,7 +13,7 @@ public final class ContigTranslator
 {
     public static TranslationResult translate(final ContigEntry contig, int contigPos, final Cigar contigCigar)
     {
-        final List<BaseRegion> spans = contig.ExonSpans;
+        final List<BaseRegion> spans = contig.exonSpans();
         if(spans.isEmpty() || contigPos < 1)
             return null;
 
@@ -82,7 +82,7 @@ public final class ContigTranslator
             }
         }
 
-        return new TranslationResult(contig.Chromosome, genomicStart, new Cigar(outElements), impliedIntrons);
+        return new TranslationResult(contig.chromosome(), genomicStart, new Cigar(outElements), impliedIntrons);
     }
 
     public static final class TranslationResult

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
@@ -1,0 +1,10 @@
+package com.hartwig.hmftools.redux.splice;
+
+public final class SpliceCommon
+{
+    public static final String CONTIG_NAME_DELIM = "_";
+    public static final String CONTIG_NAME_PREFIX = "ens";
+
+    public static final String TRANSCRIPT_CONTIGS_FILE_ID = ".transcript_contigs.fasta";
+    public static final String CONTIG_SIDECAR_FILE_ID = ".transcript_contigs.sidecar.tsv";
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
@@ -5,6 +5,6 @@ public final class SpliceCommon
     public static final String CONTIG_NAME_DELIM = "_";
     public static final String CONTIG_NAME_PREFIX = "ens";
 
-    public static final String TRANSCRIPT_CONTIGS_FILE_ID = ".transcript_contigs.fasta";
-    public static final String CONTIG_SIDECAR_FILE_ID = ".transcript_contigs.sidecar.tsv";
+    public static final String TRANSCRIPT_CONTIGS_FILE_ID = ".fasta";
+    public static final String CONTIG_SIDECAR_FILE_ID = ".sidecar.tsv";
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
@@ -32,9 +32,6 @@ public class SpliceFastaBuilder
 
     public void run()
     {
-        if(!mConfig.isValid())
-            System.exit(1);
-
         long startTimeMs = System.currentTimeMillis();
 
         RefGenomeSource refGenome = RefGenomeSource.loadRefGenome(mConfig.RefGenomeFile);
@@ -71,9 +68,8 @@ public class SpliceFastaBuilder
                     ++genesProcessed;
 
                     List<TranscriptData> transcripts = mEnsemblDataCache.getTranscripts(gene.GeneId);
-                    // TODO: do i really need this here? CHECK if ensembledatacache already covers this
                     if(transcripts == null || transcripts.isEmpty())
-                        continue;
+                        throw new IllegalStateException("ensembl cache returned no transcripts for gene " + gene.GeneId);
 
                     for(TranscriptData transcript : transcripts)
                     {
@@ -95,7 +91,7 @@ public class SpliceFastaBuilder
                             continue;
                         }
 
-                        writeFastaContig(fastaWriter, result.Entry.ContigName, result.Sequence);
+                        writeFastaContig(fastaWriter, result.Entry.contigName(), result.Sequence);
                         contigEntries.add(result.Entry);
                         ++contigsWritten;
                     }
@@ -135,7 +131,6 @@ public class SpliceFastaBuilder
 
     private static void writeFastaContig(final BufferedWriter writer, final String contigName, final String sequence) throws IOException
     {
-        // TODO: confirm this with Charles
         // unwrapped: matches BlastnRunner.writeBlastFasta. bwa-mem2 / samtools accept any line length.
         writer.write(">" + contigName);
         writer.newLine();

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
@@ -1,0 +1,156 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBufferedWriter;
+import static com.hartwig.hmftools.redux.ReduxConfig.APP_NAME;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_SIDECAR_FILE_ID;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.TRANSCRIPT_CONTIGS_FILE_ID;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource;
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+public class SpliceFastaBuilder
+{
+    private final SpliceFastaConfig mConfig;
+    private final EnsemblDataCache mEnsemblDataCache;
+
+    public SpliceFastaBuilder(final ConfigBuilder configBuilder)
+    {
+        mConfig = new SpliceFastaConfig(configBuilder);
+        mEnsemblDataCache = new EnsemblDataCache(configBuilder);
+    }
+
+    public void run()
+    {
+        if(!mConfig.isValid())
+            System.exit(1);
+
+        long startTimeMs = System.currentTimeMillis();
+
+        RefGenomeSource refGenome = RefGenomeSource.loadRefGenome(mConfig.RefGenomeFile);
+        if(refGenome == null)
+        {
+            RD_LOGGER.error("failed to load ref genome: {}", mConfig.RefGenomeFile);
+            System.exit(1);
+        }
+
+        RD_LOGGER.info("loading ensembl cache from {}", mConfig.EnsemblDataDir);
+        mEnsemblDataCache.setRequiredData(true, false, false, false);
+        mEnsemblDataCache.load(false);
+
+        Map<String, List<GeneData>> chrGeneMap = mEnsemblDataCache.getChrGeneDataMap();
+
+        String fastaFile = mConfig.formFilename(TRANSCRIPT_CONTIGS_FILE_ID);
+        String sidecarFile = mConfig.formFilename(CONTIG_SIDECAR_FILE_ID);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(refGenome);
+
+        List<ContigEntry> contigEntries = new ArrayList<>();
+
+        int genesProcessed = 0;
+        int contigsWritten = 0;
+        int skippedSingleExon = 0;
+        int skippedAllN = 0;
+
+        try(BufferedWriter fastaWriter = createBufferedWriter(fastaFile))
+        {
+            for(List<GeneData> genes : chrGeneMap.values())
+            {
+                for(GeneData gene : genes)
+                {
+                    ++genesProcessed;
+
+                    List<TranscriptData> transcripts = mEnsemblDataCache.getTranscripts(gene.GeneId);
+                    // TODO: do i really need this here? CHECK if ensembledatacache already covers this
+                    if(transcripts == null || transcripts.isEmpty())
+                        continue;
+
+                    for(TranscriptData transcript : transcripts)
+                    {
+                        // single-exon transcripts have no junctions — bwa-mem2 already aligns them fine against genomic ref
+                        if(transcript.exons().size() < 2)
+                        {
+                            ++skippedSingleExon;
+                            continue;
+                        }
+
+                        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene, transcript);
+                        if(result == null)
+                            continue;
+
+                        // exonic positions all masked to N in the ref — contig is alignment-useless
+                        if(isAllN(result.Sequence))
+                        {
+                            ++skippedAllN;
+                            continue;
+                        }
+
+                        writeFastaContig(fastaWriter, result.Entry.ContigName, result.Sequence);
+                        contigEntries.add(result.Entry);
+                        ++contigsWritten;
+                    }
+
+                    if(genesProcessed % 1000 == 0)
+                        RD_LOGGER.debug("processed {} genes, {} contigs", genesProcessed, contigsWritten);
+                }
+            }
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.error("failed to write transcript contigs FASTA: {}", e.toString());
+            System.exit(1);
+        }
+
+        RD_LOGGER.info("wrote {} transcript contigs to {} (skipped {} single-exon, {} all-N)",
+                contigsWritten, fastaFile, skippedSingleExon, skippedAllN);
+
+        ContigSidecar.write(sidecarFile, contigEntries);
+
+        RD_LOGGER.info("next: cat <ref.fasta> {} > ref_genome_<ver>_rna_contigs.fasta && bwa-mem2 index ref_genome_<ver>_rna_contigs.fasta",
+                fastaFile);
+
+        RD_LOGGER.info("SpliceFastaBuilder complete, mins({})", runTimeMinsStr(startTimeMs));
+    }
+
+    private static boolean isAllN(final String sequence)
+    {
+        for(int i = 0; i < sequence.length(); ++i)
+        {
+            char c = sequence.charAt(i);
+            if(c != 'N' && c != 'n')
+                return false;
+        }
+        return true;
+    }
+
+    private static void writeFastaContig(final BufferedWriter writer, final String contigName, final String sequence) throws IOException
+    {
+        // TODO: confirm this with Charles
+        // unwrapped: matches BlastnRunner.writeBlastFasta. bwa-mem2 / samtools accept any line length.
+        writer.write(">" + contigName);
+        writer.newLine();
+        writer.write(sequence);
+        writer.newLine();
+    }
+
+    public static void main(final String[] args)
+    {
+        ConfigBuilder configBuilder = new ConfigBuilder(APP_NAME);
+        SpliceFastaConfig.addConfig(configBuilder);
+
+        configBuilder.checkAndParseCommandLine(args);
+
+        SpliceFastaBuilder builder = new SpliceFastaBuilder(configBuilder);
+        builder.run();
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
@@ -12,7 +12,6 @@ import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
-import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
 
 import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
@@ -25,13 +24,8 @@ public class SpliceFastaConfig
     public final String OutputDir;
     public final String OutputId;
 
-    private boolean mIsValid;
-
     public SpliceFastaConfig(final ConfigBuilder configBuilder)
     {
-        // ConfigBuilder has already enforced presence + existence of every required path before we get here
-        mIsValid = true;
-
         EnsemblDataDir = configBuilder.getValue(ENSEMBL_DATA_DIR);
         RefGenomeFile = configBuilder.getValue(REF_GENOME);
         RefGenVersion = configBuilder.hasValue(REF_GENOME_VERSION) ? from(configBuilder) : RefGenomeVersion.V38;
@@ -39,18 +33,11 @@ public class SpliceFastaConfig
         OutputId = configBuilder.getValue(OUTPUT_ID);
 
         if(OutputDir == null)
-        {
-            RD_LOGGER.error("missing required config: output_dir");
-            mIsValid = false;
-        }
-        else if(!checkCreateOutputDir(OutputDir))
-        {
-            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
-            mIsValid = false;
-        }
-    }
+            throw new IllegalArgumentException("missing required config: output_dir");
 
-    public boolean isValid() { return mIsValid; }
+        if(!checkCreateOutputDir(OutputDir))
+            throw new IllegalStateException("failed to create output directory: " + OutputDir);
+    }
 
     public String formFilename(final String fileId)
     {

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
@@ -54,7 +54,7 @@ public class SpliceFastaConfig
 
     public String formFilename(final String fileId)
     {
-        String prefix = OutputId != null ? OutputId : "splice"; // TODO: can be more verbose here
+        String prefix = OutputId != null ? OutputId : "ref_genome_v" + RefGenVersion.identifier() + "_rna_contigs";
         return OutputDir + prefix + fileId;
     }
 

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
@@ -1,0 +1,70 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.ENSEMBL_DATA_DIR;
+import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.addEnsemblDir;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.REF_GENOME;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeFile;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeVersion;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.REF_GENOME_VERSION;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.from;
+import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+public class SpliceFastaConfig
+{
+    public final String EnsemblDataDir;
+    public final String RefGenomeFile;
+    public final RefGenomeVersion RefGenVersion;
+    public final String OutputDir;
+    public final String OutputId;
+
+    private boolean mIsValid;
+
+    public SpliceFastaConfig(final ConfigBuilder configBuilder)
+    {
+        // ConfigBuilder has already enforced presence + existence of every required path before we get here
+        mIsValid = true;
+
+        EnsemblDataDir = configBuilder.getValue(ENSEMBL_DATA_DIR);
+        RefGenomeFile = configBuilder.getValue(REF_GENOME);
+        RefGenVersion = configBuilder.hasValue(REF_GENOME_VERSION) ? from(configBuilder) : RefGenomeVersion.V38;
+        OutputDir = parseOutputDir(configBuilder);
+        OutputId = configBuilder.getValue(OUTPUT_ID);
+
+        if(OutputDir == null)
+        {
+            RD_LOGGER.error("missing required config: output_dir");
+            mIsValid = false;
+        }
+        else if(!checkCreateOutputDir(OutputDir))
+        {
+            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
+            mIsValid = false;
+        }
+    }
+
+    public boolean isValid() { return mIsValid; }
+
+    public String formFilename(final String fileId)
+    {
+        String prefix = OutputId != null ? OutputId : "splice"; // TODO: can be more verbose here
+        return OutputDir + prefix + fileId;
+    }
+
+    public static void addConfig(final ConfigBuilder configBuilder)
+    {
+        addEnsemblDir(configBuilder, true);
+        addRefGenomeFile(configBuilder, true);
+        addRefGenomeVersion(configBuilder);
+
+        addOutputOptions(configBuilder);
+        addLoggingOptions(configBuilder);
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
@@ -1,0 +1,127 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr;
+import static com.hartwig.hmftools.redux.ReduxConfig.APP_NAME;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+
+public class SpliceLiftBack
+{
+    private final SpliceLiftBackConfig mConfig;
+
+    public SpliceLiftBack(final ConfigBuilder configBuilder)
+    {
+        mConfig = new SpliceLiftBackConfig(configBuilder);
+    }
+
+    public void run()
+    {
+        if(!mConfig.isValid())
+            System.exit(1);
+
+        long startTimeMs = System.currentTimeMillis();
+
+        // TODO: can make this better, just getting it to work for now (PERFORMANCE IMPROVEMENTS)
+        List<ContigEntry> contigEntries = ContigSidecar.read(mConfig.ContigSidecarFile);
+        Map<String, ContigEntry> contigByName = new HashMap<>();
+        for(ContigEntry entry : contigEntries)
+            contigByName.put(entry.ContigName, entry);
+
+        RD_LOGGER.info("loaded {} contig entries", contigEntries.size());
+
+        processBam(mConfig.InputBam, mConfig.RefGenomeFile, contigByName, mConfig.formOutputBam());
+
+        RD_LOGGER.info("SpliceLiftBack complete, mins({})", runTimeMinsStr(startTimeMs));
+    }
+
+    static void processBam(
+            final String inputBam, final String refGenomeFile, final Map<String, ContigEntry> contigByName, final String outputBam)
+    {
+        int total = 0;
+        int passThrough = 0;
+        int lifted = 0;
+        int droppedUnliftable = 0;
+
+        try(SamReader samReader = SamReaderFactory.makeDefault()
+                .referenceSequence(new File(refGenomeFile))
+                .open(new File(inputBam)))
+        {
+            SAMFileHeader header = samReader.getFileHeader();
+
+            try(SAMFileWriter samWriter = new SAMFileWriterFactory().makeBAMWriter(header, false, new File(outputBam)))
+            {
+                SAMRecordIterator iter = samReader.iterator();
+                while(iter.hasNext())
+                {
+                    SAMRecord read = iter.next();
+                    ++total;
+
+                    if(read.getReadUnmappedFlag())
+                    {
+                        samWriter.addAlignment(read);
+                        ++passThrough;
+                        continue;
+                    }
+
+                    ContigEntry entry = contigByName.get(read.getReferenceName());
+                    if(entry == null)
+                    {
+                        samWriter.addAlignment(read);
+                        ++passThrough;
+                        continue;
+                    }
+
+                    ContigTranslator.TranslationResult result = ContigTranslator.translate(
+                            entry, read.getAlignmentStart(), read.getCigar());
+
+                    if(result == null)
+                    {
+                        ++droppedUnliftable;
+                        continue;
+                    }
+
+                    read.setReferenceName(result.Chromosome);
+                    read.setAlignmentStart(result.GenomicStart);
+                    read.setCigar(result.GenomicCigar);
+
+                    samWriter.addAlignment(read);
+                    ++lifted;
+                }
+            }
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.error("BAM I/O failed: {}", e.toString());
+            throw new RuntimeException(e);
+        }
+
+        RD_LOGGER.info("processed reads: total({}) passThrough({}) lifted({}) droppedUnliftable({})",
+                total, passThrough, lifted, droppedUnliftable);
+    }
+
+    public static void main(final String[] args)
+    {
+        ConfigBuilder configBuilder = new ConfigBuilder(APP_NAME);
+        SpliceLiftBackConfig.addConfig(configBuilder);
+
+        configBuilder.checkAndParseCommandLine(args);
+
+        SpliceLiftBack liftBack = new SpliceLiftBack(configBuilder);
+        liftBack.run();
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
@@ -31,16 +31,13 @@ public class SpliceLiftBack
 
     public void run()
     {
-        if(!mConfig.isValid())
-            System.exit(1);
-
         long startTimeMs = System.currentTimeMillis();
 
         // TODO: can make this better, just getting it to work for now (PERFORMANCE IMPROVEMENTS)
         List<ContigEntry> contigEntries = ContigSidecar.read(mConfig.ContigSidecarFile);
         Map<String, ContigEntry> contigByName = new HashMap<>();
         for(ContigEntry entry : contigEntries)
-            contigByName.put(entry.ContigName, entry);
+            contigByName.put(entry.contigName(), entry);
 
         RD_LOGGER.info("loaded {} contig entries", contigEntries.size());
 

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
@@ -1,0 +1,71 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.REF_GENOME;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeFile;
+import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
+import static com.hartwig.hmftools.common.utils.file.FileDelimiters.BAM_EXTENSION;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+public class SpliceLiftBackConfig
+{
+    public static final String INPUT_BAM = "input_bam";
+    public static final String INPUT_BAM_DESC = "Input BAM aligned to ref + transcript contigs";
+
+    public static final String CONTIG_SIDECAR = "contig_sidecar";
+    public static final String CONTIG_SIDECAR_DESC = "Contig sidecar TSV produced by SpliceFastaBuilder";
+
+    public final String InputBam;
+    public final String RefGenomeFile;
+    public final String ContigSidecarFile;
+    public final String OutputDir;
+    public final String OutputId;
+
+    private boolean mIsValid;
+
+    public SpliceLiftBackConfig(final ConfigBuilder configBuilder)
+    {
+        // ConfigBuilder has already enforced presence + existence of every required path before we get here
+        mIsValid = true;
+
+        InputBam = configBuilder.getValue(INPUT_BAM);
+        RefGenomeFile = configBuilder.getValue(REF_GENOME);
+        ContigSidecarFile = configBuilder.getValue(CONTIG_SIDECAR);
+        OutputDir = parseOutputDir(configBuilder);
+        OutputId = configBuilder.getValue(OUTPUT_ID);
+
+        if(OutputDir == null)
+        {
+            RD_LOGGER.error("missing required config: output_dir");
+            mIsValid = false;
+        }
+        else if(!checkCreateOutputDir(OutputDir))
+        {
+            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
+            mIsValid = false;
+        }
+    }
+
+    public boolean isValid() { return mIsValid; }
+
+    public String formOutputBam()
+    {
+        String prefix = OutputId != null ? OutputId : "splice_lifted";
+        return OutputDir + prefix + BAM_EXTENSION;
+    }
+
+    public static void addConfig(final ConfigBuilder configBuilder)
+    {
+        configBuilder.addPath(INPUT_BAM, true, INPUT_BAM_DESC);
+        addRefGenomeFile(configBuilder, true);
+        configBuilder.addPath(CONTIG_SIDECAR, true, CONTIG_SIDECAR_DESC);
+
+        addOutputOptions(configBuilder);
+        addLoggingOptions(configBuilder);
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
@@ -8,7 +8,6 @@ import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
-import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
 
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
 
@@ -26,13 +25,8 @@ public class SpliceLiftBackConfig
     public final String OutputDir;
     public final String OutputId;
 
-    private boolean mIsValid;
-
     public SpliceLiftBackConfig(final ConfigBuilder configBuilder)
     {
-        // ConfigBuilder has already enforced presence + existence of every required path before we get here
-        mIsValid = true;
-
         InputBam = configBuilder.getValue(INPUT_BAM);
         RefGenomeFile = configBuilder.getValue(REF_GENOME);
         ContigSidecarFile = configBuilder.getValue(CONTIG_SIDECAR);
@@ -40,18 +34,11 @@ public class SpliceLiftBackConfig
         OutputId = configBuilder.getValue(OUTPUT_ID);
 
         if(OutputDir == null)
-        {
-            RD_LOGGER.error("missing required config: output_dir");
-            mIsValid = false;
-        }
-        else if(!checkCreateOutputDir(OutputDir))
-        {
-            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
-            mIsValid = false;
-        }
-    }
+            throw new IllegalArgumentException("missing required config: output_dir");
 
-    public boolean isValid() { return mIsValid; }
+        if(!checkCreateOutputDir(OutputDir))
+            throw new IllegalStateException("failed to create output directory: " + OutputDir);
+    }
 
     public String formOutputBam()
     {

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
@@ -34,10 +34,19 @@ public class TranscriptContigBuilder
 
         List<BaseRegion> spans = new ArrayList<>(ordered.size());
         StringBuilder sequence = new StringBuilder();
+        int prevEnd = -1;
         for(ExonData exon : ordered)
         {
+            if(exon.Start <= prevEnd)
+            {
+                throw new IllegalStateException(String.format(
+                        "overlapping exons in transcript %s gene %s: exon [%d,%d] overlaps prior exon ending at %d",
+                        transcript.TransName, gene.GeneId, exon.Start, exon.End, prevEnd));
+            }
+
             spans.add(new BaseRegion(exon.Start, exon.End));
             sequence.append(mRefGenome.getBaseString(gene.Chromosome, exon.Start, exon.End));
+            prevEnd = exon.End;
         }
 
         String contigName = CONTIG_NAME_PREFIX + gene.GeneId

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
@@ -1,0 +1,64 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_NAME_DELIM;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_NAME_PREFIX;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import com.hartwig.hmftools.common.gene.ExonData;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeInterface;
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+public class TranscriptContigBuilder
+{
+    private final RefGenomeInterface mRefGenome;
+
+    public TranscriptContigBuilder(final RefGenomeInterface refGenome)
+    {
+        mRefGenome = refGenome;
+    }
+
+    public TranscriptContigResult build(final GeneData gene, final TranscriptData transcript)
+    {
+        if(transcript.exons() == null || transcript.exons().isEmpty())
+            return null;
+
+        // exons are stored by Rank (transcribed order). Re-sort by genomic Start so the contig sequence is in
+        // forward-strand orientation regardless of gene strand — keeps lift-back math direct.
+        List<ExonData> ordered = new ArrayList<>(transcript.exons());
+        ordered.sort(Comparator.comparingInt(e -> e.Start));
+
+        List<BaseRegion> spans = new ArrayList<>(ordered.size());
+        StringBuilder sequence = new StringBuilder();
+        for(ExonData exon : ordered)
+        {
+            spans.add(new BaseRegion(exon.Start, exon.End));
+            sequence.append(mRefGenome.getBaseString(gene.Chromosome, exon.Start, exon.End));
+        }
+
+        String contigName = CONTIG_NAME_PREFIX + gene.GeneId
+                + CONTIG_NAME_DELIM + gene.GeneName
+                + CONTIG_NAME_DELIM + transcript.TransName;
+
+        ContigEntry entry = new ContigEntry(
+                contigName, gene.GeneId, gene.GeneName, transcript.TransName, gene.Chromosome, spans);
+
+        return new TranscriptContigResult(entry, sequence.toString());
+    }
+
+    public static final class TranscriptContigResult
+    {
+        public final ContigEntry Entry;
+        public final String Sequence;
+
+        public TranscriptContigResult(final ContigEntry entry, final String sequence)
+        {
+            Entry = entry;
+            Sequence = sequence;
+        }
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
@@ -37,18 +37,18 @@ public class ContigSidecarTest
         assertEquals(2, readBack.size());
 
         ContigEntry first = readBack.get(0);
-        assertEquals("ensENSG0000001_GENEA_ENST0000001", first.ContigName);
-        assertEquals("ENSG0000001", first.GeneId);
-        assertEquals("GENEA", first.GeneName);
-        assertEquals("ENST0000001", first.TransName);
-        assertEquals(CHR_1, first.Chromosome);
-        assertEquals(2, first.ExonSpans.size());
-        assertEquals(new BaseRegion(100, 199), first.ExonSpans.get(0));
-        assertEquals(new BaseRegion(300, 399), first.ExonSpans.get(1));
+        assertEquals("ensENSG0000001_GENEA_ENST0000001", first.contigName());
+        assertEquals("ENSG0000001", first.geneId());
+        assertEquals("GENEA", first.geneName());
+        assertEquals("ENST0000001", first.transName());
+        assertEquals(CHR_1, first.chromosome());
+        assertEquals(2, first.exonSpans().size());
+        assertEquals(new BaseRegion(100, 199), first.exonSpans().get(0));
+        assertEquals(new BaseRegion(300, 399), first.exonSpans().get(1));
 
         ContigEntry second = readBack.get(1);
-        assertEquals("ENST0000002", second.TransName);
-        assertEquals(1, second.ExonSpans.size());
-        assertEquals(new BaseRegion(1000, 1050), second.ExonSpans.get(0));
+        assertEquals("ENST0000002", second.transName());
+        assertEquals(1, second.exonSpans().size());
+        assertEquals(new BaseRegion(1000, 1050), second.exonSpans().get(0));
     }
 }

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
@@ -1,0 +1,54 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_2;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import org.junit.Test;
+
+public class ContigSidecarTest
+{
+    @Test
+    public void testRoundTrip() throws IOException
+    {
+        File tempFile = Files.createTempFile("contig_sidecar_", ".tsv").toFile();
+        tempFile.deleteOnExit();
+
+        List<ContigEntry> entries = List.of(
+                new ContigEntry(
+                        "ensENSG0000001_GENEA_ENST0000001", "ENSG0000001", "GENEA", "ENST0000001", CHR_1,
+                        List.of(new BaseRegion(100, 199), new BaseRegion(300, 399))),
+                new ContigEntry(
+                        "ensENSG0000002_GENEB_ENST0000002", "ENSG0000002", "GENEB", "ENST0000002", CHR_2,
+                        List.of(new BaseRegion(1000, 1050))));
+
+        ContigSidecar.write(tempFile.getAbsolutePath(), entries);
+
+        List<ContigEntry> readBack = ContigSidecar.read(tempFile.getAbsolutePath());
+
+        assertEquals(2, readBack.size());
+
+        ContigEntry first = readBack.get(0);
+        assertEquals("ensENSG0000001_GENEA_ENST0000001", first.ContigName);
+        assertEquals("ENSG0000001", first.GeneId);
+        assertEquals("GENEA", first.GeneName);
+        assertEquals("ENST0000001", first.TransName);
+        assertEquals(CHR_1, first.Chromosome);
+        assertEquals(2, first.ExonSpans.size());
+        assertEquals(new BaseRegion(100, 199), first.ExonSpans.get(0));
+        assertEquals(new BaseRegion(300, 399), first.ExonSpans.get(1));
+
+        ContigEntry second = readBack.get(1);
+        assertEquals("ENST0000002", second.TransName);
+        assertEquals(1, second.ExonSpans.size());
+        assertEquals(new BaseRegion(1000, 1050), second.ExonSpans.get(0));
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigTranslatorTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigTranslatorTest.java
@@ -1,0 +1,224 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.TextCigarCodec;
+
+import org.junit.Test;
+
+public class ContigTranslatorTest
+{
+    private static final String GENE_ID = "ENSG00000000001";
+    private static final String GENE_NAME = "TESTGN";
+    private static final String TRANS_NAME = "ENST00000000001";
+    private static final String CONTIG_NAME = "ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME;
+
+    // three exon spans on chr1: 100-199 (len 100), 300-399 (len 100), 500-549 (len 50). Two introns: 200-299, 400-499.
+    private static ContigEntry threeExonContig()
+    {
+        return new ContigEntry(
+                CONTIG_NAME, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
+                List.of(new BaseRegion(100, 199), new BaseRegion(300, 399), new BaseRegion(500, 549)));
+    }
+
+    @Test
+    public void testReadEntirelyInFirstExon()
+    {
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("50M"));
+
+        assertNotNull(result);
+        assertEquals(CHR_1, result.Chromosome);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("50M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadEntirelyInLastExon()
+    {
+        // contig pos 201 is within the third span (cumulative offset is 200 after spans 1+2)
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 201, cigar("30M"));
+
+        assertNotNull(result);
+        assertEquals(500, result.GenomicStart);
+        assertEquals("30M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadCrossingOneJunction()
+    {
+        // start at contig pos 51 (genomic 150), 100M extends 100 bases. First 50 are in exon 1 (150-199),
+        // remaining 50 fall into exon 2 starting at 300. Intron is 200-299 (length 100).
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("100M"));
+
+        assertNotNull(result);
+        assertEquals(150, result.GenomicStart);
+        assertEquals("50M100N50M", result.GenomicCigar.toString());
+        assertEquals(1, result.ImpliedIntrons.size());
+        assertEquals(new BaseRegion(200, 299), result.ImpliedIntrons.get(0));
+    }
+
+    @Test
+    public void testReadCrossingTwoJunctions()
+    {
+        // start at contig pos 91 (genomic 190), 130M = 10 in exon1 + 100 in exon2 + 20 in exon3
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 91, cigar("130M"));
+
+        assertNotNull(result);
+        assertEquals(190, result.GenomicStart);
+        assertEquals("10M100N100M100N20M", result.GenomicCigar.toString());
+        assertEquals(2, result.ImpliedIntrons.size());
+        assertEquals(new BaseRegion(200, 299), result.ImpliedIntrons.get(0));
+        assertEquals(new BaseRegion(400, 499), result.ImpliedIntrons.get(1));
+    }
+
+    @Test
+    public void testReadWithSoftClip()
+    {
+        // 5S100M starting at contig pos 51. The 5S consumes query only — genomic start should still be 150.
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("5S100M"));
+
+        assertNotNull(result);
+        assertEquals(150, result.GenomicStart);
+        assertEquals("5S50M100N50M", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testReadWithInsertion()
+    {
+        // 30M5I20M starting at contig pos 1 — entirely in exon 1, no junctions
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("30M5I20M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("30M5I20M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadWithDeletion()
+    {
+        // 30M5D20M starting at contig pos 1 — D consumes ref but doesn't cross a junction (ends at genomic 154)
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("30M5D20M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("30M5D20M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadExactlyFillingFirstExon()
+    {
+        // 100M starting at contig pos 1 — fills exon 1 exactly (100-199), no spurious N at the end
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("100M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("100M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadExtendingPastLastSpanIsUnliftable()
+    {
+        // start at contig pos 231 (genomic 530), 50M extends past the last span (500-549, only 20 bases remain)
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 231, cigar("50M"));
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testContigPosBeyondContigLengthReturnsNull()
+    {
+        // contig length is 250 (100+100+50). Pos 251 is past the end.
+        assertNull(ContigTranslator.translate(threeExonContig(), 251, cigar("10M")));
+    }
+
+    @Test
+    public void testInvalidContigPosReturnsNull()
+    {
+        assertNull(ContigTranslator.translate(threeExonContig(), 0, cigar("10M")));
+        assertNull(ContigTranslator.translate(threeExonContig(), -5, cigar("10M")));
+    }
+
+    @Test
+    public void testReadAtFirstBaseOfContig()
+    {
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("1M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("1M", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testReadAtLastBaseOfContig()
+    {
+        // contig length is 250, so pos 250 + 1M lands on the very last contig base
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 250, cigar("1M"));
+
+        assertNotNull(result);
+        assertEquals(549, result.GenomicStart);
+        assertEquals("1M", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testReadWithLeadingAndTrailingSoftClips()
+    {
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("10S100M10S"));
+
+        assertNotNull(result);
+        assertEquals(150, result.GenomicStart);
+        assertEquals("10S50M100N50M10S", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testDeletionCrossingJunction()
+    {
+        // 10M5D5M starting at contig pos 91 (genomic 190): 10M fills the rest of exon 1, then 5D would consume
+        // ref starting at 200 (intron). We emit 100N for the intron, advance to exon 2 (300), then continue 5D + 5M.
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 91, cigar("10M5D5M"));
+
+        assertNotNull(result);
+        assertEquals(190, result.GenomicStart);
+        assertEquals("10M100N5D5M", result.GenomicCigar.toString());
+        assertEquals(1, result.ImpliedIntrons.size());
+    }
+
+    @Test
+    public void testTwoExonContigBoundaryCases()
+    {
+        ContigEntry twoExon = new ContigEntry(
+                "ensG_X_T", "G", "X", "T", CHR_1,
+                List.of(new BaseRegion(100, 149), new BaseRegion(200, 249)));
+
+        // M that exactly fills exon 1 — no spurious trailing N
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(twoExon, 1, cigar("50M"));
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("50M", result.GenomicCigar.toString());
+
+        // last base of exon 1 + 51M reaches one base into exon 2
+        result = ContigTranslator.translate(twoExon, 50, cigar("51M"));
+        assertNotNull(result);
+        assertEquals(149, result.GenomicStart);
+        assertEquals("1M50N50M", result.GenomicCigar.toString());
+    }
+
+    private static Cigar cigar(final String cigarString)
+    {
+        return TextCigarCodec.decode(cigarString);
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
@@ -35,15 +35,15 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME, result.Entry.ContigName);
-        assertEquals(GENE_ID, result.Entry.GeneId);
-        assertEquals(GENE_NAME, result.Entry.GeneName);
-        assertEquals(TRANS_NAME, result.Entry.TransName);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME, result.Entry.contigName());
+        assertEquals(GENE_ID, result.Entry.geneId());
+        assertEquals(GENE_NAME, result.Entry.geneName());
+        assertEquals(TRANS_NAME, result.Entry.transName());
 
-        assertEquals(3, result.Entry.ExonSpans.size());
-        assertEquals(new BaseRegion(100, 199), result.Entry.ExonSpans.get(0));
-        assertEquals(new BaseRegion(300, 399), result.Entry.ExonSpans.get(1));
-        assertEquals(new BaseRegion(500, 549), result.Entry.ExonSpans.get(2));
+        assertEquals(3, result.Entry.exonSpans().size());
+        assertEquals(new BaseRegion(100, 199), result.Entry.exonSpans().get(0));
+        assertEquals(new BaseRegion(300, 399), result.Entry.exonSpans().get(1));
+        assertEquals(new BaseRegion(500, 549), result.Entry.exonSpans().get(2));
 
         // sequence length equals total exonic bases (no introns)
         assertEquals(100 + 100 + 50, result.Sequence.length());
@@ -64,9 +64,9 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(NEG_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(100, result.Entry.ExonSpans.get(0).start());
-        assertEquals(300, result.Entry.ExonSpans.get(1).start());
-        assertEquals(500, result.Entry.ExonSpans.get(2).start());
+        assertEquals(100, result.Entry.exonSpans().get(0).start());
+        assertEquals(300, result.Entry.exonSpans().get(1).start());
+        assertEquals(500, result.Entry.exonSpans().get(2).start());
     }
 
     @Test
@@ -109,11 +109,11 @@ public class TranscriptContigBuilderTest
         assertNotNull(resultA);
         assertNotNull(resultB);
 
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000001", resultA.Entry.ContigName);
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000002", resultB.Entry.ContigName);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000001", resultA.Entry.contigName());
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000002", resultB.Entry.contigName());
 
-        assertEquals(2, resultA.Entry.ExonSpans.size());
-        assertEquals(2, resultB.Entry.ExonSpans.size());
+        assertEquals(2, resultA.Entry.exonSpans().size());
+        assertEquals(2, resultB.Entry.exonSpans().size());
 
         // contig A spans 100-199 + 300-399, contig B spans 100-199 + 500-549. Different lengths confirm they're independent.
         assertEquals(200, resultA.Entry.contigLength());
@@ -138,7 +138,7 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(1, result.Entry.ExonSpans.size());
+        assertEquals(1, result.Entry.exonSpans().size());
         assertEquals(101, result.Sequence.length());
     }
 

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
@@ -1,0 +1,172 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.genome.region.Strand.NEG_STRAND;
+import static com.hartwig.hmftools.common.genome.region.Strand.POS_STRAND;
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.hartwig.hmftools.common.gene.ExonData;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.region.BaseRegion;
+import com.hartwig.hmftools.common.test.MockRefGenome;
+
+import org.junit.Test;
+
+public class TranscriptContigBuilderTest
+{
+    private static final String GENE_ID = "ENSG00000171862";
+    private static final String GENE_NAME = "PTEN";
+    private static final String TRANS_NAME = "ENST00000399770";
+
+    @Test
+    public void testThreeExonForwardStrandTranscript()
+    {
+        // exons stored in transcribed (Rank) order, which equals genomic-ascending for a forward-strand gene
+        TranscriptData transcript = transcript();
+        addExon(transcript, 100, 199, 1);
+        addExon(transcript, 300, 399, 2);
+        addExon(transcript, 500, 549, 3);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
+
+        assertNotNull(result);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME, result.Entry.ContigName);
+        assertEquals(GENE_ID, result.Entry.GeneId);
+        assertEquals(GENE_NAME, result.Entry.GeneName);
+        assertEquals(TRANS_NAME, result.Entry.TransName);
+
+        assertEquals(3, result.Entry.ExonSpans.size());
+        assertEquals(new BaseRegion(100, 199), result.Entry.ExonSpans.get(0));
+        assertEquals(new BaseRegion(300, 399), result.Entry.ExonSpans.get(1));
+        assertEquals(new BaseRegion(500, 549), result.Entry.ExonSpans.get(2));
+
+        // sequence length equals total exonic bases (no introns)
+        assertEquals(100 + 100 + 50, result.Sequence.length());
+        assertEquals(result.Entry.contigLength(), result.Sequence.length());
+    }
+
+    @Test
+    public void testNegativeStrandTranscriptStoresExonsInGenomicOrder()
+    {
+        // Rank-ordered exons for a negative-strand transcript run genomic-descending. The builder must re-sort to
+        // genomic-ascending so the contig sequence mirrors the forward strand.
+        TranscriptData transcript = transcript();
+        addExon(transcript, 500, 549, 1); // 5' end of mRNA, but genomic-high
+        addExon(transcript, 300, 399, 2);
+        addExon(transcript, 100, 199, 3);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(NEG_STRAND), transcript);
+
+        assertNotNull(result);
+        assertEquals(100, result.Entry.ExonSpans.get(0).start());
+        assertEquals(300, result.Entry.ExonSpans.get(1).start());
+        assertEquals(500, result.Entry.ExonSpans.get(2).start());
+    }
+
+    @Test
+    public void testEmittedSequenceMatchesExonConcatenation()
+    {
+        TranscriptData transcript = transcript();
+        addExon(transcript, 100, 199, 1);
+        addExon(transcript, 300, 399, 2);
+        addExon(transcript, 500, 549, 3);
+
+        MockRefGenome ref = buildMockRef();
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(ref);
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
+
+        assertNotNull(result);
+
+        String expected = ref.getBaseString(CHR_1, 100, 199)
+                + ref.getBaseString(CHR_1, 300, 399)
+                + ref.getBaseString(CHR_1, 500, 549);
+        assertEquals(expected, result.Sequence);
+    }
+
+    @Test
+    public void testMultipleTranscriptsEachGetTheirOwnContig()
+    {
+        // simulate two isoforms of the same gene with different exon sets — each should be built independently
+        // (caller iterates transcripts; the builder is per-transcript)
+        TranscriptData transA = new TranscriptData(1, "ENST00000001", GENE_ID, true, POS_STRAND, 0, 0, null, null, "protein_coding", null);
+        addExon(transA, 100, 199, 1);
+        addExon(transA, 300, 399, 2);
+
+        TranscriptData transB = new TranscriptData(2, "ENST00000002", GENE_ID, false, POS_STRAND, 0, 0, null, null, "protein_coding", null);
+        addExon(transB, 100, 199, 1);
+        addExon(transB, 500, 549, 2);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult resultA = builder.build(gene(POS_STRAND), transA);
+        TranscriptContigBuilder.TranscriptContigResult resultB = builder.build(gene(POS_STRAND), transB);
+
+        assertNotNull(resultA);
+        assertNotNull(resultB);
+
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000001", resultA.Entry.ContigName);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000002", resultB.Entry.ContigName);
+
+        assertEquals(2, resultA.Entry.ExonSpans.size());
+        assertEquals(2, resultB.Entry.ExonSpans.size());
+
+        // contig A spans 100-199 + 300-399, contig B spans 100-199 + 500-549. Different lengths confirm they're independent.
+        assertEquals(200, resultA.Entry.contigLength());
+        assertEquals(150, resultB.Entry.contigLength());
+    }
+
+    @Test
+    public void testTranscriptWithNoExonsReturnsNull()
+    {
+        TranscriptData empty = transcript();
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        assertNull(builder.build(gene(POS_STRAND), empty));
+    }
+
+    @Test
+    public void testSingleExonTranscriptHasNoIntrons()
+    {
+        TranscriptData transcript = transcript();
+        addExon(transcript, 100, 200, 1);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
+
+        assertNotNull(result);
+        assertEquals(1, result.Entry.ExonSpans.size());
+        assertEquals(101, result.Sequence.length());
+    }
+
+    private static GeneData gene(final byte strand)
+    {
+        return new GeneData(GENE_ID, GENE_NAME, CHR_1, strand, 100, 549, "");
+    }
+
+    private static TranscriptData transcript()
+    {
+        return new TranscriptData(1, TRANS_NAME, GENE_ID, true, POS_STRAND, 0, 0, null, null, "protein_coding", null);
+    }
+
+    private static void addExon(final TranscriptData transcript, int start, int end, int rank)
+    {
+        transcript.exons().add(new ExonData(transcript.TransId, start, end, rank, -1, -1));
+    }
+
+    private static MockRefGenome buildMockRef()
+    {
+        // position-distinguishable bases so sequence-content assertions actually catch bad concatenations
+        MockRefGenome refGenome = new MockRefGenome(true);
+        char[] alphabet = { 'A', 'C', 'G', 'T' };
+        StringBuilder bases = new StringBuilder();
+        bases.append('N'); // pad index 0
+        for(int i = 1; i <= 1000; ++i)
+            bases.append(alphabet[i % 4]);
+        refGenome.RefGenomeMap.put(CHR_1, bases.toString());
+        return refGenome;
+    }
+}


### PR DESCRIPTION
**SpliceFastaBuilder** 

Output: `splice.transcript_contigs.fasta+ splice.transcript_contigs.sidecar.tsv (contig → gene, transcript, chromosome, exon spans)`

**SpliceLiftBack** 

per read; reads the sidecar tsc, translates transcript-coordinate alignments in input BAM back to genome coordinates (CIGAR N gaps for introns)
