### PR TITLE
REDUX: SpliceFastABuilder & SpliceLiftBack

### DIFF
--- a/redux/SPLICE_PROTOTYPE_README.md
+++ b/redux/SPLICE_PROTOTYPE_README.md
@@ -1,0 +1,23 @@
+# Splice-aware alignment prototype
+
+Experimental helpers under `com.hartwig.hmftools.redux.splice` that make `bwa-mem2` splice-aware in an effort to replace STAR.
+
+The flow is:
+
+1. **SpliceFastaBuilder**: offline, run once per ensembl release. Emits a FASTA of synthetic per-transcript contigs (concatenated exon sequences) plus a sidecar TSV mapping each contig back to gene / transcript / chromosome / exon spans.
+2. Append the synthetic contigs to the genome FASTA and re-index with `bwa-mem2`.
+3. Align reads with `bwa-mem2` against the combined FASTA.
+4. **SpliceLiftBack**: per sample. Reads the sidecar, translates transcript-coordinate alignments back to genome coordinates (CIGAR with `N` gaps across introns).
+
+## Tool 1: SpliceFastaBuilder (offline, one-time per ensembl)
+
+```
+java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
+    com.hartwig.hmftools.redux.splice.SpliceFastaBuilder \
+    -ensembl_data_dir ~/Documents/hartwig/common-resources-public/ensembl_data_cache/38 \
+    -ref_genome ~/Documents/hartwig/data/rna/ref_genome/38/GRCh38_masked_exclusions_alts_hlas.fasta \
+    -ref_genome_version V38 \
+    -output_dir ~/Documents/hartwig/temp-output
+```
+
+Outputs `splice.transcript_contigs.fasta` + `splice.transcript_contigs.sidecar.tsv` in the output dir.

--- a/redux/SPLICE_PROTOTYPE_README.md
+++ b/redux/SPLICE_PROTOTYPE_README.md
@@ -20,4 +20,4 @@ java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
     -output_dir ~/Documents/hartwig/temp-output
 ```
 
-Outputs `splice.transcript_contigs.fasta` + `splice.transcript_contigs.sidecar.tsv` in the output dir.
+Outputs `ref_genome_v38_rna_contigs.fasta` + `ref_genome_v38_rna_contigs.sidecar.tsv` in the output dir.

--- a/redux/SPLICE_PROTOTYPE_README.md
+++ b/redux/SPLICE_PROTOTYPE_README.md
@@ -20,4 +20,17 @@ java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
     -output_dir ~/Documents/hartwig/temp-output
 ```
 
-Outputs `ref_genome_v38_rna_contigs.fasta` + `ref_genome_v38_rna_contigs.sidecar.tsv` in the output dir.
+Outputs `ref_genome_v38_rna_contigs.fasta` + `ref_genome_v38_rna_contigs.rna_contigs_mappings.tsv` in the output dir.
+
+## Tool 2: SpliceLiftBack (per sample, after bwa-mem2 mapping)
+
+```
+java -cp redux/target/redux-2.0-jar-with-dependencies.jar \
+    com.hartwig.hmftools.redux.splice.SpliceLiftBack \
+    -input_bam <path-to-bwa-mem2-output.bam> \
+    -ref_genome ~/Documents/hartwig/data/rna/ref_genome/38/ref_genome_v38_rna_contigs.fasta \
+    -contig_mappings ~/Documents/hartwig/temp-output/ref_genome_v38_rna_contigs.rna_contigs_mappings.tsv \
+    -output_dir ~/Documents/hartwig/temp-output
+```
+
+Outputs `splice_lifted.bam` (default) in the output dir. Pass `-output_id mysample` for a custom id.

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/AltContigPacker.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/AltContigPacker.java
@@ -1,0 +1,60 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.altContigName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// packs a list of per-transcript sequences into a single per-chromosome alt contig. Lays transcripts down in
+// input order with an N-spacer between consecutive transcripts so no real read can align across two.
+// Output: the assembled sequence + one ContigEntry per packed transcript, each carrying its altStart/altEnd
+// position on the alt contig. Pure function — no I/O — so it tests cleanly in isolation.
+public final class AltContigPacker
+{
+    private final String mSpacer;
+
+    public AltContigPacker(final int spacerLength)
+    {
+        mSpacer = "N".repeat(spacerLength);
+    }
+
+    public PackResult pack(final String chromosome, final List<TranscriptContigBuilder.TranscriptContigResult> transcripts)
+    {
+        String altContig = altContigName(chromosome);
+        StringBuilder sequence = new StringBuilder();
+        List<ContigEntry> entries = new ArrayList<>();
+
+        for(TranscriptContigBuilder.TranscriptContigResult transcript : transcripts)
+        {
+            if(sequence.length() > 0)
+                sequence.append(mSpacer);
+
+            int altStart = sequence.length() + 1;
+            sequence.append(transcript.Sequence);
+            int altEnd = sequence.length();
+
+            entries.add(new ContigEntry(
+                    altContig, altStart, altEnd,
+                    transcript.GeneId, transcript.GeneName, transcript.TransName, transcript.Chromosome,
+                    transcript.ExonSpans));
+        }
+
+        return new PackResult(altContig, sequence.toString(), entries);
+    }
+
+    public static final class PackResult
+    {
+        public final String AltContig;
+        public final String Sequence;
+        public final List<ContigEntry> Entries;
+
+        public PackResult(final String altContig, final String sequence, final List<ContigEntry> entries)
+        {
+            AltContig = altContig;
+            Sequence = sequence;
+            Entries = entries;
+        }
+
+        public boolean isEmpty() { return Entries.isEmpty(); }
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/AltContigPacker.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/AltContigPacker.java
@@ -20,41 +20,30 @@ public final class AltContigPacker
 
     public PackResult pack(final String chromosome, final List<TranscriptContigBuilder.TranscriptContigResult> transcripts)
     {
-        String altContig = altContigName(chromosome);
-        StringBuilder sequence = new StringBuilder();
-        List<ContigEntry> entries = new ArrayList<>();
+        final String altContig = altContigName(chromosome);
+        final StringBuilder sequence = new StringBuilder();
+        final List<ContigEntry> entries = new ArrayList<>();
 
-        for(TranscriptContigBuilder.TranscriptContigResult transcript : transcripts)
+        for(final TranscriptContigBuilder.TranscriptContigResult transcript : transcripts)
         {
             if(sequence.length() > 0)
                 sequence.append(mSpacer);
 
-            int altStart = sequence.length() + 1;
-            sequence.append(transcript.Sequence);
-            int altEnd = sequence.length();
+            final int altStart = sequence.length() + 1;
+            sequence.append(transcript.sequence());
+            final int altEnd = sequence.length();
 
             entries.add(new ContigEntry(
                     altContig, altStart, altEnd,
-                    transcript.GeneId, transcript.GeneName, transcript.TransName, transcript.Chromosome,
-                    transcript.ExonSpans));
+                    transcript.geneId(), transcript.geneName(), transcript.transName(), transcript.chromosome(),
+                    transcript.exonSpans()));
         }
 
         return new PackResult(altContig, sequence.toString(), entries);
     }
 
-    public static final class PackResult
+    public record PackResult(String altContig, String sequence, List<ContigEntry> entries)
     {
-        public final String AltContig;
-        public final String Sequence;
-        public final List<ContigEntry> Entries;
-
-        public PackResult(final String altContig, final String sequence, final List<ContigEntry> entries)
-        {
-            AltContig = altContig;
-            Sequence = sequence;
-            Entries = entries;
-        }
-
-        public boolean isEmpty() { return Entries.isEmpty(); }
+        public boolean isEmpty() { return entries.isEmpty(); }
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
@@ -4,17 +4,20 @@ import java.util.List;
 
 import com.hartwig.hmftools.common.region.BaseRegion;
 
+// one transcript-shaped segment laid down on a per-chromosome alt contig. AltStart/AltEnd are 1-based inclusive
+// positions on contigName; exonSpans are 1-based inclusive genomic positions on chromosome.
 public record ContigEntry(
         String contigName,
+        int altStart,
+        int altEnd,
         String geneId,
         String geneName,
         String transName,
         String chromosome,
-        // exon spans on the forward genomic strand, sorted ascending. Each span is 1-based, inclusive.
         List<BaseRegion> exonSpans)
 {
     public int contigLength()
     {
-        return exonSpans.stream().mapToInt(BaseRegion::baseLength).sum();
+        return altEnd - altStart + 1;
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
@@ -1,0 +1,37 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+public class ContigEntry
+{
+    public final String ContigName;
+    public final String GeneId;
+    public final String GeneName;
+    public final String TransName;
+    public final String Chromosome;
+
+    // exon spans on the forward genomic strand, sorted ascending. Each span is 1-based, inclusive.
+    public final List<BaseRegion> ExonSpans;
+
+    public ContigEntry(
+            final String contigName, final String geneId, final String geneName, final String transName,
+            final String chromosome, final List<BaseRegion> exonSpans)
+    {
+        ContigName = contigName;
+        GeneId = geneId;
+        GeneName = geneName;
+        TransName = transName;
+        Chromosome = chromosome;
+        ExonSpans = exonSpans;
+    }
+
+    public int contigLength()
+    {
+        int length = 0;
+        for(BaseRegion span : ExonSpans)
+            length += span.baseLength();
+        return length;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigEntry.java
@@ -4,34 +4,17 @@ import java.util.List;
 
 import com.hartwig.hmftools.common.region.BaseRegion;
 
-public class ContigEntry
+public record ContigEntry(
+        String contigName,
+        String geneId,
+        String geneName,
+        String transName,
+        String chromosome,
+        // exon spans on the forward genomic strand, sorted ascending. Each span is 1-based, inclusive.
+        List<BaseRegion> exonSpans)
 {
-    public final String ContigName;
-    public final String GeneId;
-    public final String GeneName;
-    public final String TransName;
-    public final String Chromosome;
-
-    // exon spans on the forward genomic strand, sorted ascending. Each span is 1-based, inclusive.
-    public final List<BaseRegion> ExonSpans;
-
-    public ContigEntry(
-            final String contigName, final String geneId, final String geneName, final String transName,
-            final String chromosome, final List<BaseRegion> exonSpans)
-    {
-        ContigName = contigName;
-        GeneId = geneId;
-        GeneName = geneName;
-        TransName = transName;
-        Chromosome = chromosome;
-        ExonSpans = exonSpans;
-    }
-
     public int contigLength()
     {
-        int length = 0;
-        for(BaseRegion span : ExonSpans)
-            length += span.baseLength();
-        return length;
+        return exonSpans.stream().mapToInt(BaseRegion::baseLength).sum();
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigMappings.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigMappings.java
@@ -11,7 +11,7 @@ import com.hartwig.hmftools.common.region.BaseRegion;
 import com.hartwig.hmftools.common.utils.file.DelimFileReader;
 import com.hartwig.hmftools.common.utils.file.DelimFileWriter;
 
-public final class ContigSidecar
+public final class ContigMappings
 {
     public enum Column
     {

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigMappings.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigMappings.java
@@ -23,7 +23,6 @@ public final class ContigMappings
         ExonSpans
     }
 
-    // matches the convention in SpecificRegions: ITEM_DELIM separates spans, '-' separates start from end (BaseRegion.toString)
     private static final String SPAN_DELIM = "-";
 
     public static void write(final String filename, final List<ContigEntry> entries)

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
@@ -13,29 +13,29 @@ import com.hartwig.hmftools.common.utils.file.DelimFileWriter;
 
 public final class ContigSidecar
 {
-    public static final String COL_CONTIG_NAME = "ContigName";
-    public static final String COL_GENE_ID = "GeneId";
-    public static final String COL_GENE_NAME = "GeneName";
-    public static final String COL_TRANS_NAME = "TransName";
-    public static final String COL_CHROMOSOME = "Chromosome";
-    public static final String COL_EXON_SPANS = "ExonSpans";
-
-    private static final List<String> COLUMNS = List.of(
-            COL_CONTIG_NAME, COL_GENE_ID, COL_GENE_NAME, COL_TRANS_NAME, COL_CHROMOSOME, COL_EXON_SPANS);
+    public enum Column
+    {
+        ContigName,
+        GeneId,
+        GeneName,
+        TransName,
+        Chromosome,
+        ExonSpans
+    }
 
     // matches the convention in SpecificRegions: ITEM_DELIM separates spans, '-' separates start from end (BaseRegion.toString)
     private static final String SPAN_DELIM = "-";
 
     public static void write(final String filename, final List<ContigEntry> entries)
     {
-        try(DelimFileWriter<ContigEntry> writer = new DelimFileWriter<>(filename, COLUMNS, (entry, row) ->
+        try(DelimFileWriter<ContigEntry> writer = new DelimFileWriter<>(filename, Column.values(), (entry, row) ->
         {
-            row.set(COL_CONTIG_NAME, entry.ContigName);
-            row.set(COL_GENE_ID, entry.GeneId);
-            row.set(COL_GENE_NAME, entry.GeneName);
-            row.set(COL_TRANS_NAME, entry.TransName);
-            row.set(COL_CHROMOSOME, entry.Chromosome);
-            row.set(COL_EXON_SPANS, entry.ExonSpans.stream().map(BaseRegion::toString).collect(Collectors.joining(ITEM_DELIM)));
+            row.set(Column.ContigName, entry.contigName());
+            row.set(Column.GeneId, entry.geneId());
+            row.set(Column.GeneName, entry.geneName());
+            row.set(Column.TransName, entry.transName());
+            row.set(Column.Chromosome, entry.chromosome());
+            row.set(Column.ExonSpans, entry.exonSpans().stream().map(BaseRegion::toString).collect(Collectors.joining(ITEM_DELIM)));
         }))
         {
             for(ContigEntry entry : entries)
@@ -54,12 +54,12 @@ public final class ContigSidecar
             for(DelimFileReader.Row row : reader)
             {
                 entries.add(new ContigEntry(
-                        row.get(COL_CONTIG_NAME),
-                        row.get(COL_GENE_ID),
-                        row.get(COL_GENE_NAME),
-                        row.get(COL_TRANS_NAME),
-                        row.get(COL_CHROMOSOME),
-                        decodeSpans(row.get(COL_EXON_SPANS))));
+                        row.get(Column.ContigName),
+                        row.get(Column.GeneId),
+                        row.get(Column.GeneName),
+                        row.get(Column.TransName),
+                        row.get(Column.Chromosome),
+                        decodeSpans(row.get(Column.ExonSpans))));
             }
         }
 

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
@@ -1,0 +1,81 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.utils.file.FileDelimiters.ITEM_DELIM;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+import com.hartwig.hmftools.common.utils.file.DelimFileReader;
+import com.hartwig.hmftools.common.utils.file.DelimFileWriter;
+
+public final class ContigSidecar
+{
+    public static final String COL_CONTIG_NAME = "ContigName";
+    public static final String COL_GENE_ID = "GeneId";
+    public static final String COL_GENE_NAME = "GeneName";
+    public static final String COL_TRANS_NAME = "TransName";
+    public static final String COL_CHROMOSOME = "Chromosome";
+    public static final String COL_EXON_SPANS = "ExonSpans";
+
+    private static final List<String> COLUMNS = List.of(
+            COL_CONTIG_NAME, COL_GENE_ID, COL_GENE_NAME, COL_TRANS_NAME, COL_CHROMOSOME, COL_EXON_SPANS);
+
+    // matches the convention in SpecificRegions: ITEM_DELIM separates spans, '-' separates start from end (BaseRegion.toString)
+    private static final String SPAN_DELIM = "-";
+
+    public static void write(final String filename, final List<ContigEntry> entries)
+    {
+        try(DelimFileWriter<ContigEntry> writer = new DelimFileWriter<>(filename, COLUMNS, (entry, row) ->
+        {
+            row.set(COL_CONTIG_NAME, entry.ContigName);
+            row.set(COL_GENE_ID, entry.GeneId);
+            row.set(COL_GENE_NAME, entry.GeneName);
+            row.set(COL_TRANS_NAME, entry.TransName);
+            row.set(COL_CHROMOSOME, entry.Chromosome);
+            row.set(COL_EXON_SPANS, entry.ExonSpans.stream().map(BaseRegion::toString).collect(Collectors.joining(ITEM_DELIM)));
+        }))
+        {
+            for(ContigEntry entry : entries)
+                writer.writeRow(entry);
+        }
+
+        RD_LOGGER.info("wrote {} contig entries to {}", entries.size(), filename);
+    }
+
+    public static List<ContigEntry> read(final String filename)
+    {
+        List<ContigEntry> entries = new ArrayList<>();
+
+        try(DelimFileReader reader = new DelimFileReader(filename))
+        {
+            for(DelimFileReader.Row row : reader)
+            {
+                entries.add(new ContigEntry(
+                        row.get(COL_CONTIG_NAME),
+                        row.get(COL_GENE_ID),
+                        row.get(COL_GENE_NAME),
+                        row.get(COL_TRANS_NAME),
+                        row.get(COL_CHROMOSOME),
+                        decodeSpans(row.get(COL_EXON_SPANS))));
+            }
+        }
+
+        RD_LOGGER.info("loaded {} contig entries from {}", entries.size(), filename);
+        return entries;
+    }
+
+    private static List<BaseRegion> decodeSpans(final String encoded)
+    {
+        List<BaseRegion> spans = new ArrayList<>();
+        for(String token : encoded.split(ITEM_DELIM))
+        {
+            String[] parts = token.split(SPAN_DELIM);
+            spans.add(new BaseRegion(Integer.parseInt(parts[0]), Integer.parseInt(parts[1])));
+        }
+        return spans;
+    }
+
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigSidecar.java
@@ -16,6 +16,8 @@ public final class ContigSidecar
     public enum Column
     {
         ContigName,
+        AltStart,
+        AltEnd,
         GeneId,
         GeneName,
         TransName,
@@ -31,6 +33,8 @@ public final class ContigSidecar
         try(DelimFileWriter<ContigEntry> writer = new DelimFileWriter<>(filename, Column.values(), (entry, row) ->
         {
             row.set(Column.ContigName, entry.contigName());
+            row.set(Column.AltStart, String.valueOf(entry.altStart()));
+            row.set(Column.AltEnd, String.valueOf(entry.altEnd()));
             row.set(Column.GeneId, entry.geneId());
             row.set(Column.GeneName, entry.geneName());
             row.set(Column.TransName, entry.transName());
@@ -55,6 +59,8 @@ public final class ContigSidecar
             {
                 entries.add(new ContigEntry(
                         row.get(Column.ContigName),
+                        Integer.parseInt(row.get(Column.AltStart)),
+                        Integer.parseInt(row.get(Column.AltEnd)),
                         row.get(Column.GeneId),
                         row.get(Column.GeneName),
                         row.get(Column.TransName),

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
@@ -14,33 +14,61 @@ public final class ContigTranslator
     public static TranslationResult translate(final ContigEntry contig, int contigPos, final Cigar contigCigar)
     {
         final List<BaseRegion> spans = contig.exonSpans();
-        if(spans.isEmpty() || contigPos < 1)
+        if(spans.isEmpty() || contigPos > contig.altEnd())
             return null;
 
+        // bwa-mem2 sometimes anchors a read 1-N bases before this transcript's altStart (i.e. into the
+        // upstream alt-packing spacer-N region) or extends a few bases past altEnd into the downstream
+        // spacer. Reclaim those overhanging M bases as soft-clip so the read still lifts. Falls through
+        // to null when the overhang lands on a non-M op or the M is too short to absorb the shift.
+        Cigar workingCigar = contigCigar;
+        if(contigPos < contig.altStart())
+        {
+            int overhang = contig.altStart() - contigPos;
+            workingCigar = clampLeadingMToSoftClip(workingCigar, overhang);
+            if(workingCigar == null)
+                return null;
+            contigPos = contig.altStart();
+        }
+
+        int readEnd = contigPos + workingCigar.getReferenceLength() - 1;
+        if(readEnd > contig.altEnd())
+        {
+            int overhang = readEnd - contig.altEnd();
+            workingCigar = clampTrailingMToSoftClip(workingCigar, overhang);
+            if(workingCigar == null)
+                return null;
+        }
+
+        int localPos = contigPos - contig.altStart() + 1;
+
         // locate the span that contains the read's leftmost mapped contig position
-        int curSpanIdx = -1;
-        int curGenomicPos = -1;
-        int cumOffset = 0;
+        int currentSpanIndex = -1;
+        int currentGenomicPos = -1;
+        int exonLengthSoFar = 0;
         for(int i = 0; i < spans.size(); ++i)
         {
             BaseRegion span = spans.get(i);
-            if(contigPos <= cumOffset + span.baseLength())
+            if(localPos <= exonLengthSoFar + span.baseLength())
             {
-                curSpanIdx = i;
-                curGenomicPos = span.start() + (contigPos - cumOffset - 1);
+                currentSpanIndex = i;
+                currentGenomicPos = span.start() + (localPos - exonLengthSoFar - 1);
                 break;
             }
-            cumOffset += span.baseLength();
+            exonLengthSoFar += span.baseLength();
         }
 
-        if(curSpanIdx < 0)
+        if(currentSpanIndex < 0)
             return null; // read starts past the end of the contig
 
-        int genomicStart = curGenomicPos;
+        int genomicStart = currentGenomicPos;
         List<CigarElement> outElements = new ArrayList<>();
         List<BaseRegion> impliedIntrons = new ArrayList<>();
 
-        for(CigarElement element : contigCigar.getCigarElements())
+        // walk the contig-space CIGAR left-to-right; for each reference-consuming chunk, step through the
+        // exon spans, copying the operator out and emitting an N whenever we cross an exon boundary so the
+        // rebuilt CIGAR is genome-spaced. Non-reference ops (I, S) pass through unchanged.
+        for(CigarElement element : workingCigar.getCigarElements())
         {
             CigarOperator op = element.getOperator();
             int remaining = element.getLength();
@@ -53,31 +81,31 @@ public final class ContigTranslator
 
             while(remaining > 0)
             {
-                BaseRegion currentSpan = spans.get(curSpanIdx);
+                BaseRegion currentSpan = spans.get(currentSpanIndex);
 
                 // if we've stepped past the current span, insert an intron and advance into the next span
-                if(curGenomicPos > currentSpan.end())
+                if(currentGenomicPos > currentSpan.end())
                 {
-                    if(curSpanIdx + 1 >= spans.size())
-                        return null; // read extends past last span — un-liftable
+                    if(currentSpanIndex + 1 >= spans.size())
+                        return null; // read extends past last span
 
-                    BaseRegion nextSpan = spans.get(curSpanIdx + 1);
+                    BaseRegion nextSpan = spans.get(currentSpanIndex + 1);
                     int intronStart = currentSpan.end() + 1;
                     int intronEnd = nextSpan.start() - 1;
 
                     outElements.add(new CigarElement(intronEnd - intronStart + 1, CigarOperator.N));
                     impliedIntrons.add(new BaseRegion(intronStart, intronEnd));
 
-                    ++curSpanIdx;
+                    ++currentSpanIndex;
                     currentSpan = nextSpan;
-                    curGenomicPos = currentSpan.start();
+                    currentGenomicPos = currentSpan.start();
                 }
 
-                int remainInSpan = currentSpan.end() - curGenomicPos + 1;
+                int remainInSpan = currentSpan.end() - currentGenomicPos + 1;
                 int take = Math.min(remaining, remainInSpan);
 
                 outElements.add(new CigarElement(take, op));
-                curGenomicPos += take;
+                currentGenomicPos += take;
                 remaining -= take;
             }
         }
@@ -85,20 +113,95 @@ public final class ContigTranslator
         return new TranslationResult(contig.chromosome(), genomicStart, new Cigar(outElements), impliedIntrons);
     }
 
-    public static final class TranslationResult
+    // true if the contig CIGAR has a leading or trailing S whose adjacent edge sits at an interior exon
+    // boundary of the contig (i.e. a real splice-junction edge, not the outermost end of the first/last exon).
+    public static boolean hasSoftClipAtExonBoundary(
+            final ContigEntry contig, final int contigPos, final Cigar contigCigar)
     {
-        public final String Chromosome;
-        public final int GenomicStart;
-        public final Cigar GenomicCigar;
-        public final List<BaseRegion> ImpliedIntrons;
+        final List<BaseRegion> spans = contig.exonSpans();
+        if(spans.size() < 2 || contigCigar.isEmpty())
+            return false;
 
-        public TranslationResult(
-                final String chromosome, int genomicStart, final Cigar genomicCigar, final List<BaseRegion> impliedIntrons)
+        final List<CigarElement> elements = contigCigar.getCigarElements();
+        final boolean leadingSoftClip = elements.get(0).getOperator() == CigarOperator.S;
+        final boolean trailingSoftClip = elements.get(elements.size() - 1).getOperator() == CigarOperator.S;
+        if(!leadingSoftClip && !trailingSoftClip)
+            return false;
+
+        // shift alt-contig position into transcript-local coordinates (1-based)
+        final int localPos = contigPos - contig.altStart() + 1;
+        final int endLocalPos = localPos + contigCigar.getReferenceLength() - 1;
+
+        // interior exon-end boundary in contig-local coords = cumulative length of exons[0..i] for i < last
+        int exonLengthSoFar = 0;
+        for(int i = 0; i < spans.size() - 1; ++i)
         {
-            Chromosome = chromosome;
-            GenomicStart = genomicStart;
-            GenomicCigar = genomicCigar;
-            ImpliedIntrons = impliedIntrons;
+            exonLengthSoFar += spans.get(i).baseLength();
+            if(leadingSoftClip && localPos == exonLengthSoFar + 1)
+                return true;
+            if(trailingSoftClip && endLocalPos == exonLengthSoFar)
+                return true;
         }
+        return false;
     }
+
+    // converts the first `overhang` ref-consuming bases of the leading M into soft-clip. Any pre-existing
+    // leading S is merged into one larger S. Returns null when the first ref-consuming op is not a long
+    // enough M (e.g. starts with an I/D/N, or M is shorter than the overhang).
+    private static Cigar clampLeadingMToSoftClip(final Cigar cigar, final int overhang)
+    {
+        List<CigarElement> elements = cigar.getCigarElements();
+        int existingLeadingSoftClip = 0;
+        int idx = 0;
+        while(idx < elements.size() && elements.get(idx).getOperator() == CigarOperator.S)
+        {
+            existingLeadingSoftClip += elements.get(idx).getLength();
+            ++idx;
+        }
+        if(idx >= elements.size())
+            return null;
+
+        CigarElement first = elements.get(idx);
+        if(first.getOperator() != CigarOperator.M || first.getLength() <= overhang)
+            return null;
+
+        List<CigarElement> out = new ArrayList<>(elements.size());
+        out.add(new CigarElement(existingLeadingSoftClip + overhang, CigarOperator.S));
+        out.add(new CigarElement(first.getLength() - overhang, CigarOperator.M));
+        for(int i = idx + 1; i < elements.size(); ++i)
+            out.add(elements.get(i));
+        return new Cigar(out);
+    }
+
+    // mirror of clampLeadingMToSoftClip for the trailing edge.
+    private static Cigar clampTrailingMToSoftClip(final Cigar cigar, final int overhang)
+    {
+        List<CigarElement> elements = cigar.getCigarElements();
+        int existingTrailingSoftClip = 0;
+        int idx = elements.size() - 1;
+        while(idx >= 0 && elements.get(idx).getOperator() == CigarOperator.S)
+        {
+            existingTrailingSoftClip += elements.get(idx).getLength();
+            --idx;
+        }
+        if(idx < 0)
+            return null;
+
+        CigarElement last = elements.get(idx);
+        if(last.getOperator() != CigarOperator.M || last.getLength() <= overhang)
+            return null;
+
+        List<CigarElement> out = new ArrayList<>(elements.size());
+        for(int i = 0; i < idx; ++i)
+            out.add(elements.get(i));
+        out.add(new CigarElement(last.getLength() - overhang, CigarOperator.M));
+        out.add(new CigarElement(existingTrailingSoftClip + overhang, CigarOperator.S));
+        return new Cigar(out);
+    }
+
+    public record TranslationResult(
+            String chromosome,
+            int genomicStart,
+            Cigar genomicCigar,
+            List<BaseRegion> impliedIntrons) {}
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
@@ -1,0 +1,104 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+
+public final class ContigTranslator
+{
+    public static TranslationResult translate(final ContigEntry contig, int contigPos, final Cigar contigCigar)
+    {
+        final List<BaseRegion> spans = contig.ExonSpans;
+        if(spans.isEmpty() || contigPos < 1)
+            return null;
+
+        // locate the span that contains the read's leftmost mapped contig position
+        int curSpanIdx = -1;
+        int curGenomicPos = -1;
+        int cumOffset = 0;
+        for(int i = 0; i < spans.size(); ++i)
+        {
+            BaseRegion span = spans.get(i);
+            if(contigPos <= cumOffset + span.baseLength())
+            {
+                curSpanIdx = i;
+                curGenomicPos = span.start() + (contigPos - cumOffset - 1);
+                break;
+            }
+            cumOffset += span.baseLength();
+        }
+
+        if(curSpanIdx < 0)
+            return null; // read starts past the end of the contig
+
+        int genomicStart = curGenomicPos;
+        List<CigarElement> outElements = new ArrayList<>();
+        List<BaseRegion> impliedIntrons = new ArrayList<>();
+
+        for(CigarElement element : contigCigar.getCigarElements())
+        {
+            CigarOperator op = element.getOperator();
+            int remaining = element.getLength();
+
+            if(!op.consumesReferenceBases())
+            {
+                outElements.add(new CigarElement(remaining, op));
+                continue;
+            }
+
+            while(remaining > 0)
+            {
+                BaseRegion currentSpan = spans.get(curSpanIdx);
+
+                // if we've stepped past the current span, insert an intron and advance into the next span
+                if(curGenomicPos > currentSpan.end())
+                {
+                    if(curSpanIdx + 1 >= spans.size())
+                        return null; // read extends past last span — un-liftable
+
+                    BaseRegion nextSpan = spans.get(curSpanIdx + 1);
+                    int intronStart = currentSpan.end() + 1;
+                    int intronEnd = nextSpan.start() - 1;
+
+                    outElements.add(new CigarElement(intronEnd - intronStart + 1, CigarOperator.N));
+                    impliedIntrons.add(new BaseRegion(intronStart, intronEnd));
+
+                    ++curSpanIdx;
+                    currentSpan = nextSpan;
+                    curGenomicPos = currentSpan.start();
+                }
+
+                int remainInSpan = currentSpan.end() - curGenomicPos + 1;
+                int take = Math.min(remaining, remainInSpan);
+
+                outElements.add(new CigarElement(take, op));
+                curGenomicPos += take;
+                remaining -= take;
+            }
+        }
+
+        return new TranslationResult(contig.Chromosome, genomicStart, new Cigar(outElements), impliedIntrons);
+    }
+
+    public static final class TranslationResult
+    {
+        public final String Chromosome;
+        public final int GenomicStart;
+        public final Cigar GenomicCigar;
+        public final List<BaseRegion> ImpliedIntrons;
+
+        public TranslationResult(
+                final String chromosome, int genomicStart, final Cigar genomicCigar, final List<BaseRegion> impliedIntrons)
+        {
+            Chromosome = chromosome;
+            GenomicStart = genomicStart;
+            GenomicCigar = genomicCigar;
+            ImpliedIntrons = impliedIntrons;
+        }
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/ContigTranslator.java
@@ -13,7 +13,7 @@ public final class ContigTranslator
 {
     public static TranslationResult translate(final ContigEntry contig, int contigPos, final Cigar contigCigar)
     {
-        final List<BaseRegion> spans = contig.ExonSpans;
+        final List<BaseRegion> spans = contig.exonSpans();
         if(spans.isEmpty() || contigPos < 1)
             return null;
 
@@ -82,7 +82,7 @@ public final class ContigTranslator
             }
         }
 
-        return new TranslationResult(contig.Chromosome, genomicStart, new Cigar(outElements), impliedIntrons);
+        return new TranslationResult(contig.chromosome(), genomicStart, new Cigar(outElements), impliedIntrons);
     }
 
     public static final class TranslationResult

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackCategory.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackCategory.java
@@ -1,0 +1,101 @@
+package com.hartwig.hmftools.redux.splice;
+
+// per-record decision categories assigned by LiftBackResolver.
+public enum LiftBackCategory
+{
+    // input record was unmapped on entry; passed through.
+    UNMAPPED,
+
+    // supplementary records take a separate bucket; not run through the discriminator tree.
+    SUPPLEMENTARY,
+
+    // record's primary alignment was on a tx contig but ContigTranslator failed (e.g. position falls in
+    // an inter-transcript N-spacer of the packed alt contig [case to be made for supplementary]). Emitted unmapped with placeholder coords.
+    LIFT_FAILED,
+
+    // ---- 1 locus ----
+
+    // record's lifted alignment set contains only ref-chromosome alignments collapsing to a single locus.
+    REF_SINGLE,
+
+    // tx-contig alignments only (no ref alts), all collapsing to a single genomic locus after lift.
+    TX_SINGLE,
+
+    // ref + tx both contributed, single locus, same CIGAR, no N operator. Confirms the read's alignment
+    // is identical whether viewed through the genome or a transcript.
+    BOTH_AGREE,
+
+    // single locus with both ref and tx alignments. Tx has an N (junction) in its CIGAR; ref is soft-clipped
+    // around the junction. The transcript-aware alignment wins, picks up the splice the genome alignment missed.
+    BOTH_TX_JUNCTION_REF_SOFTCLIP,
+
+    // single locus with both ref and tx. Tx has an N (junction); ref alignment is a full match across the
+    // supposed intron with no soft-clip. Ref full-match with low NM is overwhelming evidence the read is
+    // genuinely unspliced (pre-mRNA / retained-intron / DNA contamination) — the tx N-CIGAR is the
+    // artifact, not the ref full-match. We pick ref and drop the tx alt.
+    BOTH_TX_JUNCTION_REF_MATCH,
+
+    // single locus with both ref and tx alignments. Tx has soft-clip at an exon boundary; ref is a full match.
+    // Ref alignment wins — likely an intron-retention event the tx-contig encoding can't capture.
+    BOTH_TX_SOFTCLIP_REF_MATCH,
+
+    // single locus with both ref and tx but none of the discriminator rules above fire. Falls through.
+    BOTH_AMBIGUOUS,
+
+    // ---- >=2 loci ----
+
+    // ref-chromosome alignments only (no tx alts) spanning >=2 distinct genomic loci.
+    // Genuine multi-mapper on the reference alone, paralog or repeat hit.
+    REF_MULTI,
+
+    // tx-contig alignments only but lift maps them to >=2 distinct genomic loci. Multi-locus, ambiguous.
+    TX_MULTI,
+
+    // ref + tx both contributed at distinct loci. Tx has an N (real annotated junction); none of the ref
+    // alts have an N (they sit at intronless paralogs — typically processed pseudogenes). The tx alignment
+    // is the biologically faithful one. We promote tx to primary and demote ref alts.
+    BOTH_MULTI_TX_JUNCTION,
+
+    // ref + tx both contributed but they map to >=2 distinct genomic loci, and the tx-junction discriminator
+    // didn't fire. Genuine multi-mapper — paralog hit, gene-family overlap, or similar.
+    BOTH_MULTI;
+
+    // headline grouping for at-a-glance stats / TSV scanning. Most reads fall in RESOLVED on a typical sample;
+    // PROBLEM is the bucket worth digging into (multi-locus + discriminator outcomes); NON_PRIMARY is everything
+    // the resolver didn't make a positive decision about.
+    public PrimaryBucket primaryBucket()
+    {
+        switch(this)
+        {
+            case REF_SINGLE:
+            case TX_SINGLE:
+            case BOTH_AGREE:
+            case BOTH_TX_JUNCTION_REF_SOFTCLIP:
+            case BOTH_TX_JUNCTION_REF_MATCH:
+            case BOTH_TX_SOFTCLIP_REF_MATCH:
+            case BOTH_MULTI_TX_JUNCTION:
+                // discriminator outcomes are confident picks — bucket as RESOLVED, not PROBLEM
+                return PrimaryBucket.RESOLVED;
+            case TX_MULTI:
+            case REF_MULTI:
+            case BOTH_MULTI:
+            case BOTH_AMBIGUOUS:
+                return PrimaryBucket.PROBLEM;
+            case UNMAPPED:
+            case LIFT_FAILED:
+            case SUPPLEMENTARY:
+            default:
+                return PrimaryBucket.NON_PRIMARY;
+        }
+    }
+
+    public enum PrimaryBucket
+    {
+        // a single locus identified with confidence — the read is downstream-ready.
+        RESOLVED,
+        // multi-locus or a discriminator outcome — downstream tools need to be aware which sub-category this came from.
+        PROBLEM,
+        // not a primary alignment the resolver made a decision about (unmapped, lift failed, or supplementary).
+        NON_PRIMARY
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackDiscriminator.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackDiscriminator.java
@@ -1,0 +1,248 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+// pure decision step on a record's full lifted alignment set (self + lifted XA alts):
+//   1. categorize() walks the alignments and returns the LiftBackCategory along with the per-alignment
+//      evidence the resolver feeds into LiftBackResult / TSV-A.
+//   2. apply() resolves the discriminator outcome for the categories that need one: marks losing-side
+//      alts Dropped, and may swap the BAM primary onto a winning XA alt (e.g. when bwa picked an
+//      intronless paralog over the spliced parent gene).
+//
+// No SAMRecord, no I/O — kept separate from LiftBackResolver so the decision tree reads as one piece.
+public final class LiftBackDiscriminator
+{
+    // minimum flanking M length for an N operator to be treated as a real splice junction in
+    // discriminator decisions. Lift-back of a tx alignment whose last bases bleed into the next exon
+    // can produce N with anchors of 1-3 bp — those are not evidence of splicing and must not swap the
+    // primary off a clean ref full-match. 8 bp gives ~1-in-65k random-match probability.
+    static final int MIN_REAL_N_ANCHOR = 8;
+
+    private LiftBackDiscriminator() {}
+
+    // per-alignment evidence the discriminator collected, emitted into TSV-A so post-hoc analysis can
+    // answer "why did this read land in category X?".
+    public static class Features
+    {
+        public LiftBackCategory Category;
+        public int NumRefAlts;
+        public int NumTxAlts;
+        public boolean TxHasNCigar;
+        public boolean TxSoftClipAtBoundary;
+        public boolean RefSoftClipped;
+        public boolean RefFullMatch;
+        public boolean RefHasNCigar;
+    }
+
+    public static Features categorize(final List<LiftedAlignment> alignments)
+    {
+        final Features features = new Features();
+
+        if(alignments.isEmpty())
+        {
+            features.Category = LiftBackCategory.LIFT_FAILED;
+            return features;
+        }
+
+        final Set<String> loci = new HashSet<>();
+        final Set<String> distinctCigars = new HashSet<>();
+        boolean anyHasN = false;
+
+        for(final LiftedAlignment alignment : alignments)
+        {
+            loci.add(locusKey(alignment));
+            distinctCigars.add(alignment.LiftedCigar);
+            if(alignment.cigarHasN())
+                anyHasN = true;
+
+            if(alignment.fromTxContig())
+            {
+                ++features.NumTxAlts;
+                if(alignment.cigarHasRealNJunction(MIN_REAL_N_ANCHOR))
+                    features.TxHasNCigar = true;
+                if(alignment.SoftClipAtBoundary)
+                    features.TxSoftClipAtBoundary = true;
+            }
+            else
+            {
+                ++features.NumRefAlts;
+                if(alignment.cigarHasSoftClip())
+                    features.RefSoftClipped = true;
+                else
+                    features.RefFullMatch = true;
+                if(alignment.cigarHasRealNJunction(MIN_REAL_N_ANCHOR))
+                    features.RefHasNCigar = true;
+            }
+        }
+
+        final boolean hasRef = features.NumRefAlts > 0;
+        final boolean hasTx = features.NumTxAlts > 0;
+
+        if(loci.size() >= 2)
+        {
+            if(hasRef && hasTx)
+            {
+                // tx found an annotated junction at one locus, ref alts hit other loci intronlessly —
+                // almost always processed pseudogenes / paralogs. Favour tx and swap the BAM primary.
+                if(features.TxHasNCigar && !features.RefHasNCigar)
+                    features.Category = LiftBackCategory.BOTH_MULTI_TX_JUNCTION;
+                else
+                    features.Category = LiftBackCategory.BOTH_MULTI;
+            }
+            else if(hasTx)
+                features.Category = LiftBackCategory.TX_MULTI;
+            else
+                features.Category = LiftBackCategory.REF_MULTI;
+            return features;
+        }
+
+        // single locus
+        if(hasRef && !hasTx)
+        {
+            features.Category = LiftBackCategory.REF_SINGLE;
+            return features;
+        }
+        if(hasTx && !hasRef)
+        {
+            features.Category = LiftBackCategory.TX_SINGLE;
+            return features;
+        }
+
+        // single locus, both ref and tx contributed — run discriminator
+        if(distinctCigars.size() == 1 && !anyHasN)
+            features.Category = LiftBackCategory.BOTH_AGREE;
+        else if(features.TxHasNCigar && features.RefSoftClipped)
+            features.Category = LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP;
+        else if(features.TxHasNCigar && features.RefFullMatch && !features.RefSoftClipped)
+            // ref full-match across the supposed intron with NM=0 is overwhelming evidence the read is
+            // genuinely unspliced (pre-mRNA / retained-intron / DNA contamination). The tx N-CIGAR is
+            // the artifact — favour ref.
+            features.Category = LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH;
+        else if(features.TxSoftClipAtBoundary && features.RefFullMatch)
+            features.Category = LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH;
+        else
+            features.Category = LiftBackCategory.BOTH_AMBIGUOUS;
+
+        return features;
+    }
+
+    public record Outcome(LiftedAlignment effectivePrimary, String note) {}
+
+    // applies confident discriminator outcomes by mutating LiftedAlignment.Dropped / IsPrimaryChoice.
+    // Returns the effective primary (the alignment whose lifted coords become the BAM record's coords)
+    // and a short note for TSV diagnostics.
+    public static Outcome apply(
+            final List<LiftedAlignment> alignments, final LiftBackCategory category, final LiftedAlignment self)
+    {
+        switch(category)
+        {
+            case BOTH_TX_JUNCTION_REF_SOFTCLIP:
+            case BOTH_MULTI_TX_JUNCTION:
+                return promoteTxOverRef(alignments, self);
+
+            case BOTH_TX_JUNCTION_REF_MATCH:
+                return promoteRefOverTx(alignments, self);
+
+            case BOTH_TX_SOFTCLIP_REF_MATCH:
+                if(!self.fromTxContig())
+                {
+                    for(final LiftedAlignment la : alignments)
+                        if(la.fromTxContig())
+                            la.Dropped = true;
+                    return new Outcome(self, "");
+                }
+                return new Outcome(self, "self_was_tx_no_swap");
+
+            default:
+                return new Outcome(self, "");
+        }
+    }
+
+    // ref-favouring outcome. If self is ref, drop all tx alts. If self is tx, swap: promote the winning
+    // ref alt to primary, demote self (tx) to XA, drop other tx alts.
+    private static Outcome promoteRefOverTx(final List<LiftedAlignment> alignments, final LiftedAlignment self)
+    {
+        if(!self.fromTxContig())
+        {
+            for(final LiftedAlignment la : alignments)
+                if(la.fromTxContig())
+                    la.Dropped = true;
+            return new Outcome(self, "");
+        }
+
+        LiftedAlignment winner = null;
+        for(final LiftedAlignment la : alignments)
+        {
+            if(!la.fromTxContig())
+            {
+                winner = la;
+                break;
+            }
+        }
+        if(winner == null)
+            return new Outcome(self, "");
+
+        self.IsPrimaryChoice = false;
+        winner.IsPrimaryChoice = true;
+        for(final LiftedAlignment la : alignments)
+        {
+            if(la.fromTxContig() && la != self)
+                la.Dropped = true;
+        }
+        return new Outcome(winner, "swapped_tx_to_ref");
+    }
+
+    // tx-favouring outcome. If self is tx, drop all ref alts. If self is ref, swap: promote the winning
+    // tx alt to primary, demote self to XA (preserves the original locus as an informative paralog hit),
+    // and drop other ref alts.
+    private static Outcome promoteTxOverRef(final List<LiftedAlignment> alignments, final LiftedAlignment self)
+    {
+        if(self.fromTxContig())
+        {
+            for(final LiftedAlignment la : alignments)
+                if(!la.fromTxContig())
+                    la.Dropped = true;
+            return new Outcome(self, "");
+        }
+
+        // prefer the tx alt that actually carries the N junction; fall back to any tx alt
+        LiftedAlignment winner = null;
+        for(final LiftedAlignment la : alignments)
+        {
+            if(la.fromTxContig() && la.cigarHasN())
+            {
+                winner = la;
+                break;
+            }
+        }
+        if(winner == null)
+        {
+            for(final LiftedAlignment la : alignments)
+            {
+                if(la.fromTxContig())
+                {
+                    winner = la;
+                    break;
+                }
+            }
+        }
+        if(winner == null)
+            return new Outcome(self, "");
+
+        self.IsPrimaryChoice = false;
+        winner.IsPrimaryChoice = true;
+        for(final LiftedAlignment la : alignments)
+        {
+            if(!la.fromTxContig() && la != self)
+                la.Dropped = true;
+        }
+        return new Outcome(winner, "swapped_ref_to_tx");
+    }
+
+    private static String locusKey(final LiftedAlignment la)
+    {
+        return la.LiftedChrom + ":" + la.LiftedPos;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResolver.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResolver.java
@@ -1,0 +1,716 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.ALT_CONTIG_SUFFIX;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.TextCigarCodec;
+
+// per-record categorizer: takes a SAMRecord aligned against ref + Tx contigs and produces a LiftBackResult
+// with the chosen lifted (chrom, pos, CIGAR), the assigned LiftBackCategory, and the full lifted alignment set.
+//
+// 1:1 contract: every input record produces exactly one result. UNMAPPED / LIFT_FAILED results carry placeholder
+// fields so the downstream emit step can flag the BAM record unmapped without dropping it.
+public class LiftBackResolver
+{
+    private static final String XA_TAG = "XA";
+    private static final String AS_TAG = "AS";
+    private static final String NM_TAG = "NM";
+
+    private static final int RESCUED_MAPQ = 60;
+
+    // minimum flanking M length for an N operator to be treated as a real splice junction in
+    // discriminator decisions. Lift-back of a tx alignment whose last bases bleed into the next exon
+    // can produce N with anchors of 1-3 bp — those are not evidence of splicing and must not swap the
+    // primary off a clean ref full-match. 8 bp gives ~1-in-65k random-match probability.
+    static final int MIN_REAL_N_ANCHOR = 8;
+
+    // per-alt-contig list of segments sorted by altStart so a record's alt-contig position can be
+    // bin-searched back to the owning transcript. Non-alt-contig alignments (ref) fall through unindexed.
+    private final Map<String, List<ContigEntry>> mSegmentsByAltContig;
+
+    public LiftBackResolver(final List<ContigEntry> entries)
+    {
+        mSegmentsByAltContig = new HashMap<>();
+        for(ContigEntry entry : entries)
+            mSegmentsByAltContig.computeIfAbsent(entry.contigName(), k -> new ArrayList<>()).add(entry);
+        for(List<ContigEntry> segments : mSegmentsByAltContig.values())
+            segments.sort(Comparator.comparingInt(ContigEntry::altStart));
+    }
+
+    public Set<String> contigNames()
+    {
+        return mSegmentsByAltContig.keySet();
+    }
+
+    // locates the transcript segment that owns altPos on the given alt contig, or null if the position
+    // falls outside any transcript (e.g. inside the inter-transcript N spacer) or the contig isn't an alt contig.
+    ContigEntry findSegment(final String altContig, final int altPos)
+    {
+        List<ContigEntry> segments = mSegmentsByAltContig.get(altContig);
+        if(segments == null)
+            return null;
+
+        // binary search: find the rightmost segment with altStart <= altPos, then check altEnd
+        int lo = 0;
+        int hi = segments.size() - 1;
+        int candidate = -1;
+        while(lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            if(segments.get(mid).altStart() <= altPos)
+            {
+                candidate = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        if(candidate < 0)
+        {
+            // altPos sits before the first segment's altStart (in the upstream spacer). Hand back the first
+            // segment so ContigTranslator's leading-overhang clamp can salvage it.
+            return segments.isEmpty() ? null : segments.get(0);
+        }
+
+        ContigEntry segment = segments.get(candidate);
+        if(altPos <= segment.altEnd())
+            return segment;
+
+        // altPos sits in the spacer between candidate and candidate+1. Choose whichever neighbour the read
+        // overhangs less, and let ContigTranslator's clamp convert the overhang into soft-clip.
+        if(candidate + 1 < segments.size())
+        {
+            ContigEntry next = segments.get(candidate + 1);
+            int leadingOverhang = next.altStart() - altPos;
+            int trailingOverhang = altPos - segment.altEnd();
+            return leadingOverhang <= trailingOverhang ? next : segment;
+        }
+
+        return segment;
+    }
+
+    // translates a single (contig, pos, cigar) triple from transcript-contig coordinates to genomic.
+    // pass-through (returns the input values) for non-alt contigs. Returns null when the contig is an alt
+    // contig but the position cannot be translated (e.g. it falls into the inter-transcript N spacer).
+    //
+    // intended for callers that want lift-only translation without the full LiftBackResult machinery
+    // (e.g. SA tag rewriting, where mapQ / NM pass through unchanged).
+    public LiftedCoords liftCoords(final String contig, final int pos, final String cigarStr)
+    {
+        LiftCore core = lift(contig, pos, cigarStr);
+        return core == null ? null : new LiftedCoords(core.LiftedChrom, core.LiftedPos, core.LiftedCigar);
+    }
+
+    public static class LiftedCoords
+    {
+        public final String Chromosome;
+        public final int Position;
+        public final String CigarString;
+
+        public LiftedCoords(final String chromosome, final int position, final String cigarString)
+        {
+            Chromosome = chromosome;
+            Position = position;
+            CigarString = cigarString;
+        }
+    }
+
+    // shared lift kernel for liftCoords + liftAlignment. Returns null when the contig is an alt contig but
+    // the position cannot be translated; ref-genome alignments fall through with Entry / ParsedCigar = null.
+    private static final class LiftCore
+    {
+        final ContigEntry Entry;            // null = ref pass-through
+        final String LiftedChrom;
+        final int LiftedPos;
+        final String LiftedCigar;
+        final Cigar ParsedCigar;            // null = ref pass-through (no exon-boundary check needed)
+
+        LiftCore(final ContigEntry entry, final String liftedChrom, final int liftedPos, final String liftedCigar,
+                final Cigar parsedCigar)
+        {
+            Entry = entry;
+            LiftedChrom = liftedChrom;
+            LiftedPos = liftedPos;
+            LiftedCigar = liftedCigar;
+            ParsedCigar = parsedCigar;
+        }
+    }
+
+    private LiftCore lift(final String contig, final int pos, final String cigarStr)
+    {
+        if(!mSegmentsByAltContig.containsKey(contig))
+        {
+            // alt contig missing from the segments map (FASTA/sidecar mismatch) must not pass through
+            // as if it were ref — the resulting "lifted" coords would leak _tx contig names into the BAM
+            // (read RNAME, mate RNEXT, MC) and break downstream tools that key off genomic coords.
+            if(contig.endsWith(ALT_CONTIG_SUFFIX))
+                return null;
+
+            // ref alignment — pass through unchanged
+            return new LiftCore(null, contig, pos, cigarStr, null);
+        }
+
+        ContigEntry entry = findSegment(contig, pos);
+        if(entry == null)
+            return null;
+
+        Cigar cigar = TextCigarCodec.decode(cigarStr);
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(entry, pos, cigar);
+        if(result == null)
+            return null;
+
+        return new LiftCore(entry, result.chromosome(), result.genomicStart(), result.genomicCigar().toString(), cigar);
+    }
+
+    public LiftBackResult resolve(final SAMRecord record)
+    {
+        if(record.getReadUnmappedFlag())
+            return unmappedResult(record);
+
+        if(record.isSecondaryOrSupplementary())
+            return supplementaryResult(record);
+
+        return resolvePrimary(record);
+    }
+
+    private LiftBackResult resolvePrimary(final SAMRecord record)
+    {
+        LiftedAlignment selfAlignment = liftAlignment(
+                LiftedAlignment.AlignmentSource.SELF,
+                record.getReferenceName(), record.getAlignmentStart(), record.getCigarString(),
+                getInt(record, AS_TAG), getInt(record, NM_TAG),
+                !record.getReadNegativeStrandFlag());
+
+        // bwa's chosen primary failed to translate — record kept but flagged unmapped on emit
+        if(selfAlignment == null)
+            return unliftableResult(LiftBackResult.RecordRole.PRIMARY, countXaEntries(record), "primary_translate_failed");
+
+        selfAlignment.IsPrimaryChoice = true;
+
+        List<LiftedAlignment> xaAlts = parseAndLiftXa(record);
+
+        List<LiftedAlignment> allAlignments = new ArrayList<>(1 + xaAlts.size());
+        allAlignments.add(selfAlignment);
+        allAlignments.addAll(xaAlts);
+
+        Features features = categorize(allAlignments);
+
+        // confident discriminator outcomes may swap the BAM primary (when bwa picked a paralog over the
+        // spliced transcript alignment) and mark losing-side alts with Dropped=true. Returns the effective
+        // primary — usually selfAlignment, but a winning tx alt when a swap occurred.
+        DiscriminatorOutcome outcome = applyDiscriminator(allAlignments, features.Category, selfAlignment);
+        LiftedAlignment effectivePrimary = outcome.EffectivePrimary;
+
+        // aggregate stats (loci, cigarsAtPrimary, geneIds) over the kept (non-Dropped) alignments,
+        // matching what the BAM XA tag will surface.
+        List<LiftedAlignment> keptAlignments = keptAlignments(allAlignments);
+        Aggregates aggregates = aggregate(keptAlignments, effectivePrimary);
+
+        // bwa drops MAPQ to 0 when a read ties across multiple alt transcript contigs of the same gene.
+        // when every lifted alignment (self + XA alts) collapses to a single genomic locus, the tie is
+        // an artefact of the transcript-contig representation, not a real multi-mapper — restore MAPQ
+        // so downstream tools (Isofox, redux) don't discard the read as ambiguous.
+        //
+        // also rescue when we swapped the BAM primary to a different locus — bwa's MAPQ belonged to the
+        // (rejected) original locus and shouldn't carry over.
+        int bwaMapq = record.getMappingQuality();
+        boolean swapped = effectivePrimary != selfAlignment;
+        int updatedMapq;
+        if(swapped)
+            updatedMapq = RESCUED_MAPQ;
+        else if(aggregates.NumLoci == 1 && bwaMapq == 0)
+            updatedMapq = RESCUED_MAPQ;
+        else
+            updatedMapq = bwaMapq;
+
+        return new LiftBackResult(
+                features.Category, LiftBackResult.Composition.fromAlignments(keptAlignments),
+                LiftBackResult.RecordRole.PRIMARY,
+                effectivePrimary.LiftedChrom, effectivePrimary.LiftedPos, effectivePrimary.LiftedCigar,
+                !effectivePrimary.ForwardStrand,
+                effectivePrimary.cigarHasN(), bwaMapq, updatedMapq,
+                xaAlts.size(), features.NumRefAlts, features.NumTxAlts,
+                aggregates.NumLoci, aggregates.CigarsAtPrimaryLocus,
+                features.TxHasNCigar, features.TxSoftClipAtBoundary,
+                features.RefSoftClipped, features.RefFullMatch,
+                aggregates.GeneIds, outcome.Note,
+                allAlignments);
+    }
+
+    private static List<LiftedAlignment> keptAlignments(final List<LiftedAlignment> alignments)
+    {
+        return alignments.stream().filter(la -> !la.Dropped).collect(Collectors.toList());
+    }
+
+    private static class Aggregates
+    {
+        int NumLoci;
+        int CigarsAtPrimaryLocus;
+        String GeneIds;
+    }
+
+    private static Aggregates aggregate(final List<LiftedAlignment> alignments, final LiftedAlignment effectivePrimary)
+    {
+        String primaryLocus = locusKey(effectivePrimary);
+        Set<String> loci = new HashSet<>();
+        Set<String> cigarsAtPrimary = new HashSet<>();
+        Set<String> geneIdSet = new HashSet<>();
+        for(LiftedAlignment la : alignments)
+        {
+            String locus = locusKey(la);
+            loci.add(locus);
+            if(locus.equals(primaryLocus))
+                cigarsAtPrimary.add(la.LiftedCigar);
+            if(la.GeneId != null)
+                geneIdSet.add(la.GeneId);
+        }
+        Aggregates aggregates = new Aggregates();
+        aggregates.NumLoci = loci.size();
+        aggregates.CigarsAtPrimaryLocus = cigarsAtPrimary.size();
+        aggregates.GeneIds = geneIdSet.stream().sorted().collect(Collectors.joining("|"));
+        return aggregates;
+    }
+
+    // bundles the effective-primary alignment with a diagnostic note. Effective primary equals selfAlignment
+    // for most categories; for tx-favouring discriminators when bwa picked ref as primary, it is the winning
+    // tx alt (BAM primary is swapped onto it, original ref-self demoted to an XA entry).
+    private static class DiscriminatorOutcome
+    {
+        final LiftedAlignment EffectivePrimary;
+        final String Note;
+
+        DiscriminatorOutcome(final LiftedAlignment effectivePrimary, final String note)
+        {
+            EffectivePrimary = effectivePrimary;
+            Note = note;
+        }
+    }
+
+    // applies confident discriminator outcomes:
+    //   - marks losing-side alts with Dropped=true (stay in LiftedAlignments for TSV-B diagnostics,
+    //     excluded from the rebuilt BAM XA tag)
+    //   - swaps the BAM primary onto the winning side when bwa's chosen primary disagreed with the
+    //     discriminator (e.g. bwa picked a processed-pseudogene paralog over the spliced parent gene).
+    private static DiscriminatorOutcome applyDiscriminator(
+            final List<LiftedAlignment> alignments, final LiftBackCategory category, final LiftedAlignment self)
+    {
+        switch(category)
+        {
+            case BOTH_TX_JUNCTION_REF_SOFTCLIP:
+            case BOTH_MULTI_TX_JUNCTION:
+                return promoteTxOverRef(alignments, self);
+
+            case BOTH_TX_JUNCTION_REF_MATCH:
+                // ref full-match across the supposed intron with NM=0 is overwhelming evidence the read is
+                // genuinely unspliced (pre-mRNA / retained-intron / DNA contamination). 100bp of intron
+                // matching by chance is ~4^-100 — essentially zero. The tx N-CIGAR is the artifact, not the
+                // ref full-match. Favour ref and drop the tx alt.
+                return promoteRefOverTx(alignments, self);
+
+            case BOTH_TX_SOFTCLIP_REF_MATCH:
+                if(!self.fromTxContig())
+                {
+                    for(LiftedAlignment la : alignments)
+                        if(la.fromTxContig())
+                            la.Dropped = true;
+                    return new DiscriminatorOutcome(self, "");
+                }
+                return new DiscriminatorOutcome(self, "self_was_tx_no_swap");
+
+            default:
+                return new DiscriminatorOutcome(self, "");
+        }
+    }
+
+    // ref-favouring outcome (mirror of promoteTxOverRef). If self is ref, drop all tx alts. If self is
+    // tx, swap: promote the winning ref alt to primary, demote self (tx) to XA, drop other tx alts.
+    private static DiscriminatorOutcome promoteRefOverTx(
+            final List<LiftedAlignment> alignments, final LiftedAlignment self)
+    {
+        if(!self.fromTxContig())
+        {
+            for(final LiftedAlignment la : alignments)
+                if(la.fromTxContig())
+                    la.Dropped = true;
+            return new DiscriminatorOutcome(self, "");
+        }
+
+        // self is tx — promote the first ref alt
+        LiftedAlignment winner = null;
+        for(final LiftedAlignment la : alignments)
+        {
+            if(!la.fromTxContig())
+            {
+                winner = la;
+                break;
+            }
+        }
+        if(winner == null)
+            return new DiscriminatorOutcome(self, "");
+
+        self.IsPrimaryChoice = false;
+        winner.IsPrimaryChoice = true;
+        // keep self (tx) in XA as a transcript hit; drop OTHER tx alts
+        for(final LiftedAlignment la : alignments)
+        {
+            if(la.fromTxContig() && la != self)
+                la.Dropped = true;
+        }
+        return new DiscriminatorOutcome(winner, "swapped_tx_to_ref");
+    }
+
+    // tx-favouring outcome: keep the best tx alt as primary. If self is tx, drop all ref alts. If self is
+    // ref, swap: promote the winning tx alt to primary, demote self to XA (preserves the original locus as
+    // an informative paralog hit), and drop other ref alts.
+    private static DiscriminatorOutcome promoteTxOverRef(
+            final List<LiftedAlignment> alignments, final LiftedAlignment self)
+    {
+        if(self.fromTxContig())
+        {
+            for(LiftedAlignment la : alignments)
+                if(!la.fromTxContig())
+                    la.Dropped = true;
+            return new DiscriminatorOutcome(self, "");
+        }
+
+        // self is ref — prefer the tx alt that actually carries the N junction; fall back to any tx alt
+        LiftedAlignment winner = null;
+        for(LiftedAlignment la : alignments)
+        {
+            if(la.fromTxContig() && la.cigarHasN())
+            {
+                winner = la;
+                break;
+            }
+        }
+        if(winner == null)
+        {
+            for(LiftedAlignment la : alignments)
+            {
+                if(la.fromTxContig())
+                {
+                    winner = la;
+                    break;
+                }
+            }
+        }
+        if(winner == null)
+            return new DiscriminatorOutcome(self, "");
+
+        self.IsPrimaryChoice = false;
+        winner.IsPrimaryChoice = true;
+        // keep self in XA as a paralog reference; drop OTHER ref alts (paralog noise)
+        for(LiftedAlignment la : alignments)
+        {
+            if(!la.fromTxContig() && la != self)
+                la.Dropped = true;
+        }
+        return new DiscriminatorOutcome(winner, "swapped_ref_to_tx");
+    }
+
+    private LiftBackResult supplementaryResult(final SAMRecord record)
+    {
+        LiftedAlignment lifted = liftAlignment(
+                LiftedAlignment.AlignmentSource.SELF,
+                record.getReferenceName(), record.getAlignmentStart(), record.getCigarString(),
+                getInt(record, AS_TAG), getInt(record, NM_TAG),
+                !record.getReadNegativeStrandFlag());
+
+        if(lifted == null)
+            return unliftableResult(LiftBackResult.RecordRole.SUPPLEMENTARY, 0, "supp_translate_failed");
+
+        lifted.IsPrimaryChoice = true;
+
+        // supplementaries don't carry XA, so collapsed-locus check doesn't apply. Rescue only when bwa
+        // dropped to 0 on a tx-contig supp (the multi-alt-contig tie artefact); leave non-zero MAPQ alone.
+        int bwaMapq = record.getMappingQuality();
+        int suppMapq = (lifted.fromTxContig() && bwaMapq == 0) ? RESCUED_MAPQ : bwaMapq;
+
+        int numRefAlts = lifted.fromTxContig() ? 0 : 1;
+        int numTxAlts = lifted.fromTxContig() ? 1 : 0;
+
+        return new LiftBackResult(
+                LiftBackCategory.SUPPLEMENTARY, LiftBackResult.Composition.fromAlignments(List.of(lifted)),
+                LiftBackResult.RecordRole.SUPPLEMENTARY,
+                lifted.LiftedChrom, lifted.LiftedPos, lifted.LiftedCigar,
+                !lifted.ForwardStrand,
+                lifted.cigarHasN(), bwaMapq, suppMapq,
+                0, numRefAlts, numTxAlts,
+                1, 1,
+                false, false, false, false,
+                lifted.GeneId != null ? lifted.GeneId : "", "",
+                List.of(lifted));
+    }
+
+    // bundles the category decision with the per-alignment evidence the discriminator collected.
+    // emitted into TSV-A so post-hoc analysis can answer "why did this read land in category X?"
+    static class Features
+    {
+        LiftBackCategory Category;
+        int NumRefAlts;
+        int NumTxAlts;
+        boolean TxHasNCigar;
+        boolean TxSoftClipAtBoundary;
+        boolean RefSoftClipped;
+        boolean RefFullMatch;
+        boolean RefHasNCigar;
+    }
+
+    private Features categorize(final List<LiftedAlignment> alignments)
+    {
+        Features features = new Features();
+
+        if(alignments.isEmpty())
+        {
+            features.Category = LiftBackCategory.LIFT_FAILED;
+            return features;
+        }
+
+        Set<String> loci = new HashSet<>();
+        boolean anyHasN = false;
+        Set<String> distinctCigars = new HashSet<>();
+
+        for(LiftedAlignment alignment : alignments)
+        {
+            loci.add(locusKey(alignment));
+            distinctCigars.add(alignment.LiftedCigar);
+            if(alignment.cigarHasN())
+                anyHasN = true;
+
+            if(alignment.fromTxContig())
+            {
+                ++features.NumTxAlts;
+                if(alignment.cigarHasRealNJunction(MIN_REAL_N_ANCHOR))
+                    features.TxHasNCigar = true;
+                if(alignment.SoftClipAtBoundary)
+                    features.TxSoftClipAtBoundary = true;
+            }
+            else
+            {
+                ++features.NumRefAlts;
+                if(alignment.cigarHasSoftClip())
+                    features.RefSoftClipped = true;
+                else
+                    features.RefFullMatch = true;
+                if(alignment.cigarHasRealNJunction(MIN_REAL_N_ANCHOR))
+                    features.RefHasNCigar = true;
+            }
+        }
+
+        boolean hasRef = features.NumRefAlts > 0;
+        boolean hasTx = features.NumTxAlts > 0;
+
+        if(loci.size() >= 2)
+        {
+            if(hasRef && hasTx)
+            {
+                // tx found an annotated junction (N-CIGAR) at one locus; ref alts hit other loci
+                // intronlessly — almost always processed pseudogenes / paralogs. Favour tx and swap
+                // the BAM primary onto it.
+                if(features.TxHasNCigar && !features.RefHasNCigar)
+                    features.Category = LiftBackCategory.BOTH_MULTI_TX_JUNCTION;
+                else
+                    features.Category = LiftBackCategory.BOTH_MULTI;
+            }
+            else if(hasTx)
+                features.Category = LiftBackCategory.TX_MULTI;
+            else
+                features.Category = LiftBackCategory.REF_MULTI;
+            return features;
+        }
+
+        // numLoci == 1
+        if(hasRef && !hasTx)
+        {
+            features.Category = LiftBackCategory.REF_SINGLE;
+            return features;
+        }
+        if(hasTx && !hasRef)
+        {
+            features.Category = LiftBackCategory.TX_SINGLE;
+            return features;
+        }
+
+        // single locus, both ref and tx contributed — run discriminator
+        if(distinctCigars.size() == 1 && !anyHasN)
+            features.Category = LiftBackCategory.BOTH_AGREE;
+        else if(features.TxHasNCigar && features.RefSoftClipped)
+            features.Category = LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP;
+        else if(features.TxHasNCigar && features.RefFullMatch && !features.RefSoftClipped)
+            // tx found a real junction; ref ignored it and stretched through with a full match.
+            // tx is the more faithful alignment — drop the ref alt downstream.
+            features.Category = LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH;
+        else if(features.TxSoftClipAtBoundary && features.RefFullMatch)
+            features.Category = LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH;
+        else
+            features.Category = LiftBackCategory.BOTH_AMBIGUOUS;
+
+        return features;
+    }
+
+    // parses the XA tag, lifts each alt, then dedupes (Stage 2):
+    //   - drops XA entries that fail to lift or fail to parse
+    //   - dedupes among XA alts by lifted (chrom, pos, CIGAR), keeping first occurrence.
+    // Self is intentionally NOT included in the dedup key set so a Tx XA alt that lifts to the same
+    // (chrom, pos, CIGAR) as a ref self-alignment is preserved (drives BOTH_AGREE).
+    private List<LiftedAlignment> parseAndLiftXa(final SAMRecord record)
+    {
+        List<LiftedAlignment> alts = new ArrayList<>();
+        String xa = record.getStringAttribute(XA_TAG);
+        if(xa == null || xa.isEmpty())
+            return alts;
+
+        Set<String> seenKeys = new HashSet<>();
+
+        for(String entry : xa.split(";"))
+        {
+            if(entry.isEmpty())
+                continue;
+            String[] parts = entry.split(",");
+            if(parts.length < 4)
+                continue;
+
+            String contig = parts[0];
+            String cigar = parts[2];
+
+            // bwa XA pos is signed (sign = strand); be tolerant of malformed XA — skip entries we can't parse
+            int signedPos;
+            int nm;
+            try
+            {
+                signedPos = Integer.parseInt(parts[1]);
+            }
+            catch(NumberFormatException e)
+            {
+                continue;
+            }
+            try
+            {
+                nm = Integer.parseInt(parts[3]);
+            }
+            catch(NumberFormatException e)
+            {
+                nm = 0;
+            }
+
+            boolean forwardStrand = signedPos >= 0;
+            int pos = Math.abs(signedPos);
+
+            LiftedAlignment lifted = liftAlignment(
+                    LiftedAlignment.AlignmentSource.XA_INPUT, contig, pos, cigar, 0, nm, forwardStrand);
+            if(lifted == null)
+                continue;
+            if(seenKeys.add(liftedKey(lifted)))
+                alts.add(lifted);
+        }
+
+        return alts;
+    }
+
+    private LiftedAlignment liftAlignment(
+            final LiftedAlignment.AlignmentSource source, final String contig, final int pos, final String cigarStr,
+            final int as, final int nm, final boolean forwardStrand)
+    {
+        LiftCore core = lift(contig, pos, cigarStr);
+        if(core == null)
+            return null;
+
+        if(core.Entry == null)
+        {
+            // ref alignment — pass through unchanged; no transcript metadata, no boundary check
+            return new LiftedAlignment(
+                    source, contig, pos, cigarStr,
+                    core.LiftedChrom, core.LiftedPos, core.LiftedCigar,
+                    as, nm,
+                    null, null, null,
+                    false, forwardStrand);
+        }
+
+        boolean softClipAtBoundary = ContigTranslator.hasSoftClipAtExonBoundary(core.Entry, pos, core.ParsedCigar);
+
+        return new LiftedAlignment(
+                source, contig, pos, cigarStr,
+                core.LiftedChrom, core.LiftedPos, core.LiftedCigar,
+                as, nm,
+                core.Entry.transName(), core.Entry.geneId(), core.Entry.geneName(),
+                softClipAtBoundary, forwardStrand);
+    }
+
+    private static String liftedKey(final LiftedAlignment la)
+    {
+        return la.LiftedChrom + ":" + la.LiftedPos + ":" + la.LiftedCigar;
+    }
+
+    private static String locusKey(final LiftedAlignment la)
+    {
+        return la.LiftedChrom + ":" + la.LiftedPos;
+    }
+
+    private static int countXaEntries(final SAMRecord record)
+    {
+        String xa = record.getStringAttribute(XA_TAG);
+        if(xa == null || xa.isEmpty())
+            return 0;
+
+        int count = 0;
+        for(String entry : xa.split(";"))
+        {
+            if(!entry.isEmpty())
+                ++count;
+        }
+        return count;
+    }
+
+    private static int getInt(final SAMRecord record, final String tag)
+    {
+        Integer val = record.getIntegerAttribute(tag);
+        return val != null ? val : 0;
+    }
+
+    private static LiftBackResult unmappedResult(final SAMRecord record)
+    {
+        LiftBackResult.RecordRole role = record.isSecondaryOrSupplementary()
+                ? LiftBackResult.RecordRole.SUPPLEMENTARY
+                : LiftBackResult.RecordRole.PRIMARY;
+
+        return new LiftBackResult(
+                LiftBackCategory.UNMAPPED, LiftBackResult.Composition.NONE,
+                role,
+                "*", 0, "*",
+                false,
+                false, 0, 0,
+                0, 0, 0,
+                0, 0,
+                false, false, false, false,
+                "", "",
+                List.<LiftedAlignment>of());
+    }
+
+    private static LiftBackResult unliftableResult(final LiftBackResult.RecordRole role, final int numXaAlts, final String note)
+    {
+        return new LiftBackResult(
+                LiftBackCategory.LIFT_FAILED, LiftBackResult.Composition.NONE,
+                role,
+                "*", 0, "*",
+                false,
+                false, 0, 0,
+                numXaAlts, 0, 0,
+                0, 0,
+                false, false, false, false,
+                "", note,
+                List.<LiftedAlignment>of());
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResolver.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResolver.java
@@ -28,12 +28,6 @@ public class LiftBackResolver
 
     private static final int RESCUED_MAPQ = 60;
 
-    // minimum flanking M length for an N operator to be treated as a real splice junction in
-    // discriminator decisions. Lift-back of a tx alignment whose last bases bleed into the next exon
-    // can produce N with anchors of 1-3 bp — those are not evidence of splicing and must not swap the
-    // primary off a clean ref full-match. 8 bp gives ~1-in-65k random-match probability.
-    static final int MIN_REAL_N_ANCHOR = 8;
-
     // per-alt-contig list of segments sorted by altStart so a record's alt-contig position can be
     // bin-searched back to the owning transcript. Non-alt-contig alignments (ref) fall through unindexed.
     private final Map<String, List<ContigEntry>> mSegmentsByAltContig;
@@ -41,9 +35,9 @@ public class LiftBackResolver
     public LiftBackResolver(final List<ContigEntry> entries)
     {
         mSegmentsByAltContig = new HashMap<>();
-        for(ContigEntry entry : entries)
+        for(final ContigEntry entry : entries)
             mSegmentsByAltContig.computeIfAbsent(entry.contigName(), k -> new ArrayList<>()).add(entry);
-        for(List<ContigEntry> segments : mSegmentsByAltContig.values())
+        for(final List<ContigEntry> segments : mSegmentsByAltContig.values())
             segments.sort(Comparator.comparingInt(ContigEntry::altStart));
     }
 
@@ -56,17 +50,16 @@ public class LiftBackResolver
     // falls outside any transcript (e.g. inside the inter-transcript N spacer) or the contig isn't an alt contig.
     ContigEntry findSegment(final String altContig, final int altPos)
     {
-        List<ContigEntry> segments = mSegmentsByAltContig.get(altContig);
+        final List<ContigEntry> segments = mSegmentsByAltContig.get(altContig);
         if(segments == null)
             return null;
 
-        // binary search: find the rightmost segment with altStart <= altPos, then check altEnd
         int lo = 0;
         int hi = segments.size() - 1;
         int candidate = -1;
         while(lo <= hi)
         {
-            int mid = (lo + hi) >>> 1;
+            final int mid = (lo + hi) >>> 1;
             if(segments.get(mid).altStart() <= altPos)
             {
                 candidate = mid;
@@ -85,7 +78,7 @@ public class LiftBackResolver
             return segments.isEmpty() ? null : segments.get(0);
         }
 
-        ContigEntry segment = segments.get(candidate);
+        final ContigEntry segment = segments.get(candidate);
         if(altPos <= segment.altEnd())
             return segment;
 
@@ -93,86 +86,23 @@ public class LiftBackResolver
         // overhangs less, and let ContigTranslator's clamp convert the overhang into soft-clip.
         if(candidate + 1 < segments.size())
         {
-            ContigEntry next = segments.get(candidate + 1);
-            int leadingOverhang = next.altStart() - altPos;
-            int trailingOverhang = altPos - segment.altEnd();
+            final ContigEntry next = segments.get(candidate + 1);
+            final int leadingOverhang = next.altStart() - altPos;
+            final int trailingOverhang = altPos - segment.altEnd();
             return leadingOverhang <= trailingOverhang ? next : segment;
         }
 
         return segment;
     }
 
-    // translates a single (contig, pos, cigar) triple from transcript-contig coordinates to genomic.
-    // pass-through (returns the input values) for non-alt contigs. Returns null when the contig is an alt
-    // contig but the position cannot be translated (e.g. it falls into the inter-transcript N spacer).
-    //
-    // intended for callers that want lift-only translation without the full LiftBackResult machinery
-    // (e.g. SA tag rewriting, where mapQ / NM pass through unchanged).
+    // lift-only API for callers that don't need the full LiftBackResult machinery (e.g. SA tag rewriting).
     public LiftedCoords liftCoords(final String contig, final int pos, final String cigarStr)
     {
-        LiftCore core = lift(contig, pos, cigarStr);
-        return core == null ? null : new LiftedCoords(core.LiftedChrom, core.LiftedPos, core.LiftedCigar);
-    }
-
-    public static class LiftedCoords
-    {
-        public final String Chromosome;
-        public final int Position;
-        public final String CigarString;
-
-        public LiftedCoords(final String chromosome, final int position, final String cigarString)
-        {
-            Chromosome = chromosome;
-            Position = position;
-            CigarString = cigarString;
-        }
-    }
-
-    // shared lift kernel for liftCoords + liftAlignment. Returns null when the contig is an alt contig but
-    // the position cannot be translated; ref-genome alignments fall through with Entry / ParsedCigar = null.
-    private static final class LiftCore
-    {
-        final ContigEntry Entry;            // null = ref pass-through
-        final String LiftedChrom;
-        final int LiftedPos;
-        final String LiftedCigar;
-        final Cigar ParsedCigar;            // null = ref pass-through (no exon-boundary check needed)
-
-        LiftCore(final ContigEntry entry, final String liftedChrom, final int liftedPos, final String liftedCigar,
-                final Cigar parsedCigar)
-        {
-            Entry = entry;
-            LiftedChrom = liftedChrom;
-            LiftedPos = liftedPos;
-            LiftedCigar = liftedCigar;
-            ParsedCigar = parsedCigar;
-        }
-    }
-
-    private LiftCore lift(final String contig, final int pos, final String cigarStr)
-    {
-        if(!mSegmentsByAltContig.containsKey(contig))
-        {
-            // alt contig missing from the segments map (FASTA/sidecar mismatch) must not pass through
-            // as if it were ref — the resulting "lifted" coords would leak _tx contig names into the BAM
-            // (read RNAME, mate RNEXT, MC) and break downstream tools that key off genomic coords.
-            if(contig.endsWith(ALT_CONTIG_SUFFIX))
-                return null;
-
-            // ref alignment — pass through unchanged
-            return new LiftCore(null, contig, pos, cigarStr, null);
-        }
-
-        ContigEntry entry = findSegment(contig, pos);
-        if(entry == null)
+        final LiftedAlignment lifted = liftAlignment(
+                LiftedAlignment.AlignmentSource.SELF, contig, pos, cigarStr, 0, 0, true);
+        if(lifted == null)
             return null;
-
-        Cigar cigar = TextCigarCodec.decode(cigarStr);
-        ContigTranslator.TranslationResult result = ContigTranslator.translate(entry, pos, cigar);
-        if(result == null)
-            return null;
-
-        return new LiftCore(entry, result.chromosome(), result.genomicStart(), result.genomicCigar().toString(), cigar);
+        return new LiftedCoords(lifted.LiftedChrom, lifted.LiftedPos, lifted.LiftedCigar);
     }
 
     public LiftBackResult resolve(final SAMRecord record)
@@ -188,50 +118,45 @@ public class LiftBackResolver
 
     private LiftBackResult resolvePrimary(final SAMRecord record)
     {
-        LiftedAlignment selfAlignment = liftAlignment(
+        final LiftedAlignment self = liftAlignment(
                 LiftedAlignment.AlignmentSource.SELF,
                 record.getReferenceName(), record.getAlignmentStart(), record.getCigarString(),
                 getInt(record, AS_TAG), getInt(record, NM_TAG),
                 !record.getReadNegativeStrandFlag());
 
-        // bwa's chosen primary failed to translate — record kept but flagged unmapped on emit
-        if(selfAlignment == null)
+        if(self == null)
             return unliftableResult(LiftBackResult.RecordRole.PRIMARY, countXaEntries(record), "primary_translate_failed");
 
-        selfAlignment.IsPrimaryChoice = true;
+        self.IsPrimaryChoice = true;
 
-        List<LiftedAlignment> xaAlts = parseAndLiftXa(record);
+        final List<LiftedAlignment> xaAlts = parseAndLiftXa(record);
 
-        List<LiftedAlignment> allAlignments = new ArrayList<>(1 + xaAlts.size());
-        allAlignments.add(selfAlignment);
+        final List<LiftedAlignment> allAlignments = new ArrayList<>(1 + xaAlts.size());
+        allAlignments.add(self);
         allAlignments.addAll(xaAlts);
 
-        Features features = categorize(allAlignments);
+        final LiftBackDiscriminator.Features features = LiftBackDiscriminator.categorize(allAlignments);
+        final LiftBackDiscriminator.Outcome outcome = LiftBackDiscriminator.apply(allAlignments, features.Category, self);
+        final LiftedAlignment effectivePrimary = outcome.effectivePrimary();
 
-        // confident discriminator outcomes may swap the BAM primary (when bwa picked a paralog over the
-        // spliced transcript alignment) and mark losing-side alts with Dropped=true. Returns the effective
-        // primary — usually selfAlignment, but a winning tx alt when a swap occurred.
-        DiscriminatorOutcome outcome = applyDiscriminator(allAlignments, features.Category, selfAlignment);
-        LiftedAlignment effectivePrimary = outcome.EffectivePrimary;
+        final List<LiftedAlignment> keptAlignments = allAlignments.stream()
+                .filter(la -> !la.Dropped)
+                .collect(Collectors.toList());
 
-        // aggregate stats (loci, cigarsAtPrimary, geneIds) over the kept (non-Dropped) alignments,
-        // matching what the BAM XA tag will surface.
-        List<LiftedAlignment> keptAlignments = keptAlignments(allAlignments);
-        Aggregates aggregates = aggregate(keptAlignments, effectivePrimary);
+        final int numLoci = countDistinctLoci(keptAlignments);
+        final int cigarsAtPrimaryLocus = countDistinctCigarsAtLocus(keptAlignments, effectivePrimary);
+        final String geneIds = joinGeneIds(keptAlignments);
 
         // bwa drops MAPQ to 0 when a read ties across multiple alt transcript contigs of the same gene.
-        // when every lifted alignment (self + XA alts) collapses to a single genomic locus, the tie is
-        // an artefact of the transcript-contig representation, not a real multi-mapper — restore MAPQ
-        // so downstream tools (Isofox, redux) don't discard the read as ambiguous.
-        //
-        // also rescue when we swapped the BAM primary to a different locus — bwa's MAPQ belonged to the
-        // (rejected) original locus and shouldn't carry over.
-        int bwaMapq = record.getMappingQuality();
-        boolean swapped = effectivePrimary != selfAlignment;
-        int updatedMapq;
+        // when every lifted alignment collapses to a single genomic locus, the tie is an artefact of the
+        // transcript-contig representation, not a real multi-mapper — restore MAPQ so downstream tools
+        // (Isofox, redux) don't discard the read as ambiguous. Also rescue when we swapped the BAM primary.
+        final int bwaMapq = record.getMappingQuality();
+        final boolean swapped = effectivePrimary != self;
+        final int updatedMapq;
         if(swapped)
             updatedMapq = RESCUED_MAPQ;
-        else if(aggregates.NumLoci == 1 && bwaMapq == 0)
+        else if(numLoci == 1 && bwaMapq == 0)
             updatedMapq = RESCUED_MAPQ;
         else
             updatedMapq = bwaMapq;
@@ -243,187 +168,16 @@ public class LiftBackResolver
                 !effectivePrimary.ForwardStrand,
                 effectivePrimary.cigarHasN(), bwaMapq, updatedMapq,
                 xaAlts.size(), features.NumRefAlts, features.NumTxAlts,
-                aggregates.NumLoci, aggregates.CigarsAtPrimaryLocus,
+                numLoci, cigarsAtPrimaryLocus,
                 features.TxHasNCigar, features.TxSoftClipAtBoundary,
                 features.RefSoftClipped, features.RefFullMatch,
-                aggregates.GeneIds, outcome.Note,
+                geneIds, outcome.note(),
                 allAlignments);
-    }
-
-    private static List<LiftedAlignment> keptAlignments(final List<LiftedAlignment> alignments)
-    {
-        return alignments.stream().filter(la -> !la.Dropped).collect(Collectors.toList());
-    }
-
-    private static class Aggregates
-    {
-        int NumLoci;
-        int CigarsAtPrimaryLocus;
-        String GeneIds;
-    }
-
-    private static Aggregates aggregate(final List<LiftedAlignment> alignments, final LiftedAlignment effectivePrimary)
-    {
-        String primaryLocus = locusKey(effectivePrimary);
-        Set<String> loci = new HashSet<>();
-        Set<String> cigarsAtPrimary = new HashSet<>();
-        Set<String> geneIdSet = new HashSet<>();
-        for(LiftedAlignment la : alignments)
-        {
-            String locus = locusKey(la);
-            loci.add(locus);
-            if(locus.equals(primaryLocus))
-                cigarsAtPrimary.add(la.LiftedCigar);
-            if(la.GeneId != null)
-                geneIdSet.add(la.GeneId);
-        }
-        Aggregates aggregates = new Aggregates();
-        aggregates.NumLoci = loci.size();
-        aggregates.CigarsAtPrimaryLocus = cigarsAtPrimary.size();
-        aggregates.GeneIds = geneIdSet.stream().sorted().collect(Collectors.joining("|"));
-        return aggregates;
-    }
-
-    // bundles the effective-primary alignment with a diagnostic note. Effective primary equals selfAlignment
-    // for most categories; for tx-favouring discriminators when bwa picked ref as primary, it is the winning
-    // tx alt (BAM primary is swapped onto it, original ref-self demoted to an XA entry).
-    private static class DiscriminatorOutcome
-    {
-        final LiftedAlignment EffectivePrimary;
-        final String Note;
-
-        DiscriminatorOutcome(final LiftedAlignment effectivePrimary, final String note)
-        {
-            EffectivePrimary = effectivePrimary;
-            Note = note;
-        }
-    }
-
-    // applies confident discriminator outcomes:
-    //   - marks losing-side alts with Dropped=true (stay in LiftedAlignments for TSV-B diagnostics,
-    //     excluded from the rebuilt BAM XA tag)
-    //   - swaps the BAM primary onto the winning side when bwa's chosen primary disagreed with the
-    //     discriminator (e.g. bwa picked a processed-pseudogene paralog over the spliced parent gene).
-    private static DiscriminatorOutcome applyDiscriminator(
-            final List<LiftedAlignment> alignments, final LiftBackCategory category, final LiftedAlignment self)
-    {
-        switch(category)
-        {
-            case BOTH_TX_JUNCTION_REF_SOFTCLIP:
-            case BOTH_MULTI_TX_JUNCTION:
-                return promoteTxOverRef(alignments, self);
-
-            case BOTH_TX_JUNCTION_REF_MATCH:
-                // ref full-match across the supposed intron with NM=0 is overwhelming evidence the read is
-                // genuinely unspliced (pre-mRNA / retained-intron / DNA contamination). 100bp of intron
-                // matching by chance is ~4^-100 — essentially zero. The tx N-CIGAR is the artifact, not the
-                // ref full-match. Favour ref and drop the tx alt.
-                return promoteRefOverTx(alignments, self);
-
-            case BOTH_TX_SOFTCLIP_REF_MATCH:
-                if(!self.fromTxContig())
-                {
-                    for(LiftedAlignment la : alignments)
-                        if(la.fromTxContig())
-                            la.Dropped = true;
-                    return new DiscriminatorOutcome(self, "");
-                }
-                return new DiscriminatorOutcome(self, "self_was_tx_no_swap");
-
-            default:
-                return new DiscriminatorOutcome(self, "");
-        }
-    }
-
-    // ref-favouring outcome (mirror of promoteTxOverRef). If self is ref, drop all tx alts. If self is
-    // tx, swap: promote the winning ref alt to primary, demote self (tx) to XA, drop other tx alts.
-    private static DiscriminatorOutcome promoteRefOverTx(
-            final List<LiftedAlignment> alignments, final LiftedAlignment self)
-    {
-        if(!self.fromTxContig())
-        {
-            for(final LiftedAlignment la : alignments)
-                if(la.fromTxContig())
-                    la.Dropped = true;
-            return new DiscriminatorOutcome(self, "");
-        }
-
-        // self is tx — promote the first ref alt
-        LiftedAlignment winner = null;
-        for(final LiftedAlignment la : alignments)
-        {
-            if(!la.fromTxContig())
-            {
-                winner = la;
-                break;
-            }
-        }
-        if(winner == null)
-            return new DiscriminatorOutcome(self, "");
-
-        self.IsPrimaryChoice = false;
-        winner.IsPrimaryChoice = true;
-        // keep self (tx) in XA as a transcript hit; drop OTHER tx alts
-        for(final LiftedAlignment la : alignments)
-        {
-            if(la.fromTxContig() && la != self)
-                la.Dropped = true;
-        }
-        return new DiscriminatorOutcome(winner, "swapped_tx_to_ref");
-    }
-
-    // tx-favouring outcome: keep the best tx alt as primary. If self is tx, drop all ref alts. If self is
-    // ref, swap: promote the winning tx alt to primary, demote self to XA (preserves the original locus as
-    // an informative paralog hit), and drop other ref alts.
-    private static DiscriminatorOutcome promoteTxOverRef(
-            final List<LiftedAlignment> alignments, final LiftedAlignment self)
-    {
-        if(self.fromTxContig())
-        {
-            for(LiftedAlignment la : alignments)
-                if(!la.fromTxContig())
-                    la.Dropped = true;
-            return new DiscriminatorOutcome(self, "");
-        }
-
-        // self is ref — prefer the tx alt that actually carries the N junction; fall back to any tx alt
-        LiftedAlignment winner = null;
-        for(LiftedAlignment la : alignments)
-        {
-            if(la.fromTxContig() && la.cigarHasN())
-            {
-                winner = la;
-                break;
-            }
-        }
-        if(winner == null)
-        {
-            for(LiftedAlignment la : alignments)
-            {
-                if(la.fromTxContig())
-                {
-                    winner = la;
-                    break;
-                }
-            }
-        }
-        if(winner == null)
-            return new DiscriminatorOutcome(self, "");
-
-        self.IsPrimaryChoice = false;
-        winner.IsPrimaryChoice = true;
-        // keep self in XA as a paralog reference; drop OTHER ref alts (paralog noise)
-        for(LiftedAlignment la : alignments)
-        {
-            if(!la.fromTxContig() && la != self)
-                la.Dropped = true;
-        }
-        return new DiscriminatorOutcome(winner, "swapped_ref_to_tx");
     }
 
     private LiftBackResult supplementaryResult(final SAMRecord record)
     {
-        LiftedAlignment lifted = liftAlignment(
+        final LiftedAlignment lifted = liftAlignment(
                 LiftedAlignment.AlignmentSource.SELF,
                 record.getReferenceName(), record.getAlignmentStart(), record.getCigarString(),
                 getInt(record, AS_TAG), getInt(record, NM_TAG),
@@ -434,13 +188,13 @@ public class LiftBackResolver
 
         lifted.IsPrimaryChoice = true;
 
-        // supplementaries don't carry XA, so collapsed-locus check doesn't apply. Rescue only when bwa
-        // dropped to 0 on a tx-contig supp (the multi-alt-contig tie artefact); leave non-zero MAPQ alone.
-        int bwaMapq = record.getMappingQuality();
-        int suppMapq = (lifted.fromTxContig() && bwaMapq == 0) ? RESCUED_MAPQ : bwaMapq;
+        // supplementaries don't carry XA, so the collapsed-locus check doesn't apply. Rescue MAPQ only on
+        // a tx-contig supp where bwa dropped to 0 due to the multi-alt-contig tie artefact.
+        final int bwaMapq = record.getMappingQuality();
+        final int suppMapq = (lifted.fromTxContig() && bwaMapq == 0) ? RESCUED_MAPQ : bwaMapq;
 
-        int numRefAlts = lifted.fromTxContig() ? 0 : 1;
-        int numTxAlts = lifted.fromTxContig() ? 1 : 0;
+        final int numRefAlts = lifted.fromTxContig() ? 0 : 1;
+        final int numTxAlts = lifted.fromTxContig() ? 1 : 0;
 
         return new LiftBackResult(
                 LiftBackCategory.SUPPLEMENTARY, LiftBackResult.Composition.fromAlignments(List.of(lifted)),
@@ -455,139 +209,31 @@ public class LiftBackResolver
                 List.of(lifted));
     }
 
-    // bundles the category decision with the per-alignment evidence the discriminator collected.
-    // emitted into TSV-A so post-hoc analysis can answer "why did this read land in category X?"
-    static class Features
-    {
-        LiftBackCategory Category;
-        int NumRefAlts;
-        int NumTxAlts;
-        boolean TxHasNCigar;
-        boolean TxSoftClipAtBoundary;
-        boolean RefSoftClipped;
-        boolean RefFullMatch;
-        boolean RefHasNCigar;
-    }
-
-    private Features categorize(final List<LiftedAlignment> alignments)
-    {
-        Features features = new Features();
-
-        if(alignments.isEmpty())
-        {
-            features.Category = LiftBackCategory.LIFT_FAILED;
-            return features;
-        }
-
-        Set<String> loci = new HashSet<>();
-        boolean anyHasN = false;
-        Set<String> distinctCigars = new HashSet<>();
-
-        for(LiftedAlignment alignment : alignments)
-        {
-            loci.add(locusKey(alignment));
-            distinctCigars.add(alignment.LiftedCigar);
-            if(alignment.cigarHasN())
-                anyHasN = true;
-
-            if(alignment.fromTxContig())
-            {
-                ++features.NumTxAlts;
-                if(alignment.cigarHasRealNJunction(MIN_REAL_N_ANCHOR))
-                    features.TxHasNCigar = true;
-                if(alignment.SoftClipAtBoundary)
-                    features.TxSoftClipAtBoundary = true;
-            }
-            else
-            {
-                ++features.NumRefAlts;
-                if(alignment.cigarHasSoftClip())
-                    features.RefSoftClipped = true;
-                else
-                    features.RefFullMatch = true;
-                if(alignment.cigarHasRealNJunction(MIN_REAL_N_ANCHOR))
-                    features.RefHasNCigar = true;
-            }
-        }
-
-        boolean hasRef = features.NumRefAlts > 0;
-        boolean hasTx = features.NumTxAlts > 0;
-
-        if(loci.size() >= 2)
-        {
-            if(hasRef && hasTx)
-            {
-                // tx found an annotated junction (N-CIGAR) at one locus; ref alts hit other loci
-                // intronlessly — almost always processed pseudogenes / paralogs. Favour tx and swap
-                // the BAM primary onto it.
-                if(features.TxHasNCigar && !features.RefHasNCigar)
-                    features.Category = LiftBackCategory.BOTH_MULTI_TX_JUNCTION;
-                else
-                    features.Category = LiftBackCategory.BOTH_MULTI;
-            }
-            else if(hasTx)
-                features.Category = LiftBackCategory.TX_MULTI;
-            else
-                features.Category = LiftBackCategory.REF_MULTI;
-            return features;
-        }
-
-        // numLoci == 1
-        if(hasRef && !hasTx)
-        {
-            features.Category = LiftBackCategory.REF_SINGLE;
-            return features;
-        }
-        if(hasTx && !hasRef)
-        {
-            features.Category = LiftBackCategory.TX_SINGLE;
-            return features;
-        }
-
-        // single locus, both ref and tx contributed — run discriminator
-        if(distinctCigars.size() == 1 && !anyHasN)
-            features.Category = LiftBackCategory.BOTH_AGREE;
-        else if(features.TxHasNCigar && features.RefSoftClipped)
-            features.Category = LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP;
-        else if(features.TxHasNCigar && features.RefFullMatch && !features.RefSoftClipped)
-            // tx found a real junction; ref ignored it and stretched through with a full match.
-            // tx is the more faithful alignment — drop the ref alt downstream.
-            features.Category = LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH;
-        else if(features.TxSoftClipAtBoundary && features.RefFullMatch)
-            features.Category = LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH;
-        else
-            features.Category = LiftBackCategory.BOTH_AMBIGUOUS;
-
-        return features;
-    }
-
-    // parses the XA tag, lifts each alt, then dedupes (Stage 2):
-    //   - drops XA entries that fail to lift or fail to parse
-    //   - dedupes among XA alts by lifted (chrom, pos, CIGAR), keeping first occurrence.
-    // Self is intentionally NOT included in the dedup key set so a Tx XA alt that lifts to the same
-    // (chrom, pos, CIGAR) as a ref self-alignment is preserved (drives BOTH_AGREE).
+    // parses the XA tag, lifts each alt, and dedupes XA-internally by lifted (chrom, pos, CIGAR).
+    // Self is intentionally NOT in the dedup key set so a Tx XA alt that lifts to the same coords as a
+    // ref self-alignment is preserved (drives BOTH_AGREE).
     private List<LiftedAlignment> parseAndLiftXa(final SAMRecord record)
     {
-        List<LiftedAlignment> alts = new ArrayList<>();
-        String xa = record.getStringAttribute(XA_TAG);
+        final List<LiftedAlignment> alts = new ArrayList<>();
+        final String xa = record.getStringAttribute(XA_TAG);
         if(xa == null || xa.isEmpty())
             return alts;
 
-        Set<String> seenKeys = new HashSet<>();
+        final Set<String> seenKeys = new HashSet<>();
 
-        for(String entry : xa.split(";"))
+        for(final String entry : xa.split(";"))
         {
             if(entry.isEmpty())
                 continue;
-            String[] parts = entry.split(",");
+            final String[] parts = entry.split(",");
             if(parts.length < 4)
                 continue;
 
-            String contig = parts[0];
-            String cigar = parts[2];
+            final String contig = parts[0];
+            final String cigar = parts[2];
 
-            // bwa XA pos is signed (sign = strand); be tolerant of malformed XA — skip entries we can't parse
-            int signedPos;
+            // bwa XA pos is signed (sign = strand). Tolerate malformed XA — skip entries we can't parse.
+            final int signedPos;
             int nm;
             try
             {
@@ -606,10 +252,10 @@ public class LiftBackResolver
                 nm = 0;
             }
 
-            boolean forwardStrand = signedPos >= 0;
-            int pos = Math.abs(signedPos);
+            final boolean forwardStrand = signedPos >= 0;
+            final int pos = Math.abs(signedPos);
 
-            LiftedAlignment lifted = liftAlignment(
+            final LiftedAlignment lifted = liftAlignment(
                     LiftedAlignment.AlignmentSource.XA_INPUT, contig, pos, cigar, 0, nm, forwardStrand);
             if(lifted == null)
                 continue;
@@ -620,33 +266,74 @@ public class LiftBackResolver
         return alts;
     }
 
+    // single lift kernel. Returns null when the contig is an alt contig but the position cannot be
+    // translated (alt missing from segments map, or position falls outside any transcript span).
+    // For ref alignments the returned LiftedAlignment is a coord-preserving pass-through.
     private LiftedAlignment liftAlignment(
             final LiftedAlignment.AlignmentSource source, final String contig, final int pos, final String cigarStr,
             final int as, final int nm, final boolean forwardStrand)
     {
-        LiftCore core = lift(contig, pos, cigarStr);
-        if(core == null)
-            return null;
-
-        if(core.Entry == null)
+        if(!mSegmentsByAltContig.containsKey(contig))
         {
-            // ref alignment — pass through unchanged; no transcript metadata, no boundary check
+            // alt contig missing from the segments map (FASTA/sidecar mismatch) must not pass through
+            // as if it were ref — the resulting "lifted" coords would leak _tx contig names into the BAM.
+            if(contig.endsWith(ALT_CONTIG_SUFFIX))
+                return null;
+
             return new LiftedAlignment(
                     source, contig, pos, cigarStr,
-                    core.LiftedChrom, core.LiftedPos, core.LiftedCigar,
+                    contig, pos, cigarStr,
                     as, nm,
                     null, null, null,
                     false, forwardStrand);
         }
 
-        boolean softClipAtBoundary = ContigTranslator.hasSoftClipAtExonBoundary(core.Entry, pos, core.ParsedCigar);
+        final ContigEntry entry = findSegment(contig, pos);
+        if(entry == null)
+            return null;
+
+        final Cigar parsedCigar = TextCigarCodec.decode(cigarStr);
+        final ContigTranslator.TranslationResult translated = ContigTranslator.translate(entry, pos, parsedCigar);
+        if(translated == null)
+            return null;
+
+        final boolean softClipAtBoundary = ContigTranslator.hasSoftClipAtExonBoundary(entry, pos, parsedCigar);
 
         return new LiftedAlignment(
                 source, contig, pos, cigarStr,
-                core.LiftedChrom, core.LiftedPos, core.LiftedCigar,
+                translated.chromosome(), translated.genomicStart(), translated.genomicCigar().toString(),
                 as, nm,
-                core.Entry.transName(), core.Entry.geneId(), core.Entry.geneName(),
+                entry.transName(), entry.geneId(), entry.geneName(),
                 softClipAtBoundary, forwardStrand);
+    }
+
+    private static int countDistinctLoci(final List<LiftedAlignment> alignments)
+    {
+        final Set<String> loci = new HashSet<>();
+        for(final LiftedAlignment la : alignments)
+            loci.add(locusKey(la));
+        return loci.size();
+    }
+
+    private static int countDistinctCigarsAtLocus(final List<LiftedAlignment> alignments, final LiftedAlignment primary)
+    {
+        final String primaryLocus = locusKey(primary);
+        final Set<String> cigars = new HashSet<>();
+        for(final LiftedAlignment la : alignments)
+        {
+            if(locusKey(la).equals(primaryLocus))
+                cigars.add(la.LiftedCigar);
+        }
+        return cigars.size();
+    }
+
+    private static String joinGeneIds(final List<LiftedAlignment> alignments)
+    {
+        final Set<String> geneIds = new HashSet<>();
+        for(final LiftedAlignment la : alignments)
+            if(la.GeneId != null)
+                geneIds.add(la.GeneId);
+        return geneIds.stream().sorted().collect(Collectors.joining("|"));
     }
 
     private static String liftedKey(final LiftedAlignment la)
@@ -661,12 +348,12 @@ public class LiftBackResolver
 
     private static int countXaEntries(final SAMRecord record)
     {
-        String xa = record.getStringAttribute(XA_TAG);
+        final String xa = record.getStringAttribute(XA_TAG);
         if(xa == null || xa.isEmpty())
             return 0;
 
         int count = 0;
-        for(String entry : xa.split(";"))
+        for(final String entry : xa.split(";"))
         {
             if(!entry.isEmpty())
                 ++count;
@@ -676,13 +363,13 @@ public class LiftBackResolver
 
     private static int getInt(final SAMRecord record, final String tag)
     {
-        Integer val = record.getIntegerAttribute(tag);
+        final Integer val = record.getIntegerAttribute(tag);
         return val != null ? val : 0;
     }
 
     private static LiftBackResult unmappedResult(final SAMRecord record)
     {
-        LiftBackResult.RecordRole role = record.isSecondaryOrSupplementary()
+        final LiftBackResult.RecordRole role = record.isSecondaryOrSupplementary()
                 ? LiftBackResult.RecordRole.SUPPLEMENTARY
                 : LiftBackResult.RecordRole.PRIMARY;
 
@@ -696,7 +383,7 @@ public class LiftBackResolver
                 0, 0,
                 false, false, false, false,
                 "", "",
-                List.<LiftedAlignment>of());
+                List.of());
     }
 
     private static LiftBackResult unliftableResult(final LiftBackResult.RecordRole role, final int numXaAlts, final String note)
@@ -711,6 +398,6 @@ public class LiftBackResolver
                 0, 0,
                 false, false, false, false,
                 "", note,
-                List.<LiftedAlignment>of());
+                List.of());
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResult.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResult.java
@@ -3,8 +3,30 @@ package com.hartwig.hmftools.redux.splice;
 import java.util.List;
 
 // per-record decision result. Drives the BAM record rewrite and one TSV-A row.
-// LiftedAlignments contains every component of the record's alignment set (self + lifted XA alts) for TSV-B.
-public class LiftBackResult
+// liftedAlignments contains every component of the record's alignment set (self + lifted XA alts) for TSV-B.
+public record LiftBackResult(
+        LiftBackCategory category,
+        Composition comp,
+        RecordRole role,
+        String finalChrom,
+        int finalPos,
+        String finalCigar,
+        boolean negativeStrand,
+        boolean hasNCigar,
+        int bwaMapq,
+        int updatedMapq,
+        int numXaAlts,
+        int numRefAlts,
+        int numTxAlts,
+        int numLoci,
+        int numDistinctCigarsAtPrimaryLocus,
+        boolean txHasNCigar,
+        boolean txSoftClipAtBoundary,
+        boolean refSoftClipped,
+        boolean refFullMatch,
+        String geneIds,
+        String notes,
+        List<LiftedAlignment> liftedAlignments)
 {
     public enum RecordRole
     {
@@ -12,9 +34,8 @@ public class LiftBackResult
         SUPPLEMENTARY
     }
 
-    // describes the contig composition of an alignment set (the BAM record's self + lifted XA alts).
-    // used in two views: (a) post-drop "kept" alignments (LiftBackResult.Comp) drives TSV-A + XA rebuild;
-    // (b) pre-drop full alignment set, derived on the fly from LiftedAlignments, drives the LiftBackStats summary.
+    // contig composition of an alignment set. Two views: (a) post-drop "kept" alignments drives TSV-A +
+    // XA rebuild; (b) pre-drop full alignment set drives the LiftBackStats summary.
     public enum Composition
     {
         REF_ONLY,
@@ -29,7 +50,7 @@ public class LiftBackResult
 
             boolean hasRef = false;
             boolean hasTx = false;
-            for(LiftedAlignment alignment : alignments)
+            for(final LiftedAlignment alignment : alignments)
             {
                 if(alignment.fromTxContig())
                     hasTx = true;
@@ -43,63 +64,5 @@ public class LiftBackResult
                 return TX_ONLY;
             return REF_ONLY;
         }
-    }
-
-    public final LiftBackCategory Category;
-    public final Composition Comp;
-    public final RecordRole Role;
-    public final String FinalChrom;
-    public final int FinalPos;
-    public final String FinalCigar;
-    public final boolean NegativeStrand;
-    public final boolean HasNCigar;
-    public final int BwaMapq;
-    public final int UpdatedMapq;
-    public final int NumXaAlts;
-    public final int NumRefAlts;
-    public final int NumTxAlts;
-    public final int NumLoci;
-    public final int NumDistinctCigarsAtPrimaryLocus;
-    public final boolean TxHasNCigar;
-    public final boolean TxSoftClipAtBoundary;
-    public final boolean RefSoftClipped;
-    public final boolean RefFullMatch;
-    public final String GeneIds;
-    public final String Notes;
-    public final List<LiftedAlignment> LiftedAlignments;
-
-    public LiftBackResult(
-            final LiftBackCategory category, final Composition composition, final RecordRole role,
-            final String finalChrom, final int finalPos, final String finalCigar, final boolean negativeStrand,
-            final boolean hasNCigar, final int bwaMapq, final int updatedMapq,
-            final int numXaAlts, final int numRefAlts, final int numTxAlts,
-            final int numLoci, final int numDistinctCigarsAtPrimaryLocus,
-            final boolean txHasNCigar, final boolean txSoftClipAtBoundary,
-            final boolean refSoftClipped, final boolean refFullMatch,
-            final String geneIds, final String notes,
-            final List<LiftedAlignment> liftedAlignments)
-    {
-        Category = category;
-        Comp = composition;
-        Role = role;
-        FinalChrom = finalChrom;
-        FinalPos = finalPos;
-        FinalCigar = finalCigar;
-        NegativeStrand = negativeStrand;
-        HasNCigar = hasNCigar;
-        BwaMapq = bwaMapq;
-        UpdatedMapq = updatedMapq;
-        NumXaAlts = numXaAlts;
-        NumRefAlts = numRefAlts;
-        NumTxAlts = numTxAlts;
-        NumLoci = numLoci;
-        NumDistinctCigarsAtPrimaryLocus = numDistinctCigarsAtPrimaryLocus;
-        TxHasNCigar = txHasNCigar;
-        TxSoftClipAtBoundary = txSoftClipAtBoundary;
-        RefSoftClipped = refSoftClipped;
-        RefFullMatch = refFullMatch;
-        GeneIds = geneIds;
-        Notes = notes;
-        LiftedAlignments = liftedAlignments;
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResult.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackResult.java
@@ -1,0 +1,105 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.List;
+
+// per-record decision result. Drives the BAM record rewrite and one TSV-A row.
+// LiftedAlignments contains every component of the record's alignment set (self + lifted XA alts) for TSV-B.
+public class LiftBackResult
+{
+    public enum RecordRole
+    {
+        PRIMARY,
+        SUPPLEMENTARY
+    }
+
+    // describes the contig composition of an alignment set (the BAM record's self + lifted XA alts).
+    // used in two views: (a) post-drop "kept" alignments (LiftBackResult.Comp) drives TSV-A + XA rebuild;
+    // (b) pre-drop full alignment set, derived on the fly from LiftedAlignments, drives the LiftBackStats summary.
+    public enum Composition
+    {
+        REF_ONLY,
+        TX_ONLY,
+        REF_AND_TX,
+        NONE;
+
+        public static Composition fromAlignments(final List<LiftedAlignment> alignments)
+        {
+            if(alignments.isEmpty())
+                return NONE;
+
+            boolean hasRef = false;
+            boolean hasTx = false;
+            for(LiftedAlignment alignment : alignments)
+            {
+                if(alignment.fromTxContig())
+                    hasTx = true;
+                else
+                    hasRef = true;
+            }
+
+            if(hasRef && hasTx)
+                return REF_AND_TX;
+            if(hasTx)
+                return TX_ONLY;
+            return REF_ONLY;
+        }
+    }
+
+    public final LiftBackCategory Category;
+    public final Composition Comp;
+    public final RecordRole Role;
+    public final String FinalChrom;
+    public final int FinalPos;
+    public final String FinalCigar;
+    public final boolean NegativeStrand;
+    public final boolean HasNCigar;
+    public final int BwaMapq;
+    public final int UpdatedMapq;
+    public final int NumXaAlts;
+    public final int NumRefAlts;
+    public final int NumTxAlts;
+    public final int NumLoci;
+    public final int NumDistinctCigarsAtPrimaryLocus;
+    public final boolean TxHasNCigar;
+    public final boolean TxSoftClipAtBoundary;
+    public final boolean RefSoftClipped;
+    public final boolean RefFullMatch;
+    public final String GeneIds;
+    public final String Notes;
+    public final List<LiftedAlignment> LiftedAlignments;
+
+    public LiftBackResult(
+            final LiftBackCategory category, final Composition composition, final RecordRole role,
+            final String finalChrom, final int finalPos, final String finalCigar, final boolean negativeStrand,
+            final boolean hasNCigar, final int bwaMapq, final int updatedMapq,
+            final int numXaAlts, final int numRefAlts, final int numTxAlts,
+            final int numLoci, final int numDistinctCigarsAtPrimaryLocus,
+            final boolean txHasNCigar, final boolean txSoftClipAtBoundary,
+            final boolean refSoftClipped, final boolean refFullMatch,
+            final String geneIds, final String notes,
+            final List<LiftedAlignment> liftedAlignments)
+    {
+        Category = category;
+        Comp = composition;
+        Role = role;
+        FinalChrom = finalChrom;
+        FinalPos = finalPos;
+        FinalCigar = finalCigar;
+        NegativeStrand = negativeStrand;
+        HasNCigar = hasNCigar;
+        BwaMapq = bwaMapq;
+        UpdatedMapq = updatedMapq;
+        NumXaAlts = numXaAlts;
+        NumRefAlts = numRefAlts;
+        NumTxAlts = numTxAlts;
+        NumLoci = numLoci;
+        NumDistinctCigarsAtPrimaryLocus = numDistinctCigarsAtPrimaryLocus;
+        TxHasNCigar = txHasNCigar;
+        TxSoftClipAtBoundary = txSoftClipAtBoundary;
+        RefSoftClipped = refSoftClipped;
+        RefFullMatch = refFullMatch;
+        GeneIds = geneIds;
+        Notes = notes;
+        LiftedAlignments = liftedAlignments;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackStats.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackStats.java
@@ -1,0 +1,181 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.utils.file.FileDelimiters.TSV_DELIM;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBufferedWriter;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+
+import htsjdk.samtools.SAMRecord;
+
+// run-level counters for SpliceLiftBack: per-category, alignment-set composition × MAPQ tier, category × MAPQ tier.
+// emits a summary at end-of-run (logs + a TSV) so reviewers can see prevalence before any category pruning is committed.
+public class LiftBackStats
+{
+    private static final double LIFT_FAILED_WARN_FRACTION = 0.01;
+
+    public enum MapqTier
+    {
+        MAPQ_ZERO,         // bwa flagged as multi-mapping
+        MAPQ_POS_MULTI,    // MAPQ > 0 but XA non-empty (some ambiguity remains)
+        MAPQ_POS_UNIQUE    // MAPQ > 0, no XA alts
+    }
+
+    private static final int N_CATEGORIES = LiftBackCategory.values().length;
+    private static final int N_COMPOSITIONS = LiftBackResult.Composition.values().length;
+    private static final int N_TIERS = MapqTier.values().length;
+
+    private final int[] mPerCategory = new int[N_CATEGORIES];
+    private final int[][] mCompositionByTier = new int[N_COMPOSITIONS][N_TIERS];
+    private final int[][] mCategoryByTier = new int[N_CATEGORIES][N_TIERS];
+    private int mTotal = 0;
+
+    public void record(final SAMRecord record, final LiftBackResult result)
+    {
+        // pre-drop full-set composition: includes alts dropped by the discriminator, so the summary reflects what
+        // bwa actually produced (vs. result.Comp, the post-drop "kept" view written to TSV-A).
+        LiftBackResult.Composition fullComposition = LiftBackResult.Composition.fromAlignments(result.LiftedAlignments);
+        MapqTier tier = deriveMapqTier(record, result);
+
+        ++mTotal;
+        ++mPerCategory[result.Category.ordinal()];
+        ++mCompositionByTier[fullComposition.ordinal()][tier.ordinal()];
+        ++mCategoryByTier[result.Category.ordinal()][tier.ordinal()];
+    }
+
+    public int total()
+    {
+        return mTotal;
+    }
+
+    public int categoryCount(final LiftBackCategory category)
+    {
+        return mPerCategory[category.ordinal()];
+    }
+
+    public void logSummary()
+    {
+        RD_LOGGER.info("processed {} records", mTotal);
+
+        RD_LOGGER.info("alignment-set composition x MAPQ tier:");
+        logTable(mCompositionByTier, LiftBackResult.Composition.values(), MapqTier.values());
+
+        RD_LOGGER.info("category x MAPQ tier:");
+        logTable(mCategoryByTier, LiftBackCategory.values(), MapqTier.values());
+
+        RD_LOGGER.info("primary bucket -> category breakdown:");
+        for(LiftBackCategory.PrimaryBucket bucket : LiftBackCategory.PrimaryBucket.values())
+        {
+            int bucketTotal = 0;
+            StringBuilder sb = new StringBuilder();
+            for(LiftBackCategory cat : LiftBackCategory.values())
+            {
+                if(cat.primaryBucket() != bucket)
+                    continue;
+                int count = mPerCategory[cat.ordinal()];
+                bucketTotal += count;
+                if(count > 0)
+                    sb.append(cat.name()).append("=").append(count).append(" ");
+            }
+            if(bucketTotal == 0)
+                continue;
+            RD_LOGGER.info("  {}: total={} {}", bucket.name(), bucketTotal, sb.toString());
+        }
+
+        int unliftable = mPerCategory[LiftBackCategory.LIFT_FAILED.ordinal()];
+        if(mTotal > 0 && unliftable / (double) mTotal > LIFT_FAILED_WARN_FRACTION)
+        {
+            // run is already done; ERROR (not throw) so the operator sees this in log scrapers but the
+            // BAM/TSVs we've already written are still available for inspection.
+            RD_LOGGER.error("LIFT_FAILED rate {} / {} = {}% exceeds {}% threshold — likely sidecar/FASTA mismatch",
+                    unliftable, mTotal,
+                    String.format("%.2f", 100.0 * unliftable / mTotal),
+                    String.format("%.2f", 100.0 * LIFT_FAILED_WARN_FRACTION));
+        }
+    }
+
+    public void writeSummary(final String path) throws IOException
+    {
+        try(BufferedWriter writer = createBufferedWriter(path))
+        {
+            writer.write(String.join(TSV_DELIM, "Section", "RowKey", "ColumnKey", "Count"));
+            writer.newLine();
+
+            for(LiftBackResult.Composition comp : LiftBackResult.Composition.values())
+            {
+                for(MapqTier tier : MapqTier.values())
+                {
+                    int count = mCompositionByTier[comp.ordinal()][tier.ordinal()];
+                    if(count == 0)
+                        continue;
+                    writer.write(String.join(TSV_DELIM,
+                            "composition_x_mapq", comp.name(), tier.name(), String.valueOf(count)));
+                    writer.newLine();
+                }
+            }
+
+            for(LiftBackCategory cat : LiftBackCategory.values())
+            {
+                for(MapqTier tier : MapqTier.values())
+                {
+                    int count = mCategoryByTier[cat.ordinal()][tier.ordinal()];
+                    if(count == 0)
+                        continue;
+                    writer.write(String.join(TSV_DELIM,
+                            "category_x_mapq", cat.name(), tier.name(), String.valueOf(count)));
+                    writer.newLine();
+                }
+            }
+
+            // bucket -> category breakdown: retains the secondary (full) category alongside the
+            // primary bucket grouping used for headline scanning.
+            for(LiftBackCategory.PrimaryBucket bucket : LiftBackCategory.PrimaryBucket.values())
+            {
+                for(LiftBackCategory cat : LiftBackCategory.values())
+                {
+                    if(cat.primaryBucket() != bucket)
+                        continue;
+                    int count = mPerCategory[cat.ordinal()];
+                    if(count == 0)
+                        continue;
+                    writer.write(String.join(TSV_DELIM,
+                            "bucket_x_category", bucket.name(), cat.name(), String.valueOf(count)));
+                    writer.newLine();
+                }
+            }
+        }
+
+        RD_LOGGER.info("wrote summary to {}", path);
+    }
+
+    private static <R extends Enum<R>, C extends Enum<C>> void logTable(
+            final int[][] table, final R[] rows, final C[] cols)
+    {
+        for(R row : rows)
+        {
+            StringBuilder sb = new StringBuilder();
+            int rowTotal = 0;
+            for(C col : cols)
+            {
+                int count = table[row.ordinal()][col.ordinal()];
+                rowTotal += count;
+                if(count > 0)
+                    sb.append(col.name()).append("=").append(count).append(" ");
+            }
+
+            if(rowTotal == 0)
+                continue;
+
+            RD_LOGGER.info("  {}: total={} {}", row.name(), rowTotal, sb.toString());
+        }
+    }
+
+    static MapqTier deriveMapqTier(final SAMRecord record, final LiftBackResult result)
+    {
+        int mapq = record.getMappingQuality();
+        if(mapq == 0)
+            return MapqTier.MAPQ_ZERO;
+        return result.NumXaAlts > 0 ? MapqTier.MAPQ_POS_MULTI : MapqTier.MAPQ_POS_UNIQUE;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackStats.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackStats.java
@@ -34,14 +34,14 @@ public class LiftBackStats
     public void record(final SAMRecord record, final LiftBackResult result)
     {
         // pre-drop full-set composition: includes alts dropped by the discriminator, so the summary reflects what
-        // bwa actually produced (vs. result.Comp, the post-drop "kept" view written to TSV-A).
-        LiftBackResult.Composition fullComposition = LiftBackResult.Composition.fromAlignments(result.LiftedAlignments);
+        // bwa actually produced (vs. result.comp(), the post-drop "kept" view written to TSV-A).
+        LiftBackResult.Composition fullComposition = LiftBackResult.Composition.fromAlignments(result.liftedAlignments());
         MapqTier tier = deriveMapqTier(record, result);
 
         ++mTotal;
-        ++mPerCategory[result.Category.ordinal()];
+        ++mPerCategory[result.category().ordinal()];
         ++mCompositionByTier[fullComposition.ordinal()][tier.ordinal()];
-        ++mCategoryByTier[result.Category.ordinal()][tier.ordinal()];
+        ++mCategoryByTier[result.category().ordinal()][tier.ordinal()];
     }
 
     public int total()
@@ -176,6 +176,6 @@ public class LiftBackStats
         int mapq = record.getMappingQuality();
         if(mapq == 0)
             return MapqTier.MAPQ_ZERO;
-        return result.NumXaAlts > 0 ? MapqTier.MAPQ_POS_MULTI : MapqTier.MAPQ_POS_UNIQUE;
+        return result.numXaAlts() > 0 ? MapqTier.MAPQ_POS_MULTI : MapqTier.MAPQ_POS_UNIQUE;
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackWriter.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftBackWriter.java
@@ -1,0 +1,132 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.utils.file.FileDelimiters.TSV_DELIM;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBufferedWriter;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+
+import htsjdk.samtools.SAMRecord;
+
+// streaming writer for the two LiftBack TSVs (per-record decision + per-alignment detail).
+// owns both BufferedWriters; one instance per SpliceLiftBack run, closed at end.
+public class LiftBackWriter implements AutoCloseable
+{
+    private final BufferedWriter mTsvAWriter;
+    private final BufferedWriter mTsvBWriter;
+
+    // MateNum is 1 for first-of-pair, 2 for second-of-pair, 0 for unpaired records.
+    // Filtered = "true" when the read pair was dropped from the BAM (e.g. rRNA filter); audit row still emitted.
+    private static final String[] TSV_A_HEADERS = {
+            "ReadName", "MateNum", "RecordRole", "PrimaryBucket", "Composition", "DecisionCategory",
+            "BwaMapq", "UpdatedMapq",
+            "NumXaAlts", "NumRefAlts", "NumTxAlts", "NumLoci", "NumDistinctCigarsAtPrimaryLocus",
+            "TxHasNCigar", "TxSoftClipAtBoundary", "RefSoftClipped", "RefFullMatch",
+            "FinalChrom", "FinalPos", "FinalCigar", "HasNCigar",
+            "GeneIds", "Notes", "Filtered"
+    };
+
+    private static final String[] TSV_B_HEADERS = {
+            "ReadName", "MateNum", "RecordRole", "Source",
+            "OrigContig", "OrigPos", "OrigCigar",
+            "LiftedChrom", "LiftedPos", "LiftedCigar",
+            "AlignmentScore", "NumMismatches",
+            "TransName", "GeneId", "GeneName"
+    };
+
+    public LiftBackWriter(final String tsvAPath, final String tsvBPath) throws IOException
+    {
+        mTsvAWriter = createBufferedWriter(tsvAPath);
+        mTsvBWriter = createBufferedWriter(tsvBPath);
+        writeHeader(mTsvAWriter, TSV_A_HEADERS);
+        writeHeader(mTsvBWriter, TSV_B_HEADERS);
+    }
+
+    public void write(final SAMRecord record, final LiftBackResult result, final boolean filtered) throws IOException
+    {
+        final String readName = record.getReadName();
+        final String mateNum = mateNumColumn(record);
+        writeTsvARow(readName, mateNum, result, filtered);
+        for(final LiftedAlignment la : result.LiftedAlignments)
+            writeTsvBRow(readName, mateNum, result.Role, la);
+    }
+
+    private static String mateNumColumn(final SAMRecord record)
+    {
+        if(!record.getReadPairedFlag())
+            return "0";
+        return record.getFirstOfPairFlag() ? "1" : "2";
+    }
+
+    private void writeTsvARow(final String readName, final String mateNum, final LiftBackResult result, final boolean filtered)
+            throws IOException
+    {
+        mTsvAWriter.write(String.join(TSV_DELIM,
+                readName,
+                mateNum,
+                result.Role.name(),
+                result.Category.primaryBucket().name(),
+                result.Comp.name(),
+                result.Category.name(),
+                String.valueOf(result.BwaMapq),
+                String.valueOf(result.UpdatedMapq),
+                String.valueOf(result.NumXaAlts),
+                String.valueOf(result.NumRefAlts),
+                String.valueOf(result.NumTxAlts),
+                String.valueOf(result.NumLoci),
+                String.valueOf(result.NumDistinctCigarsAtPrimaryLocus),
+                String.valueOf(result.TxHasNCigar),
+                String.valueOf(result.TxSoftClipAtBoundary),
+                String.valueOf(result.RefSoftClipped),
+                String.valueOf(result.RefFullMatch),
+                result.FinalChrom,
+                String.valueOf(result.FinalPos),
+                result.FinalCigar,
+                String.valueOf(result.HasNCigar),
+                nullToEmpty(result.GeneIds),
+                nullToEmpty(result.Notes),
+                String.valueOf(filtered)));
+        mTsvAWriter.newLine();
+    }
+
+    private void writeTsvBRow(
+            final String readName, final String mateNum, final LiftBackResult.RecordRole role, final LiftedAlignment la)
+            throws IOException
+    {
+        mTsvBWriter.write(String.join(TSV_DELIM,
+                readName,
+                mateNum,
+                role.name(),
+                la.Source.name(),
+                la.OrigContig,
+                String.valueOf(la.OrigPos),
+                la.OrigCigar,
+                la.LiftedChrom,
+                String.valueOf(la.LiftedPos),
+                la.LiftedCigar,
+                String.valueOf(la.AlignmentScore),
+                String.valueOf(la.NumMismatches),
+                nullToEmpty(la.TransName),
+                nullToEmpty(la.GeneId),
+                nullToEmpty(la.GeneName)));
+        mTsvBWriter.newLine();
+    }
+
+    private static void writeHeader(final BufferedWriter writer, final String[] headers) throws IOException
+    {
+        writer.write(String.join(TSV_DELIM, headers));
+        writer.newLine();
+    }
+
+    private static String nullToEmpty(final String value)
+    {
+        return value != null ? value : "";
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        mTsvAWriter.close();
+        mTsvBWriter.close();
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedAlignment.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedAlignment.java
@@ -1,0 +1,154 @@
+package com.hartwig.hmftools.redux.splice;
+
+// one component of a record's alignment set: the record itself or one of its XA alts, post-lift.
+// TransName / GeneId / GeneName are populated only when the source contig was a Tx contig.
+// SoftClipAtBoundary is true only for Tx alignments whose leading or trailing S abuts an interior exon
+// boundary in the source contig (an actual exon-junction edge, not the contig's outermost edge).
+// ForwardStrand reflects the alignment's strand on the genome (Tx contigs are forward genomic, so strand
+// passes through unchanged from the contig-space alignment).
+public class LiftedAlignment
+{
+    public enum AlignmentSource
+    {
+        SELF,
+        XA_INPUT
+    }
+
+    public final AlignmentSource Source;
+    public final String OrigContig;
+    public final int OrigPos;
+    public final String OrigCigar;
+    public final String LiftedChrom;
+    public final int LiftedPos;
+    public final String LiftedCigar;
+    public final int AlignmentScore;
+    public final int NumMismatches;
+    public final String TransName;
+    public final String GeneId;
+    public final String GeneName;
+    public final boolean SoftClipAtBoundary;
+    public final boolean ForwardStrand;
+
+    // non-final: set by LiftBackResolver when this alignment is on the losing side of a confident
+    // discriminator outcome (JUNCTION_FAVOURS_TX, TX_PICKED_REF_DROPPED, INTRON_RETAINED_FAVOURS_REF,
+    // CROSS_LOCUS_FAVOURS_TX). Dropped alignments stay in LiftedAlignments for TSV-B diagnostics but are
+    // excluded from the BAM XA tag.
+    public boolean Dropped = false;
+
+    // non-final: marks the alignment chosen as the BAM primary. Set true on SELF by default; the
+    // discriminator may flip it to a winning XA alt when bwa's primary pick was suboptimal (e.g. processed
+    // pseudogene preferred over the spliced parent gene). The displaced original becomes an XA entry.
+    public boolean IsPrimaryChoice = false;
+
+    public LiftedAlignment(
+            final AlignmentSource source, final String origContig, final int origPos, final String origCigar,
+            final String liftedChrom, final int liftedPos, final String liftedCigar,
+            final int alignmentScore, final int numMismatches,
+            final String transName, final String geneId, final String geneName,
+            final boolean softClipAtBoundary, final boolean forwardStrand)
+    {
+        Source = source;
+        OrigContig = origContig;
+        OrigPos = origPos;
+        OrigCigar = origCigar;
+        LiftedChrom = liftedChrom;
+        LiftedPos = liftedPos;
+        LiftedCigar = liftedCigar;
+        AlignmentScore = alignmentScore;
+        NumMismatches = numMismatches;
+        TransName = transName;
+        GeneId = geneId;
+        GeneName = geneName;
+        SoftClipAtBoundary = softClipAtBoundary;
+        ForwardStrand = forwardStrand;
+    }
+
+    public boolean fromTxContig()
+    {
+        return TransName != null;
+    }
+
+    public boolean cigarHasN()
+    {
+        return LiftedCigar != null && LiftedCigar.indexOf('N') >= 0;
+    }
+
+    public boolean cigarHasSoftClip()
+    {
+        return LiftedCigar != null && LiftedCigar.indexOf('S') >= 0;
+    }
+
+    // returns true iff the CIGAR has at least one N operator AND every N is flanked by an M
+    // segment of at least minAnchor bp on both sides. Tiny anchors (e.g. 1-3M) on either side of
+    // an N happen by chance when a tx-contig alignment's tail bases bleed across an exon boundary —
+    // those are not real junctions and must not be used as evidence to swap the primary off a clean
+    // ref full-match. The check walks the CIGAR once.
+    public boolean cigarHasRealNJunction(final int minAnchor)
+    {
+        if(LiftedCigar == null)
+            return false;
+
+        boolean foundAny = false;
+        int prevMLength = 0;
+        int currentNum = 0;
+
+        for(int i = 0; i < LiftedCigar.length(); ++i)
+        {
+            final char c = LiftedCigar.charAt(i);
+            if(c >= '0' && c <= '9')
+            {
+                currentNum = currentNum * 10 + (c - '0');
+                continue;
+            }
+
+            if(c == 'N')
+            {
+                if(prevMLength < minAnchor)
+                    return false;
+                // scan ahead for the next M-length; if no M follows, or it is below threshold, fail.
+                final int nextM = nextMLength(LiftedCigar, i + 1);
+                if(nextM < minAnchor)
+                    return false;
+                foundAny = true;
+                prevMLength = 0;
+            }
+            else if(c == 'M' || c == '=' || c == 'X')
+            {
+                prevMLength = currentNum;
+            }
+            else
+            {
+                // any other op (S/I/D/H/P) breaks the "directly adjacent" anchor — treat as zero-length
+                // M for the next N's purposes.
+                prevMLength = 0;
+            }
+
+            currentNum = 0;
+        }
+
+        return foundAny;
+    }
+
+    private static int nextMLength(final String cigar, final int startIndex)
+    {
+        int num = 0;
+        for(int i = startIndex; i < cigar.length(); ++i)
+        {
+            final char c = cigar.charAt(i);
+            if(c >= '0' && c <= '9')
+            {
+                num = num * 10 + (c - '0');
+            }
+            else if(c == 'M' || c == '=' || c == 'X')
+            {
+                return num;
+            }
+            else
+            {
+                // any non-match op before we hit M means there is no directly adjacent M anchor.
+                return 0;
+            }
+        }
+        return 0;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedCoords.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedCoords.java
@@ -1,0 +1,10 @@
+package com.hartwig.hmftools.redux.splice;
+
+// minimal lift result — the translated genomic coordinates of a single alt-contig alignment. Used by
+// SaTagRewriter, where mapQ / NM pass through unchanged so the full LiftBackResult machinery isn't needed.
+public record LiftedCoords(
+        String chromosome,
+        int position,
+        String cigarString)
+{
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedMateInfo.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedMateInfo.java
@@ -1,0 +1,37 @@
+package com.hartwig.hmftools.redux.splice;
+
+// minimal lifted-coord summary for one primary alignment, cached in pass 1 so pass 2 can patch the
+// partner record's mate fields (RNEXT / PNEXT / mate-strand / mate-unmapped / TLEN) without re-resolving.
+public class LiftedMateInfo
+{
+    public final String Chromosome;
+    public final int AlignmentStart;
+    public final int AlignmentEnd;
+    public final String LiftedCigar;
+    public final boolean NegativeStrand; // TODO: IGV colouring: likely needs XS:A:+/- from gene strand, not this field; revisit
+    public final boolean Unmapped;
+
+    private LiftedMateInfo(
+            final String chromosome, final int alignmentStart, final int alignmentEnd, final String liftedCigar,
+            final boolean negativeStrand, final boolean unmapped)
+    {
+        Chromosome = chromosome;
+        AlignmentStart = alignmentStart;
+        AlignmentEnd = alignmentEnd;
+        LiftedCigar = liftedCigar;
+        NegativeStrand = negativeStrand;
+        Unmapped = unmapped;
+    }
+
+    public static LiftedMateInfo mapped(
+            final String chromosome, final int alignmentStart, final int alignmentEnd, final String liftedCigar,
+            final boolean negativeStrand)
+    {
+        return new LiftedMateInfo(chromosome, alignmentStart, alignmentEnd, liftedCigar, negativeStrand, false);
+    }
+
+    public static LiftedMateInfo unmapped()
+    {
+        return new LiftedMateInfo(null, 0, 0, null, false, true);
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedMateInfo.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedMateInfo.java
@@ -2,36 +2,21 @@ package com.hartwig.hmftools.redux.splice;
 
 // minimal lifted-coord summary for one primary alignment, cached in pass 1 so pass 2 can patch the
 // partner record's mate fields (RNEXT / PNEXT / mate-strand / mate-unmapped / TLEN) without re-resolving.
-public class LiftedMateInfo
+// TODO: negativeStrand may need XS:A:+/- from gene strand for IGV colouring — revisit on redux integration.
+public record LiftedMateInfo(
+        String chromosome,
+        int alignmentStart,
+        int alignmentEnd,
+        String liftedCigar,
+        boolean negativeStrand,
+        boolean unmapped)
 {
-    public final String Chromosome;
-    public final int AlignmentStart;
-    public final int AlignmentEnd;
-    public final String LiftedCigar;
-    public final boolean NegativeStrand; // TODO: IGV colouring: likely needs XS:A:+/- from gene strand, not this field; revisit
-    public final boolean Unmapped;
-
-    private LiftedMateInfo(
-            final String chromosome, final int alignmentStart, final int alignmentEnd, final String liftedCigar,
-            final boolean negativeStrand, final boolean unmapped)
-    {
-        Chromosome = chromosome;
-        AlignmentStart = alignmentStart;
-        AlignmentEnd = alignmentEnd;
-        LiftedCigar = liftedCigar;
-        NegativeStrand = negativeStrand;
-        Unmapped = unmapped;
-    }
+    public static final LiftedMateInfo UNMAPPED = new LiftedMateInfo(null, 0, 0, null, false, true);
 
     public static LiftedMateInfo mapped(
             final String chromosome, final int alignmentStart, final int alignmentEnd, final String liftedCigar,
             final boolean negativeStrand)
     {
         return new LiftedMateInfo(chromosome, alignmentStart, alignmentEnd, liftedCigar, negativeStrand, false);
-    }
-
-    public static LiftedMateInfo unmapped()
-    {
-        return new LiftedMateInfo(null, 0, 0, null, false, true);
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedMateInfoCache.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/LiftedMateInfoCache.java
@@ -1,0 +1,60 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// in-memory cache of lifted primary alignment info, keyed by read name. Built in pass 1 of SpliceLiftBack
+// (one entry per paired primary record) and consulted in pass 2 to patch each emitted record's mate fields
+// with its partner's lifted coordinates.
+//
+// Holds only primary alignments. Supplementary and secondary records do not populate mate fields in other
+// records, so they are not cached.
+public class LiftedMateInfoCache
+{
+    private final Map<String, ReadPairLiftedMateInfo> mLiftedMateInfoByReadName;
+
+    public LiftedMateInfoCache()
+    {
+        mLiftedMateInfoByReadName = new HashMap<>();
+    }
+
+    public void recordPrimaryAlignment(final String readName, final boolean firstOfPair, final LiftedMateInfo info)
+    {
+        ReadPairLiftedMateInfo pairInfo = mLiftedMateInfoByReadName.computeIfAbsent(readName, k -> new ReadPairLiftedMateInfo());
+        if(firstOfPair)
+            pairInfo.FirstInPair = info;
+        else
+            pairInfo.SecondInPair = info;
+    }
+
+    // returns the lifted info for the partner of the given read (i.e. R2's info when looking up R1, and vice versa),
+    // or null if the partner's primary was not seen in pass 1.
+    public LiftedMateInfo getPartnerMateInfo(final String readName, final boolean firstOfPair)
+    {
+        ReadPairLiftedMateInfo pairInfo = mLiftedMateInfoByReadName.get(readName);
+        if(pairInfo == null)
+            return null;
+        return firstOfPair ? pairInfo.SecondInPair : pairInfo.FirstInPair;
+    }
+
+    // returns the lifted info for this read's own primary (i.e. R1's primary when given a non-primary R1),
+    // used to mirror primary coords onto a supplementary record whose own lift failed.
+    public LiftedMateInfo getOwnPrimary(final String readName, final boolean firstOfPair)
+    {
+        ReadPairLiftedMateInfo pairInfo = mLiftedMateInfoByReadName.get(readName);
+        if(pairInfo == null)
+            return null;
+        return firstOfPair ? pairInfo.FirstInPair : pairInfo.SecondInPair;
+    }
+
+    public int size()
+    {
+        return mLiftedMateInfoByReadName.size();
+    }
+
+    private static class ReadPairLiftedMateInfo
+    {
+        public LiftedMateInfo FirstInPair;
+        public LiftedMateInfo SecondInPair;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/MateFieldPatcher.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/MateFieldPatcher.java
@@ -1,0 +1,105 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.bam.SamRecordUtils.MATE_CIGAR_ATTRIBUTE;
+
+import htsjdk.samtools.SAMRecord;
+
+// rewrites a record's mate-related fields (RNEXT / PNEXT / mate-strand / mate-unmapped / TLEN / proper-pair)
+// from the partner read's lifted primary info held in the LiftedMateInfoCache.
+//
+// Applied in pass 2 of SpliceLiftBack after the record's own coordinates have been lifted, so that both
+// sides of the pair refer to genomic (not transcript-contig) coordinates and supplementary alignments
+// carry the same mate info as their primary.
+public class MateFieldPatcher
+{
+    public static void patchMateFields(final SAMRecord record, final LiftedMateInfoCache liftedMateInfoCache)
+    {
+        if(!record.getReadPairedFlag())
+            return;
+
+        LiftedMateInfo partnerInfo = liftedMateInfoCache.getPartnerMateInfo(
+                record.getReadName(), record.getFirstOfPairFlag());
+
+        if(partnerInfo == null)
+        {
+            // partner primary not seen in pass 1 — clear proper-pair so downstream doesn't trust mate fields
+            record.setProperPairFlag(false);
+            return;
+        }
+
+        if(partnerInfo.Unmapped)
+        {
+            applyUnmappedPartner(record);
+            return;
+        }
+
+        applyMappedPartner(record, partnerInfo);
+    }
+
+    // SAM convention when the mate is unmapped: place mate at the same position as the read itself,
+    // mark mate-unmapped, drop proper-pair, zero out TLEN.
+    private static void applyUnmappedPartner(final SAMRecord record)
+    {
+        record.setMateUnmappedFlag(true);
+        record.setMateReferenceName(record.getReferenceName());
+        record.setMateAlignmentStart(record.getAlignmentStart());
+        record.setMateNegativeStrandFlag(false);
+        record.setInferredInsertSize(0);
+        record.setProperPairFlag(false);
+        // MC is only meaningful for a mapped mate
+        record.setAttribute(MATE_CIGAR_ATTRIBUTE, null);
+    }
+
+    private static void applyMappedPartner(final SAMRecord record, final LiftedMateInfo partnerInfo)
+    {
+        record.setMateUnmappedFlag(false);
+        record.setMateReferenceName(partnerInfo.Chromosome);
+        record.setMateAlignmentStart(partnerInfo.AlignmentStart);
+        record.setMateNegativeStrandFlag(partnerInfo.NegativeStrand);
+        record.setAttribute(MATE_CIGAR_ATTRIBUTE, partnerInfo.LiftedCigar);
+
+        if(record.getReadUnmappedFlag())
+        {
+            // SAM convention: an unmapped read with a mapped mate is "placed" with its mate (same RNAME/POS).
+            // Without this, the read keeps the pre-lift _tx contig name it inherited from its mate.
+            record.setReferenceName(partnerInfo.Chromosome);
+            record.setAlignmentStart(partnerInfo.AlignmentStart);
+            record.setInferredInsertSize(0);
+            record.setProperPairFlag(false);
+            return;
+        }
+
+        if(!record.getReferenceName().equals(partnerInfo.Chromosome))
+        {
+            // TLEN is defined only when both reads are on the same reference and both mapped
+            record.setInferredInsertSize(0);
+            record.setProperPairFlag(false);
+            return;
+        }
+
+        record.setInferredInsertSize(computeInferredInsertSize(record, partnerInfo));
+    }
+
+    // SAM spec TLEN: signed distance from the leftmost mapped base of the pair to the rightmost mapped base.
+    // The leftmost read gets a positive value, the rightmost read gets the negation. When both start at the
+    // same position, by convention the first-in-pair receives the positive value.
+    static int computeInferredInsertSize(final SAMRecord record, final LiftedMateInfo partnerInfo)
+    {
+        final int readStart = record.getAlignmentStart();
+        final int readEnd = record.getAlignmentEnd();
+        final int mateStart = partnerInfo.AlignmentStart;
+        final int mateEnd = partnerInfo.AlignmentEnd;
+
+        final int leftmost = Math.min(readStart, mateStart);
+        final int rightmost = Math.max(readEnd, mateEnd);
+        final int span = rightmost - leftmost + 1;
+
+        if(readStart < mateStart)
+            return span;
+        if(readStart > mateStart)
+            return -span;
+
+        // tie on start position — first-in-pair gets the positive value
+        return record.getFirstOfPairFlag() ? span : -span;
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/RrnaRegionIndex.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/RrnaRegionIndex.java
@@ -1,0 +1,231 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+// per-chromosome interval set covering ribosomal RNA contamination zones. Combines three sources:
+//   (a) ensembl genes whose transcripts carry BioType in {rRNA, Mt_rRNA}, gene range [GeneStart, GeneEnd]
+//   (b) hardcoded V38 acrocentric short-arm ranges (chr13/14/15/21/22 p-arms) which carry the rDNA
+//       repeat arrays. These are biological constants and aren't fully captured by ensembl annotation.
+//   (c) wholesale exclusion of contigs whose name starts with chr22_ or chrUn_ (V38). The chr22 random
+//       contig and the chrUn decoys are dominated by rDNA junk — observed empirically as the top sinks
+//       for rRNA reads. Any read mapping to a contig with these prefixes is treated as rRNA.
+// (b) and (c) are V38-only; on V37 the index falls back to biotype-only with a warn.
+// Lookups are inclusive at both ends; overlapping intervals are merged.
+public class RrnaRegionIndex
+{
+    public static final String BIOTYPE_RRNA = "rRNA";
+    public static final String BIOTYPE_MT_RRNA = "Mt_rRNA";
+
+    // V38 acrocentric p-arm ranges. The short arms of these chromosomes are nucleolar organizer
+    // regions carrying the 45S rDNA tandem arrays — STAR / bwa dump ambiguous rRNA reads here even
+    // when ensembl annotation doesn't cover the locus. End coords sit just below the centromere start
+    // so we capture the full rDNA-bearing p-arm without spilling into the centromere proper.
+    private static final Interval[] V38_ACROCENTRIC_P_ARMS = {
+            new Interval(1, 16_000_000),  // chr13
+            new Interval(1, 16_000_000),  // chr14
+            new Interval(1, 17_000_000),  // chr15
+            new Interval(1, 12_000_000),  // chr21
+            new Interval(1, 13_500_000),  // chr22
+    };
+
+    private static final String[] V38_ACROCENTRIC_CHROMOSOMES = {"chr13", "chr14", "chr15", "chr21", "chr22"};
+
+    // contig-name prefixes for V38 unplaced / random contigs that are dominated by rDNA junk. Any read
+    // mapping to a contig matching one of these is treated as rRNA regardless of position.
+    private static final String[] V38_EXCLUDED_CONTIG_PREFIXES = {"chr22_", "chrUn_"};
+
+    private final Map<String, List<Interval>> mIntervalsByChromosome;
+    private final String[] mExcludedContigPrefixes;
+    private final int mGeneCount;
+
+    private RrnaRegionIndex(
+            final Map<String, List<Interval>> intervalsByChromosome, final String[] excludedContigPrefixes, final int geneCount)
+    {
+        mIntervalsByChromosome = intervalsByChromosome;
+        mExcludedContigPrefixes = excludedContigPrefixes;
+        mGeneCount = geneCount;
+    }
+
+    public int geneCount()
+    {
+        return mGeneCount;
+    }
+
+    // returns true if the contig is wholly excluded by prefix, or if [start, end] (inclusive) overlaps
+    // any rRNA region on the given chromosome.
+    public boolean overlaps(final String chromosome, final int start, final int end)
+    {
+        for(final String prefix : mExcludedContigPrefixes)
+        {
+            if(chromosome.startsWith(prefix))
+                return true;
+        }
+
+        final List<Interval> intervals = mIntervalsByChromosome.get(chromosome);
+        if(intervals == null || intervals.isEmpty())
+            return false;
+
+        // binary search for the rightmost interval with Start <= end
+        int lo = 0;
+        int hi = intervals.size() - 1;
+        int candidate = -1;
+        while(lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            if(intervals.get(mid).Start <= end)
+            {
+                candidate = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        if(candidate < 0)
+            return false;
+
+        // walk back over any intervals whose End reaches our start. After merge there's typically
+        // a single overlapping interval, but unmerged overlapping rRNA genes are tolerated.
+        for(int i = candidate; i >= 0; --i)
+        {
+            final Interval interval = intervals.get(i);
+            if(interval.End < start)
+                return false;
+            if(interval.Start <= end && interval.End >= start)
+                return true;
+        }
+        return false;
+    }
+
+    public static RrnaRegionIndex build(final ConfigBuilder configBuilder, final RefGenomeVersion refGenomeVersion)
+    {
+        final EnsemblDataCache cache = new EnsemblDataCache(configBuilder);
+        cache.setRequiredData(false, false, false, false);
+        cache.load(false);
+        return build(cache, refGenomeVersion);
+    }
+
+    static RrnaRegionIndex build(final EnsemblDataCache cache, final RefGenomeVersion refGenomeVersion)
+    {
+        final Map<String, List<TranscriptData>> transcriptsByGene = cache.getTranscriptDataMap();
+        final Map<String, List<GeneData>> genesByChromosome = cache.getChrGeneDataMap();
+
+        final Set<String> rrnaGeneIds = new HashSet<>();
+        for(final Map.Entry<String, List<TranscriptData>> entry : transcriptsByGene.entrySet())
+        {
+            for(final TranscriptData transcript : entry.getValue())
+            {
+                if(isRrnaBiotype(transcript.BioType))
+                {
+                    rrnaGeneIds.add(entry.getKey());
+                    break;
+                }
+            }
+        }
+
+        final Map<String, List<Interval>> rawIntervalsByChromosome = new HashMap<>();
+        for(final Map.Entry<String, List<GeneData>> entry : genesByChromosome.entrySet())
+        {
+            final List<Interval> intervals = new ArrayList<>();
+            for(final GeneData gene : entry.getValue())
+            {
+                if(rrnaGeneIds.contains(gene.GeneId))
+                    intervals.add(new Interval(gene.GeneStart, gene.GeneEnd));
+            }
+            if(!intervals.isEmpty())
+                rawIntervalsByChromosome.put(entry.getKey(), intervals);
+        }
+
+        final String[] excludedContigPrefixes;
+        if(refGenomeVersion == RefGenomeVersion.V38)
+        {
+            for(int i = 0; i < V38_ACROCENTRIC_CHROMOSOMES.length; ++i)
+            {
+                rawIntervalsByChromosome
+                        .computeIfAbsent(V38_ACROCENTRIC_CHROMOSOMES[i], k -> new ArrayList<>())
+                        .add(V38_ACROCENTRIC_P_ARMS[i]);
+            }
+            excludedContigPrefixes = V38_EXCLUDED_CONTIG_PREFIXES;
+        }
+        else
+        {
+            RD_LOGGER.warn("rRNA filter: acrocentric p-arm and unplaced-contig exclusions are V38-only; "
+                    + "running on ref genome version {} with biotype-only coverage", refGenomeVersion);
+            excludedContigPrefixes = new String[0];
+        }
+
+        final Map<String, List<Interval>> intervalsByChromosome = new HashMap<>();
+        for(final Map.Entry<String, List<Interval>> entry : rawIntervalsByChromosome.entrySet())
+        {
+            final List<Interval> intervals = entry.getValue();
+            intervals.sort(Comparator.comparingInt(i -> i.Start));
+            intervalsByChromosome.put(entry.getKey(), mergeOverlapping(intervals));
+        }
+
+        final int geneCount = rrnaGeneIds.size();
+        final int chromosomeCount = intervalsByChromosome.size();
+        RD_LOGGER.info("loaded {} rRNA gene region(s) across {} chromosome(s); excluded contig prefixes: {}",
+                geneCount, chromosomeCount, excludedContigPrefixes.length == 0 ? "none" : String.join(",", excludedContigPrefixes));
+
+        return new RrnaRegionIndex(intervalsByChromosome, excludedContigPrefixes, geneCount);
+    }
+
+    static boolean isRrnaBiotype(final String biotype)
+    {
+        return BIOTYPE_RRNA.equals(biotype) || BIOTYPE_MT_RRNA.equals(biotype);
+    }
+
+    private static List<Interval> mergeOverlapping(final List<Interval> sorted)
+    {
+        final List<Interval> merged = new ArrayList<>(sorted.size());
+        Interval current = null;
+        for(final Interval interval : sorted)
+        {
+            if(current == null)
+            {
+                current = interval;
+                continue;
+            }
+            if(interval.Start <= current.End + 1)
+            {
+                current = new Interval(current.Start, Math.max(current.End, interval.End));
+            }
+            else
+            {
+                merged.add(current);
+                current = interval;
+            }
+        }
+        if(current != null)
+            merged.add(current);
+        return merged;
+    }
+
+    static final class Interval
+    {
+        final int Start;
+        final int End;
+
+        Interval(final int start, final int end)
+        {
+            Start = start;
+            End = end;
+        }
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/RrnaRegionIndex.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/RrnaRegionIndex.java
@@ -86,7 +86,7 @@ public class RrnaRegionIndex
         while(lo <= hi)
         {
             int mid = (lo + hi) >>> 1;
-            if(intervals.get(mid).Start <= end)
+            if(intervals.get(mid).start() <= end)
             {
                 candidate = mid;
                 lo = mid + 1;
@@ -105,9 +105,9 @@ public class RrnaRegionIndex
         for(int i = candidate; i >= 0; --i)
         {
             final Interval interval = intervals.get(i);
-            if(interval.End < start)
+            if(interval.end() < start)
                 return false;
-            if(interval.Start <= end && interval.End >= start)
+            if(interval.start() <= end && interval.end() >= start)
                 return true;
         }
         return false;
@@ -174,7 +174,7 @@ public class RrnaRegionIndex
         for(final Map.Entry<String, List<Interval>> entry : rawIntervalsByChromosome.entrySet())
         {
             final List<Interval> intervals = entry.getValue();
-            intervals.sort(Comparator.comparingInt(i -> i.Start));
+            intervals.sort(Comparator.comparingInt(Interval::start));
             intervalsByChromosome.put(entry.getKey(), mergeOverlapping(intervals));
         }
 
@@ -202,9 +202,9 @@ public class RrnaRegionIndex
                 current = interval;
                 continue;
             }
-            if(interval.Start <= current.End + 1)
+            if(interval.start() <= current.end() + 1)
             {
-                current = new Interval(current.Start, Math.max(current.End, interval.End));
+                current = new Interval(current.start(), Math.max(current.end(), interval.end()));
             }
             else
             {
@@ -217,15 +217,5 @@ public class RrnaRegionIndex
         return merged;
     }
 
-    static final class Interval
-    {
-        final int Start;
-        final int End;
-
-        Interval(final int start, final int end)
-        {
-            Start = start;
-            End = end;
-        }
-    }
+    record Interval(int start, int end) {}
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SaTagRewriter.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SaTagRewriter.java
@@ -1,0 +1,71 @@
+package com.hartwig.hmftools.redux.splice;
+
+import java.util.HashSet;
+import java.util.Set;
+
+// rewrites the SA tag of a SAMRecord so each chimeric alignment entry (primary <-> supplementaries)
+// references genomic coordinates rather than transcript-contig coordinates.
+//
+// SA tag entry format: rname,pos,strand,CIGAR,mapQ,NM; (semicolon-separated, htsjdk SAMTag.SA).
+// Strand char and mapQ pass through unchanged. NM is intentionally not recomputed (would otherwise
+// disagree with the rewritten CIGAR when junction N operators are introduced) — same limitation as
+// the read's own NM tag in SpliceLiftBack.
+//
+// Entries that fail to lift (alt-contig position outside any transcript span, malformed entry) are
+// dropped. Remaining entries are deduped by lifted (chromosome, position, strand, CIGAR).
+public class SaTagRewriter
+{
+    public static final String SA_ATTRIBUTE = "SA";
+
+    public static String rewriteSaTag(final String saTagValue, final LiftBackResolver resolver)
+    {
+        if(saTagValue == null || saTagValue.isEmpty())
+            return null;
+
+        StringBuilder rewritten = new StringBuilder();
+        Set<String> seenEntryKeys = new HashSet<>();
+
+        for(String saEntry : saTagValue.split(";"))
+        {
+            if(saEntry.isEmpty())
+                continue;
+
+            String[] saEntryParts = saEntry.split(",");
+            if(saEntryParts.length < 6)
+                continue;
+
+            String contig = saEntryParts[0];
+            int position;
+            try
+            {
+                position = Integer.parseInt(saEntryParts[1]);
+            }
+            catch(NumberFormatException e)
+            {
+                continue;
+            }
+            String strand = saEntryParts[2];
+            String cigarString = saEntryParts[3];
+            String mapQuality = saEntryParts[4];
+            String numMismatches = saEntryParts[5];
+
+            LiftBackResolver.LiftedCoords liftedCoords = resolver.liftCoords(contig, position, cigarString);
+            if(liftedCoords == null)
+                continue;
+
+            String entryKey = liftedCoords.Chromosome + ':' + liftedCoords.Position + ':' + strand
+                    + ':' + liftedCoords.CigarString;
+            if(!seenEntryKeys.add(entryKey))
+                continue;
+
+            rewritten.append(liftedCoords.Chromosome).append(',')
+                    .append(liftedCoords.Position).append(',')
+                    .append(strand).append(',')
+                    .append(liftedCoords.CigarString).append(',')
+                    .append(mapQuality).append(',')
+                    .append(numMismatches).append(';');
+        }
+
+        return rewritten.length() == 0 ? null : rewritten.toString();
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SaTagRewriter.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SaTagRewriter.java
@@ -3,16 +3,12 @@ package com.hartwig.hmftools.redux.splice;
 import java.util.HashSet;
 import java.util.Set;
 
-// rewrites the SA tag of a SAMRecord so each chimeric alignment entry (primary <-> supplementaries)
-// references genomic coordinates rather than transcript-contig coordinates.
+// rewrites each chimeric entry in a SAMRecord's SA tag from transcript-contig coordinates to genomic.
+// SA entry format: rname,pos,strand,CIGAR,mapQ,NM; (htsjdk SAMTag.SA).
 //
-// SA tag entry format: rname,pos,strand,CIGAR,mapQ,NM; (semicolon-separated, htsjdk SAMTag.SA).
-// Strand char and mapQ pass through unchanged. NM is intentionally not recomputed (would otherwise
-// disagree with the rewritten CIGAR when junction N operators are introduced) — same limitation as
-// the read's own NM tag in SpliceLiftBack.
-//
-// Entries that fail to lift (alt-contig position outside any transcript span, malformed entry) are
-// dropped. Remaining entries are deduped by lifted (chromosome, position, strand, CIGAR).
+// strand and mapQ pass through unchanged. NM is intentionally not recomputed (it would disagree with the
+// rewritten CIGAR once junction N operators are introduced) — same trade-off as the read's own NM tag.
+// Entries that fail to lift are dropped. Surviving entries are deduped by lifted (chrom, pos, strand, CIGAR).
 public class SaTagRewriter
 {
     public static final String SA_ATTRIBUTE = "SA";
@@ -22,46 +18,45 @@ public class SaTagRewriter
         if(saTagValue == null || saTagValue.isEmpty())
             return null;
 
-        StringBuilder rewritten = new StringBuilder();
-        Set<String> seenEntryKeys = new HashSet<>();
+        final StringBuilder rewritten = new StringBuilder();
+        final Set<String> seenEntryKeys = new HashSet<>();
 
-        for(String saEntry : saTagValue.split(";"))
+        for(final String saEntry : saTagValue.split(";"))
         {
             if(saEntry.isEmpty())
                 continue;
 
-            String[] saEntryParts = saEntry.split(",");
-            if(saEntryParts.length < 6)
+            final String[] parts = saEntry.split(",");
+            if(parts.length < 6)
                 continue;
 
-            String contig = saEntryParts[0];
-            int position;
+            final String contig = parts[0];
+            final int position;
             try
             {
-                position = Integer.parseInt(saEntryParts[1]);
+                position = Integer.parseInt(parts[1]);
             }
             catch(NumberFormatException e)
             {
                 continue;
             }
-            String strand = saEntryParts[2];
-            String cigarString = saEntryParts[3];
-            String mapQuality = saEntryParts[4];
-            String numMismatches = saEntryParts[5];
+            final String strand = parts[2];
+            final String cigarString = parts[3];
+            final String mapQuality = parts[4];
+            final String numMismatches = parts[5];
 
-            LiftBackResolver.LiftedCoords liftedCoords = resolver.liftCoords(contig, position, cigarString);
-            if(liftedCoords == null)
+            final LiftedCoords lifted = resolver.liftCoords(contig, position, cigarString);
+            if(lifted == null)
                 continue;
 
-            String entryKey = liftedCoords.Chromosome + ':' + liftedCoords.Position + ':' + strand
-                    + ':' + liftedCoords.CigarString;
+            final String entryKey = lifted.chromosome() + ':' + lifted.position() + ':' + strand + ':' + lifted.cigarString();
             if(!seenEntryKeys.add(entryKey))
                 continue;
 
-            rewritten.append(liftedCoords.Chromosome).append(',')
-                    .append(liftedCoords.Position).append(',')
+            rewritten.append(lifted.chromosome()).append(',')
+                    .append(lifted.position()).append(',')
                     .append(strand).append(',')
-                    .append(liftedCoords.CigarString).append(',')
+                    .append(lifted.cigarString()).append(',')
                     .append(mapQuality).append(',')
                     .append(numMismatches).append(';');
         }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
@@ -1,0 +1,10 @@
+package com.hartwig.hmftools.redux.splice;
+
+public final class SpliceCommon
+{
+    public static final String CONTIG_NAME_DELIM = "_";
+    public static final String CONTIG_NAME_PREFIX = "ens";
+
+    public static final String TRANSCRIPT_CONTIGS_FILE_ID = ".transcript_contigs.fasta";
+    public static final String CONTIG_SIDECAR_FILE_ID = ".transcript_contigs.sidecar.tsv";
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
@@ -5,6 +5,6 @@ public final class SpliceCommon
     public static final String CONTIG_NAME_DELIM = "_";
     public static final String CONTIG_NAME_PREFIX = "ens";
 
-    public static final String TRANSCRIPT_CONTIGS_FILE_ID = ".transcript_contigs.fasta";
-    public static final String CONTIG_SIDECAR_FILE_ID = ".transcript_contigs.sidecar.tsv";
+    public static final String TRANSCRIPT_CONTIGS_FILE_ID = ".fasta";
+    public static final String CONTIG_SIDECAR_FILE_ID = ".sidecar.tsv";
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceCommon.java
@@ -6,5 +6,5 @@ public final class SpliceCommon
     public static final String CONTIG_NAME_PREFIX = "ens";
 
     public static final String TRANSCRIPT_CONTIGS_FILE_ID = ".fasta";
-    public static final String CONTIG_SIDECAR_FILE_ID = ".sidecar.tsv";
+    public static final String CONTIG_MAPPINGS_FILE_ID = ".rna_contigs_mappings.tsv";
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
@@ -32,9 +32,6 @@ public class SpliceFastaBuilder
 
     public void run()
     {
-        if(!mConfig.isValid())
-            System.exit(1);
-
         long startTimeMs = System.currentTimeMillis();
 
         RefGenomeSource refGenome = RefGenomeSource.loadRefGenome(mConfig.RefGenomeFile);
@@ -71,9 +68,8 @@ public class SpliceFastaBuilder
                     ++genesProcessed;
 
                     List<TranscriptData> transcripts = mEnsemblDataCache.getTranscripts(gene.GeneId);
-                    // TODO: do i really need this here? CHECK if ensembledatacache already covers this
                     if(transcripts == null || transcripts.isEmpty())
-                        continue;
+                        throw new IllegalStateException("ensembl cache returned no transcripts for gene " + gene.GeneId);
 
                     for(TranscriptData transcript : transcripts)
                     {
@@ -95,7 +91,7 @@ public class SpliceFastaBuilder
                             continue;
                         }
 
-                        writeFastaContig(fastaWriter, result.Entry.ContigName, result.Sequence);
+                        writeFastaContig(fastaWriter, result.Entry.contigName(), result.Sequence);
                         contigEntries.add(result.Entry);
                         ++contigsWritten;
                     }
@@ -135,7 +131,6 @@ public class SpliceFastaBuilder
 
     private static void writeFastaContig(final BufferedWriter writer, final String contigName, final String sequence) throws IOException
     {
-        // TODO: confirm this with Charles
         // unwrapped: matches BlastnRunner.writeBlastFasta. bwa-mem2 / samtools accept any line length.
         writer.write(">" + contigName);
         writer.newLine();

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
@@ -4,7 +4,7 @@ import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBufferedWriter;
 import static com.hartwig.hmftools.redux.ReduxConfig.APP_NAME;
 import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
-import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_SIDECAR_FILE_ID;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_MAPPINGS_FILE_ID;
 import static com.hartwig.hmftools.redux.splice.SpliceCommon.TRANSCRIPT_CONTIGS_FILE_ID;
 
 import java.io.BufferedWriter;
@@ -48,7 +48,7 @@ public class SpliceFastaBuilder
         Map<String, List<GeneData>> chrGeneMap = mEnsemblDataCache.getChrGeneDataMap();
 
         String fastaFile = mConfig.formFilename(TRANSCRIPT_CONTIGS_FILE_ID);
-        String sidecarFile = mConfig.formFilename(CONTIG_SIDECAR_FILE_ID);
+        String mappingsFile = mConfig.formFilename(CONTIG_MAPPINGS_FILE_ID);
 
         TranscriptContigBuilder builder = new TranscriptContigBuilder(refGenome);
 
@@ -110,7 +110,7 @@ public class SpliceFastaBuilder
         RD_LOGGER.info("wrote {} transcript contigs to {} (skipped {} single-exon, {} all-N)",
                 contigsWritten, fastaFile, skippedSingleExon, skippedAllN);
 
-        ContigSidecar.write(sidecarFile, contigEntries);
+        ContigMappings.write(mappingsFile, contigEntries);
 
         RD_LOGGER.info("next: cat <ref.fasta> {} > ref_genome_<ver>_rna_contigs.fasta && bwa-mem2 index ref_genome_<ver>_rna_contigs.fasta",
                 fastaFile);

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
@@ -1,0 +1,156 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBufferedWriter;
+import static com.hartwig.hmftools.redux.ReduxConfig.APP_NAME;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_SIDECAR_FILE_ID;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.TRANSCRIPT_CONTIGS_FILE_ID;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource;
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+public class SpliceFastaBuilder
+{
+    private final SpliceFastaConfig mConfig;
+    private final EnsemblDataCache mEnsemblDataCache;
+
+    public SpliceFastaBuilder(final ConfigBuilder configBuilder)
+    {
+        mConfig = new SpliceFastaConfig(configBuilder);
+        mEnsemblDataCache = new EnsemblDataCache(configBuilder);
+    }
+
+    public void run()
+    {
+        if(!mConfig.isValid())
+            System.exit(1);
+
+        long startTimeMs = System.currentTimeMillis();
+
+        RefGenomeSource refGenome = RefGenomeSource.loadRefGenome(mConfig.RefGenomeFile);
+        if(refGenome == null)
+        {
+            RD_LOGGER.error("failed to load ref genome: {}", mConfig.RefGenomeFile);
+            System.exit(1);
+        }
+
+        RD_LOGGER.info("loading ensembl cache from {}", mConfig.EnsemblDataDir);
+        mEnsemblDataCache.setRequiredData(true, false, false, false);
+        mEnsemblDataCache.load(false);
+
+        Map<String, List<GeneData>> chrGeneMap = mEnsemblDataCache.getChrGeneDataMap();
+
+        String fastaFile = mConfig.formFilename(TRANSCRIPT_CONTIGS_FILE_ID);
+        String sidecarFile = mConfig.formFilename(CONTIG_SIDECAR_FILE_ID);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(refGenome);
+
+        List<ContigEntry> contigEntries = new ArrayList<>();
+
+        int genesProcessed = 0;
+        int contigsWritten = 0;
+        int skippedSingleExon = 0;
+        int skippedAllN = 0;
+
+        try(BufferedWriter fastaWriter = createBufferedWriter(fastaFile))
+        {
+            for(List<GeneData> genes : chrGeneMap.values())
+            {
+                for(GeneData gene : genes)
+                {
+                    ++genesProcessed;
+
+                    List<TranscriptData> transcripts = mEnsemblDataCache.getTranscripts(gene.GeneId);
+                    // TODO: do i really need this here? CHECK if ensembledatacache already covers this
+                    if(transcripts == null || transcripts.isEmpty())
+                        continue;
+
+                    for(TranscriptData transcript : transcripts)
+                    {
+                        // single-exon transcripts have no junctions — bwa-mem2 already aligns them fine against genomic ref
+                        if(transcript.exons().size() < 2)
+                        {
+                            ++skippedSingleExon;
+                            continue;
+                        }
+
+                        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene, transcript);
+                        if(result == null)
+                            continue;
+
+                        // exonic positions all masked to N in the ref — contig is alignment-useless
+                        if(isAllN(result.Sequence))
+                        {
+                            ++skippedAllN;
+                            continue;
+                        }
+
+                        writeFastaContig(fastaWriter, result.Entry.ContigName, result.Sequence);
+                        contigEntries.add(result.Entry);
+                        ++contigsWritten;
+                    }
+
+                    if(genesProcessed % 1000 == 0)
+                        RD_LOGGER.debug("processed {} genes, {} contigs", genesProcessed, contigsWritten);
+                }
+            }
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.error("failed to write transcript contigs FASTA: {}", e.toString());
+            System.exit(1);
+        }
+
+        RD_LOGGER.info("wrote {} transcript contigs to {} (skipped {} single-exon, {} all-N)",
+                contigsWritten, fastaFile, skippedSingleExon, skippedAllN);
+
+        ContigSidecar.write(sidecarFile, contigEntries);
+
+        RD_LOGGER.info("next: cat <ref.fasta> {} > ref_genome_<ver>_rna_contigs.fasta && bwa-mem2 index ref_genome_<ver>_rna_contigs.fasta",
+                fastaFile);
+
+        RD_LOGGER.info("SpliceFastaBuilder complete, mins({})", runTimeMinsStr(startTimeMs));
+    }
+
+    private static boolean isAllN(final String sequence)
+    {
+        for(int i = 0; i < sequence.length(); ++i)
+        {
+            char c = sequence.charAt(i);
+            if(c != 'N' && c != 'n')
+                return false;
+        }
+        return true;
+    }
+
+    private static void writeFastaContig(final BufferedWriter writer, final String contigName, final String sequence) throws IOException
+    {
+        // TODO: confirm this with Charles
+        // unwrapped: matches BlastnRunner.writeBlastFasta. bwa-mem2 / samtools accept any line length.
+        writer.write(">" + contigName);
+        writer.newLine();
+        writer.write(sequence);
+        writer.newLine();
+    }
+
+    public static void main(final String[] args)
+    {
+        ConfigBuilder configBuilder = new ConfigBuilder(APP_NAME);
+        SpliceFastaConfig.addConfig(configBuilder);
+
+        configBuilder.checkAndParseCommandLine(args);
+
+        SpliceFastaBuilder builder = new SpliceFastaBuilder(configBuilder);
+        builder.run();
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java
@@ -131,7 +131,6 @@ public class SpliceFastaBuilder
 
     private static void writeFastaContig(final BufferedWriter writer, final String contigName, final String sequence) throws IOException
     {
-        // unwrapped: matches BlastnRunner.writeBlastFasta. bwa-mem2 / samtools accept any line length.
         writer.write(">" + contigName);
         writer.newLine();
         writer.write(sequence);

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
@@ -12,7 +12,6 @@ import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
-import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
 
 import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
@@ -25,13 +24,8 @@ public class SpliceFastaConfig
     public final String OutputDir;
     public final String OutputId;
 
-    private boolean mIsValid;
-
     public SpliceFastaConfig(final ConfigBuilder configBuilder)
     {
-        // ConfigBuilder has already enforced presence + existence of every required path before we get here
-        mIsValid = true;
-
         EnsemblDataDir = configBuilder.getValue(ENSEMBL_DATA_DIR);
         RefGenomeFile = configBuilder.getValue(REF_GENOME);
         RefGenVersion = configBuilder.hasValue(REF_GENOME_VERSION) ? from(configBuilder) : RefGenomeVersion.V38;
@@ -39,18 +33,11 @@ public class SpliceFastaConfig
         OutputId = configBuilder.getValue(OUTPUT_ID);
 
         if(OutputDir == null)
-        {
-            RD_LOGGER.error("missing required config: output_dir");
-            mIsValid = false;
-        }
-        else if(!checkCreateOutputDir(OutputDir))
-        {
-            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
-            mIsValid = false;
-        }
-    }
+            throw new IllegalArgumentException("missing required config: output_dir");
 
-    public boolean isValid() { return mIsValid; }
+        if(!checkCreateOutputDir(OutputDir))
+            throw new IllegalStateException("failed to create output directory: " + OutputDir);
+    }
 
     public String formFilename(final String fileId)
     {

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
@@ -54,7 +54,7 @@ public class SpliceFastaConfig
 
     public String formFilename(final String fileId)
     {
-        String prefix = OutputId != null ? OutputId : "splice"; // TODO: can be more verbose here
+        String prefix = OutputId != null ? OutputId : "ref_genome_v" + RefGenVersion.identifier() + "_rna_contigs";
         return OutputDir + prefix + fileId;
     }
 

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaConfig.java
@@ -1,0 +1,70 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.ENSEMBL_DATA_DIR;
+import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.addEnsemblDir;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.REF_GENOME;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeFile;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeVersion;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.REF_GENOME_VERSION;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.from;
+import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+public class SpliceFastaConfig
+{
+    public final String EnsemblDataDir;
+    public final String RefGenomeFile;
+    public final RefGenomeVersion RefGenVersion;
+    public final String OutputDir;
+    public final String OutputId;
+
+    private boolean mIsValid;
+
+    public SpliceFastaConfig(final ConfigBuilder configBuilder)
+    {
+        // ConfigBuilder has already enforced presence + existence of every required path before we get here
+        mIsValid = true;
+
+        EnsemblDataDir = configBuilder.getValue(ENSEMBL_DATA_DIR);
+        RefGenomeFile = configBuilder.getValue(REF_GENOME);
+        RefGenVersion = configBuilder.hasValue(REF_GENOME_VERSION) ? from(configBuilder) : RefGenomeVersion.V38;
+        OutputDir = parseOutputDir(configBuilder);
+        OutputId = configBuilder.getValue(OUTPUT_ID);
+
+        if(OutputDir == null)
+        {
+            RD_LOGGER.error("missing required config: output_dir");
+            mIsValid = false;
+        }
+        else if(!checkCreateOutputDir(OutputDir))
+        {
+            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
+            mIsValid = false;
+        }
+    }
+
+    public boolean isValid() { return mIsValid; }
+
+    public String formFilename(final String fileId)
+    {
+        String prefix = OutputId != null ? OutputId : "splice"; // TODO: can be more verbose here
+        return OutputDir + prefix + fileId;
+    }
+
+    public static void addConfig(final ConfigBuilder configBuilder)
+    {
+        addEnsemblDir(configBuilder, true);
+        addRefGenomeFile(configBuilder, true);
+        addRefGenomeVersion(configBuilder);
+
+        addOutputOptions(configBuilder);
+        addLoggingOptions(configBuilder);
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
@@ -1,0 +1,127 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr;
+import static com.hartwig.hmftools.redux.ReduxConfig.APP_NAME;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+
+public class SpliceLiftBack
+{
+    private final SpliceLiftBackConfig mConfig;
+
+    public SpliceLiftBack(final ConfigBuilder configBuilder)
+    {
+        mConfig = new SpliceLiftBackConfig(configBuilder);
+    }
+
+    public void run()
+    {
+        if(!mConfig.isValid())
+            System.exit(1);
+
+        long startTimeMs = System.currentTimeMillis();
+
+        // TODO: can make this better, just getting it to work for now (PERFORMANCE IMPROVEMENTS)
+        List<ContigEntry> contigEntries = ContigSidecar.read(mConfig.ContigSidecarFile);
+        Map<String, ContigEntry> contigByName = new HashMap<>();
+        for(ContigEntry entry : contigEntries)
+            contigByName.put(entry.ContigName, entry);
+
+        RD_LOGGER.info("loaded {} contig entries", contigEntries.size());
+
+        processBam(mConfig.InputBam, mConfig.RefGenomeFile, contigByName, mConfig.formOutputBam());
+
+        RD_LOGGER.info("SpliceLiftBack complete, mins({})", runTimeMinsStr(startTimeMs));
+    }
+
+    static void processBam(
+            final String inputBam, final String refGenomeFile, final Map<String, ContigEntry> contigByName, final String outputBam)
+    {
+        int total = 0;
+        int passThrough = 0;
+        int lifted = 0;
+        int droppedUnliftable = 0;
+
+        try(SamReader samReader = SamReaderFactory.makeDefault()
+                .referenceSequence(new File(refGenomeFile))
+                .open(new File(inputBam)))
+        {
+            SAMFileHeader header = samReader.getFileHeader();
+
+            try(SAMFileWriter samWriter = new SAMFileWriterFactory().makeBAMWriter(header, false, new File(outputBam)))
+            {
+                SAMRecordIterator iter = samReader.iterator();
+                while(iter.hasNext())
+                {
+                    SAMRecord read = iter.next();
+                    ++total;
+
+                    if(read.getReadUnmappedFlag())
+                    {
+                        samWriter.addAlignment(read);
+                        ++passThrough;
+                        continue;
+                    }
+
+                    ContigEntry entry = contigByName.get(read.getReferenceName());
+                    if(entry == null)
+                    {
+                        samWriter.addAlignment(read);
+                        ++passThrough;
+                        continue;
+                    }
+
+                    ContigTranslator.TranslationResult result = ContigTranslator.translate(
+                            entry, read.getAlignmentStart(), read.getCigar());
+
+                    if(result == null)
+                    {
+                        ++droppedUnliftable;
+                        continue;
+                    }
+
+                    read.setReferenceName(result.Chromosome);
+                    read.setAlignmentStart(result.GenomicStart);
+                    read.setCigar(result.GenomicCigar);
+
+                    samWriter.addAlignment(read);
+                    ++lifted;
+                }
+            }
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.error("BAM I/O failed: {}", e.toString());
+            throw new RuntimeException(e);
+        }
+
+        RD_LOGGER.info("processed reads: total({}) passThrough({}) lifted({}) droppedUnliftable({})",
+                total, passThrough, lifted, droppedUnliftable);
+    }
+
+    public static void main(final String[] args)
+    {
+        ConfigBuilder configBuilder = new ConfigBuilder(APP_NAME);
+        SpliceLiftBackConfig.addConfig(configBuilder);
+
+        configBuilder.checkAndParseCommandLine(args);
+
+        SpliceLiftBack liftBack = new SpliceLiftBack(configBuilder);
+        liftBack.run();
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
@@ -1,5 +1,6 @@
 package com.hartwig.hmftools.redux.splice;
 
+import static com.hartwig.hmftools.common.bamops.BamToolName.fromPath;
 import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr;
 import static com.hartwig.hmftools.redux.ReduxConfig.APP_NAME;
 import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
@@ -10,12 +11,16 @@ import static com.hartwig.hmftools.redux.splice.SpliceCommon.ALT_CONTIG_SUFFIX;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import com.hartwig.hmftools.common.bamops.BamOperations;
+import com.hartwig.hmftools.common.bamops.BamToolName;
 import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
 
@@ -34,7 +39,7 @@ import htsjdk.samtools.TextCigarCodec;
 //  - pass 1: builds a LiftedMateInfoCache (one entry per paired primary record) so each read's
 //            partner-mate fields can be rewritten in genomic coords.
 //  - pass 2: resolves + applies + writes a coordinate-sorted BAM with mate fields patched.
-// 1:1 record contract still holds: every input record produces exactly one output record + one TSV-A row + N TSV-B rows.
+// 1:1 record contract: every input record produces exactly one output record + one TSV-A row + N TSV-B rows.
 public class SpliceLiftBack
 {
     private static final String XA_TAG = "XA";
@@ -136,12 +141,12 @@ public class SpliceLiftBack
                     continue;
 
                 final LiftBackResult result = resolver.resolve(record);
-                if(result.Category == LiftBackCategory.UNMAPPED || result.Category == LiftBackCategory.LIFT_FAILED)
+                if(result.category() == LiftBackCategory.UNMAPPED || result.category() == LiftBackCategory.LIFT_FAILED)
                     continue;
 
-                final Cigar cigar = TextCigarCodec.decode(result.FinalCigar);
-                final int liftedEnd = result.FinalPos + cigar.getReferenceLength() - 1;
-                if(rrnaIndex.overlaps(result.FinalChrom, result.FinalPos, liftedEnd))
+                final Cigar cigar = TextCigarCodec.decode(result.finalCigar());
+                final int liftedEnd = result.finalPos() + cigar.getReferenceLength() - 1;
+                if(rrnaIndex.overlaps(result.finalChrom(), result.finalPos(), liftedEnd))
                     filtered.add(record.getReadName());
             }
         }
@@ -198,10 +203,10 @@ public class SpliceLiftBack
         return cache;
     }
 
-    // pass 2: stream the input BAM again, apply the lift-back to each record, patch mate fields from the cache,
-    // and emit to a coordinate-sorted, indexed BAM. TSVs are written here so MateNum reflects firstOfPair.
-    // Records whose read name is in filteredReadNames are dropped from the BAM (rRNA pair filter) but a TSV-A
-    // audit row is still emitted with Filtered=true so the 1:1 record audit trail is preserved.
+    // pass 2: stream the input BAM again, apply the lift-back to each record, patch mate fields, and emit
+    // an unsorted BAM (sorted + indexed afterwards via samtools/sambamba). TSVs are written inline so MateNum
+    // reflects firstOfPair. rRNA-filtered read pairs are dropped from the BAM but get an audit row with
+    // Filtered=true in TSV-A.
     private void emitLiftedBam(
             final LiftBackResolver resolver, final LiftedMateInfoCache liftedMateInfoCache, final Set<String> filteredReadNames)
     {
@@ -209,17 +214,17 @@ public class SpliceLiftBack
         final LiftBackStats stats = new LiftBackStats();
         int rrnaRecordsDropped = 0;
 
+        final String unsortedBam = mConfig.formUnsortedBam();
+
         try(SamReader samReader = SamReaderFactory.makeDefault()
                 .referenceSequence(new File(mConfig.RefGenomeFile))
                 .open(new File(mConfig.InputBam));
             LiftBackWriter writer = new LiftBackWriter(mConfig.formTsvAFile(), mConfig.formTsvBFile()))
         {
             final SAMFileHeader header = samReader.getFileHeader().clone();
-            header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+            header.setSortOrder(SAMFileHeader.SortOrder.unsorted);
 
-            final SAMFileWriterFactory factory = new SAMFileWriterFactory().setCreateIndex(true);
-
-            try(SAMFileWriter samWriter = factory.makeBAMWriter(header, false, new File(mConfig.formOutputBam())))
+            try(SAMFileWriter samWriter = new SAMFileWriterFactory().makeBAMWriter(header, false, new File(unsortedBam)))
             {
                 final SAMRecordIterator iter = samReader.iterator();
                 while(iter.hasNext())
@@ -261,6 +266,40 @@ public class SpliceLiftBack
                     rrnaRecordsDropped, filteredReadNames.size());
         }
         RD_LOGGER.info("pass 2 emit complete, mins({})", runTimeMinsStr(startTimeMs));
+
+        sortAndIndex(unsortedBam, mConfig.formOutputBam());
+    }
+
+    // delegate sort + index to samtools/sambamba — much faster than htsjdk's in-memory SortingSamFileWriter
+    // for whole-RNA BAMs. Skips when no bamtool is configured (unsorted BAM stays in place for inspection).
+    private void sortAndIndex(final String unsortedBam, final String sortedBam)
+    {
+        if(mConfig.BamToolPath == null)
+        {
+            RD_LOGGER.info("no -{} configured; leaving unsorted BAM at {}", BamToolName.BAMTOOL_PATH, unsortedBam);
+            return;
+        }
+
+        final BamToolName toolName = fromPath(mConfig.BamToolPath);
+        RD_LOGGER.info("sorting BAM via {}: {}", toolName, sortedBam);
+
+        if(!BamOperations.sortBam(toolName, mConfig.BamToolPath, unsortedBam, sortedBam, mConfig.Threads))
+            throw new RuntimeException("failed to sort BAM: " + unsortedBam);
+
+        if(toolName == BamToolName.SAMTOOLS)
+        {
+            if(!BamOperations.indexBam(toolName, mConfig.BamToolPath, sortedBam, mConfig.Threads))
+                throw new RuntimeException("failed to index BAM: " + sortedBam);
+        }
+
+        try
+        {
+            Files.deleteIfExists(Paths.get(unsortedBam));
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.warn("could not delete intermediate {}: {}", unsortedBam, e.toString());
+        }
     }
 
     // mutate the SAMRecord in place to reflect the LiftBackResult: lifted chrom/pos/CIGAR, or unmapped flag
@@ -272,10 +311,9 @@ public class SpliceLiftBack
     static void applyResultToRecord(
             final SAMRecord record, final LiftBackResult result, final LiftedMateInfoCache liftedMateInfoCache)
     {
-        switch(result.Category)
+        switch(result.category())
         {
             case UNMAPPED:
-                // already unmapped; nothing to do
                 return;
 
             case LIFT_FAILED:
@@ -292,12 +330,12 @@ public class SpliceLiftBack
                 return;
 
             default:
-                Cigar liftedCigar = TextCigarCodec.decode(result.FinalCigar);
-                record.setReferenceName(result.FinalChrom);
-                record.setAlignmentStart(result.FinalPos);
+                final Cigar liftedCigar = TextCigarCodec.decode(result.finalCigar());
+                record.setReferenceName(result.finalChrom());
+                record.setAlignmentStart(result.finalPos());
                 record.setCigar(liftedCigar);
-                record.setReadNegativeStrandFlag(result.NegativeStrand);
-                record.setMappingQuality(result.UpdatedMapq);
+                record.setReadNegativeStrandFlag(result.negativeStrand());
+                record.setMappingQuality(result.updatedMapq());
                 record.setAttribute(XA_TAG, buildLiftedXa(result));
         }
     }
@@ -310,13 +348,13 @@ public class SpliceLiftBack
         if(!record.getReadPairedFlag())
             return false;
 
-        LiftedMateInfo ownPrimary = liftedMateInfoCache.getOwnPrimary(record.getReadName(), record.getFirstOfPairFlag());
-        if(ownPrimary == null || ownPrimary.Unmapped)
+        final LiftedMateInfo ownPrimary = liftedMateInfoCache.getOwnPrimary(record.getReadName(), record.getFirstOfPairFlag());
+        if(ownPrimary == null || ownPrimary.unmapped())
             return false;
 
-        record.setReferenceName(ownPrimary.Chromosome);
-        record.setAlignmentStart(ownPrimary.AlignmentStart);
-        record.setCigarString(ownPrimary.LiftedCigar);
+        record.setReferenceName(ownPrimary.chromosome());
+        record.setAlignmentStart(ownPrimary.alignmentStart());
+        record.setCigarString(ownPrimary.liftedCigar());
         record.setMappingQuality(0);
         record.setAttribute(XA_TAG, null);
         // leave SA tag in place — rewriteSaTag translates any tx-contig entries to genomic coords downstream,
@@ -328,22 +366,22 @@ public class SpliceLiftBack
     // UNMAPPED/LIFT_FAILED primaries are cached as unmapped so the partner can clear proper-pair on patch.
     static LiftedMateInfo toLiftedMateInfo(final SAMRecord record, final LiftBackResult result)
     {
-        if(result.Category == LiftBackCategory.UNMAPPED || result.Category == LiftBackCategory.LIFT_FAILED)
-            return LiftedMateInfo.unmapped();
+        if(result.category() == LiftBackCategory.UNMAPPED || result.category() == LiftBackCategory.LIFT_FAILED)
+            return LiftedMateInfo.UNMAPPED;
 
-        Cigar liftedCigar = TextCigarCodec.decode(result.FinalCigar);
-        int alignmentEnd = result.FinalPos + liftedCigar.getReferenceLength() - 1;
-        return LiftedMateInfo.mapped(result.FinalChrom, result.FinalPos, alignmentEnd, result.FinalCigar, result.NegativeStrand);
+        final Cigar liftedCigar = TextCigarCodec.decode(result.finalCigar());
+        final int alignmentEnd = result.finalPos() + liftedCigar.getReferenceLength() - 1;
+        return LiftedMateInfo.mapped(result.finalChrom(), result.finalPos(), alignmentEnd, result.finalCigar(), result.negativeStrand());
     }
 
     // build the bwa XA tag string from the lifted, deduped XA alts. Returns null when there are none, which
     // tells htsjdk to drop the tag entirely.
     static String buildLiftedXa(final LiftBackResult result)
     {
-        // emit every alignment in the lifted set except (a) the chosen BAM primary, (b) any losers the
-        // discriminator marked Dropped. Filtering by IsPrimaryChoice (rather than Source==SELF) is what
-        // lets a swapped original-self appear in XA as an informative paralog hit.
-        String xa = result.LiftedAlignments.stream()
+        // emit every alignment except (a) the chosen BAM primary and (b) discriminator-dropped losers.
+        // Filtering by IsPrimaryChoice (not Source==SELF) is what lets a swapped original-self appear
+        // in XA as an informative paralog hit.
+        final String xa = result.liftedAlignments().stream()
                 .filter(la -> !la.IsPrimaryChoice && !la.Dropped)
                 .map(SpliceLiftBack::formatXaEntry)
                 .collect(Collectors.joining());
@@ -358,12 +396,10 @@ public class SpliceLiftBack
 
     public static void main(final String[] args)
     {
-        ConfigBuilder configBuilder = new ConfigBuilder(APP_NAME);
+        final ConfigBuilder configBuilder = new ConfigBuilder(APP_NAME);
         SpliceLiftBackConfig.addConfig(configBuilder);
-
         configBuilder.checkAndParseCommandLine(args);
 
-        SpliceLiftBack liftBack = new SpliceLiftBack(configBuilder);
-        liftBack.run();
+        new SpliceLiftBack(configBuilder).run();
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
@@ -3,112 +3,357 @@ package com.hartwig.hmftools.redux.splice;
 import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr;
 import static com.hartwig.hmftools.redux.ReduxConfig.APP_NAME;
 import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+import static com.hartwig.hmftools.redux.splice.MateFieldPatcher.patchMateFields;
+import static com.hartwig.hmftools.redux.splice.SaTagRewriter.SA_ATTRIBUTE;
+import static com.hartwig.hmftools.redux.splice.SaTagRewriter.rewriteSaTag;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.ALT_CONTIG_SUFFIX;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
 
+import htsjdk.samtools.Cigar;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileWriter;
 import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.TextCigarCodec;
 
+// per-record lift-back driver. Two passes over the bwa-mem2 BAM aligned against ref + Tx contigs:
+//  - pass 1: builds a LiftedMateInfoCache (one entry per paired primary record) so each read's
+//            partner-mate fields can be rewritten in genomic coords.
+//  - pass 2: resolves + applies + writes a coordinate-sorted BAM with mate fields patched.
+// 1:1 record contract still holds: every input record produces exactly one output record + one TSV-A row + N TSV-B rows.
 public class SpliceLiftBack
 {
+    private static final String XA_TAG = "XA";
+
     private final SpliceLiftBackConfig mConfig;
+    private final ConfigBuilder mConfigBuilder;
 
     public SpliceLiftBack(final ConfigBuilder configBuilder)
     {
         mConfig = new SpliceLiftBackConfig(configBuilder);
+        mConfigBuilder = configBuilder;
     }
 
     public void run()
     {
-        long startTimeMs = System.currentTimeMillis();
+        final long startTimeMs = System.currentTimeMillis();
 
-        // TODO: can make this better, just getting it to work for now (PERFORMANCE IMPROVEMENTS)
-        List<ContigEntry> contigEntries = ContigSidecar.read(mConfig.ContigSidecarFile);
-        Map<String, ContigEntry> contigByName = new HashMap<>();
-        for(ContigEntry entry : contigEntries)
-            contigByName.put(entry.contigName(), entry);
+        final List<ContigEntry> contigEntries;
+        if(mConfig.hasContigSidecar())
+        {
+            contigEntries = ContigSidecar.read(mConfig.ContigSidecarFile);
+            RD_LOGGER.info("loaded {} contig entries", contigEntries.size());
+        }
+        else
+        {
+            contigEntries = List.of();
+            RD_LOGGER.info("no contig sidecar supplied — running in pass-through mode (lift-back is a no-op)");
+        }
 
-        RD_LOGGER.info("loaded {} contig entries", contigEntries.size());
+        final LiftBackResolver resolver = new LiftBackResolver(contigEntries);
+        validateBamAgainstSidecar(resolver.contigNames());
 
-        processBam(mConfig.InputBam, mConfig.RefGenomeFile, contigByName, mConfig.formOutputBam());
+        final RrnaRegionIndex rrnaIndex = mConfig.FilterRrna
+                ? RrnaRegionIndex.build(mConfigBuilder, RefGenomeVersion.from(mConfigBuilder))
+                : null;
+        final Set<String> filteredReadNames = collectFilteredReadNames(resolver, rrnaIndex);
+
+        final LiftedMateInfoCache liftedMateInfoCache = buildLiftedMateInfoCache(resolver, filteredReadNames);
+
+        emitLiftedBam(resolver, liftedMateInfoCache, filteredReadNames);
 
         RD_LOGGER.info("SpliceLiftBack complete, mins({})", runTimeMinsStr(startTimeMs));
     }
 
-    static void processBam(
-            final String inputBam, final String refGenomeFile, final Map<String, ContigEntry> contigByName, final String outputBam)
+    // fail fast if the sidecar doesn't cover every _tx alt contig the BAM was aligned against.
+    // a mismatch here was the root cause of an earlier silent-failure: alt contigs missing from the
+    // segments map fell through as ref pass-through and leaked _tx names into mate fields downstream.
+    private void validateBamAgainstSidecar(final Set<String> sidecarContigs)
     {
-        int total = 0;
-        int passThrough = 0;
-        int lifted = 0;
-        int droppedUnliftable = 0;
-
-        try(SamReader samReader = SamReaderFactory.makeDefault()
-                .referenceSequence(new File(refGenomeFile))
-                .open(new File(inputBam)))
+        Set<String> missing = new TreeSet<>();
+        try(SamReader reader = SamReaderFactory.makeDefault()
+                .referenceSequence(new File(mConfig.RefGenomeFile))
+                .open(new File(mConfig.InputBam)))
         {
-            SAMFileHeader header = samReader.getFileHeader();
-
-            try(SAMFileWriter samWriter = new SAMFileWriterFactory().makeBAMWriter(header, false, new File(outputBam)))
+            for(SAMSequenceRecord sq : reader.getFileHeader().getSequenceDictionary().getSequences())
             {
-                SAMRecordIterator iter = samReader.iterator();
-                while(iter.hasNext())
-                {
-                    SAMRecord read = iter.next();
-                    ++total;
-
-                    if(read.getReadUnmappedFlag())
-                    {
-                        samWriter.addAlignment(read);
-                        ++passThrough;
-                        continue;
-                    }
-
-                    ContigEntry entry = contigByName.get(read.getReferenceName());
-                    if(entry == null)
-                    {
-                        samWriter.addAlignment(read);
-                        ++passThrough;
-                        continue;
-                    }
-
-                    ContigTranslator.TranslationResult result = ContigTranslator.translate(
-                            entry, read.getAlignmentStart(), read.getCigar());
-
-                    if(result == null)
-                    {
-                        ++droppedUnliftable;
-                        continue;
-                    }
-
-                    read.setReferenceName(result.Chromosome);
-                    read.setAlignmentStart(result.GenomicStart);
-                    read.setCigar(result.GenomicCigar);
-
-                    samWriter.addAlignment(read);
-                    ++lifted;
-                }
+                String name = sq.getSequenceName();
+                if(name.endsWith(ALT_CONTIG_SUFFIX) && !sidecarContigs.contains(name))
+                    missing.add(name);
             }
         }
         catch(IOException e)
         {
-            RD_LOGGER.error("BAM I/O failed: {}", e.toString());
+            throw new RuntimeException("failed to read BAM header: " + mConfig.InputBam, e);
+        }
+
+        if(!missing.isEmpty())
+        {
+            throw new IllegalStateException(String.format(
+                    "BAM/sidecar mismatch: %d alt contig(s) in BAM @SQ are absent from sidecar %s — first few: %s",
+                    missing.size(), mConfig.ContigSidecarFile,
+                    missing.stream().limit(5).collect(Collectors.joining(","))));
+        }
+    }
+
+    // rRNA pre-pass: stream the BAM, resolve every record (primaries + supplementaries), flag any read
+    // name where at least one record's post-lift coords overlap an rRNA gene region. Returned set drives
+    // drop-by-read-pair in subsequent passes. Returns an empty set when filtering is disabled.
+    private Set<String> collectFilteredReadNames(final LiftBackResolver resolver, final RrnaRegionIndex rrnaIndex)
+    {
+        if(rrnaIndex == null)
+            return Set.of();
+
+        final long startTimeMs = System.currentTimeMillis();
+        final Set<String> filtered = new HashSet<>();
+        int recordsScanned = 0;
+
+        try(SamReader samReader = SamReaderFactory.makeDefault()
+                .referenceSequence(new File(mConfig.RefGenomeFile))
+                .open(new File(mConfig.InputBam)))
+        {
+            final SAMRecordIterator iter = samReader.iterator();
+            while(iter.hasNext())
+            {
+                final SAMRecord record = iter.next();
+                ++recordsScanned;
+
+                if(record.getReadUnmappedFlag())
+                    continue;
+
+                final LiftBackResult result = resolver.resolve(record);
+                if(result.Category == LiftBackCategory.UNMAPPED || result.Category == LiftBackCategory.LIFT_FAILED)
+                    continue;
+
+                final Cigar cigar = TextCigarCodec.decode(result.FinalCigar);
+                final int liftedEnd = result.FinalPos + cigar.getReferenceLength() - 1;
+                if(rrnaIndex.overlaps(result.FinalChrom, result.FinalPos, liftedEnd))
+                    filtered.add(record.getReadName());
+            }
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.error("rRNA pre-pass BAM read failed", e);
             throw new RuntimeException(e);
         }
 
-        RD_LOGGER.info("processed reads: total({}) passThrough({}) lifted({}) droppedUnliftable({})",
-                total, passThrough, lifted, droppedUnliftable);
+        RD_LOGGER.info("rRNA pre-pass scanned {} records, flagged {} read name(s), mins({})",
+                recordsScanned, filtered.size(), runTimeMinsStr(startTimeMs));
+        return filtered;
+    }
+
+    // pass 1: stream the input BAM, resolve each paired primary record, cache its lifted info keyed by read name
+    // so pass 2 can patch the partner read's mate fields. Records belonging to rRNA-filtered read names are
+    // skipped — they won't make the output BAM, and caching their mate info would waste memory.
+    private LiftedMateInfoCache buildLiftedMateInfoCache(final LiftBackResolver resolver, final Set<String> filteredReadNames)
+    {
+        final long startTimeMs = System.currentTimeMillis();
+        final LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        int primaryRecordsCached = 0;
+
+        try(SamReader samReader = SamReaderFactory.makeDefault()
+                .referenceSequence(new File(mConfig.RefGenomeFile))
+                .open(new File(mConfig.InputBam)))
+        {
+            final SAMRecordIterator iter = samReader.iterator();
+            while(iter.hasNext())
+            {
+                final SAMRecord record = iter.next();
+
+                if(!record.getReadPairedFlag())
+                    continue;
+                if(record.isSecondaryOrSupplementary())
+                    continue;
+                if(filteredReadNames.contains(record.getReadName()))
+                    continue;
+
+                final LiftBackResult result = resolver.resolve(record);
+                final LiftedMateInfo info = toLiftedMateInfo(record, result);
+                cache.recordPrimaryAlignment(record.getReadName(), record.getFirstOfPairFlag(), info);
+                ++primaryRecordsCached;
+            }
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.error("pass 1 BAM read failed", e);
+            throw new RuntimeException(e);
+        }
+
+        RD_LOGGER.info("pass 1 cached {} primary alignments across {} read pairs, mins({})",
+                primaryRecordsCached, cache.size(), runTimeMinsStr(startTimeMs));
+        return cache;
+    }
+
+    // pass 2: stream the input BAM again, apply the lift-back to each record, patch mate fields from the cache,
+    // and emit to a coordinate-sorted, indexed BAM. TSVs are written here so MateNum reflects firstOfPair.
+    // Records whose read name is in filteredReadNames are dropped from the BAM (rRNA pair filter) but a TSV-A
+    // audit row is still emitted with Filtered=true so the 1:1 record audit trail is preserved.
+    private void emitLiftedBam(
+            final LiftBackResolver resolver, final LiftedMateInfoCache liftedMateInfoCache, final Set<String> filteredReadNames)
+    {
+        final long startTimeMs = System.currentTimeMillis();
+        final LiftBackStats stats = new LiftBackStats();
+        int rrnaRecordsDropped = 0;
+
+        try(SamReader samReader = SamReaderFactory.makeDefault()
+                .referenceSequence(new File(mConfig.RefGenomeFile))
+                .open(new File(mConfig.InputBam));
+            LiftBackWriter writer = new LiftBackWriter(mConfig.formTsvAFile(), mConfig.formTsvBFile()))
+        {
+            final SAMFileHeader header = samReader.getFileHeader().clone();
+            header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+
+            final SAMFileWriterFactory factory = new SAMFileWriterFactory().setCreateIndex(true);
+
+            try(SAMFileWriter samWriter = factory.makeBAMWriter(header, false, new File(mConfig.formOutputBam())))
+            {
+                final SAMRecordIterator iter = samReader.iterator();
+                while(iter.hasNext())
+                {
+                    final SAMRecord record = iter.next();
+                    final boolean dropForRrna = filteredReadNames.contains(record.getReadName());
+
+                    final LiftBackResult result = resolver.resolve(record);
+                    stats.record(record, result);
+
+                    if(dropForRrna)
+                    {
+                        ++rrnaRecordsDropped;
+                        writer.write(record, result, true);
+                        continue;
+                    }
+
+                    applyResultToRecord(record, result, liftedMateInfoCache);
+                    record.setAttribute(SA_ATTRIBUTE, rewriteSaTag(record.getStringAttribute(SA_ATTRIBUTE), resolver));
+                    patchMateFields(record, liftedMateInfoCache);
+                    samWriter.addAlignment(record);
+
+                    writer.write(record, result, false);
+                }
+            }
+
+            stats.writeSummary(mConfig.formSummaryFile());
+        }
+        catch(IOException e)
+        {
+            RD_LOGGER.error("pass 2 BAM/TSV I/O failed", e);
+            throw new RuntimeException(e);
+        }
+
+        stats.logSummary();
+        if(!filteredReadNames.isEmpty())
+        {
+            RD_LOGGER.info("rRNA filter dropped {} record(s) across {} read pair(s)",
+                    rrnaRecordsDropped, filteredReadNames.size());
+        }
+        RD_LOGGER.info("pass 2 emit complete, mins({})", runTimeMinsStr(startTimeMs));
+    }
+
+    // mutate the SAMRecord in place to reflect the LiftBackResult: lifted chrom/pos/CIGAR, or unmapped flag
+    // for UNMAPPED/LIFT_FAILED. XA tag is rewritten from the deduped, lifted XA alts (Stage 4).
+    //
+    // Supplementary records whose own lift failed are mirrored onto their primary's lifted coordinates
+    // (keeping the supplementary flag set) rather than being marked unmapped. htsjdk's BAM validator
+    // rejects records with both the unmapped and supplementary flags set, and we never drop a read.
+    static void applyResultToRecord(
+            final SAMRecord record, final LiftBackResult result, final LiftedMateInfoCache liftedMateInfoCache)
+    {
+        switch(result.Category)
+        {
+            case UNMAPPED:
+                // already unmapped; nothing to do
+                return;
+
+            case LIFT_FAILED:
+                if(record.isSecondaryOrSupplementary() && mirrorOwnPrimaryOntoFailedSupp(record, liftedMateInfoCache))
+                    return;
+
+                record.setReadUnmappedFlag(true);
+                record.setReferenceName(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME);
+                record.setAlignmentStart(SAMRecord.NO_ALIGNMENT_START);
+                record.setCigarString(SAMRecord.NO_ALIGNMENT_CIGAR);
+                record.setMappingQuality(0);
+                record.setAttribute(XA_TAG, null);
+                record.setAttribute(SA_ATTRIBUTE, null);
+                return;
+
+            default:
+                Cigar liftedCigar = TextCigarCodec.decode(result.FinalCigar);
+                record.setReferenceName(result.FinalChrom);
+                record.setAlignmentStart(result.FinalPos);
+                record.setCigar(liftedCigar);
+                record.setReadNegativeStrandFlag(result.NegativeStrand);
+                record.setMappingQuality(result.UpdatedMapq);
+                record.setAttribute(XA_TAG, buildLiftedXa(result));
+        }
+    }
+
+    // mirror a supplementary record onto its primary's lifted alignment. Returns false (caller falls back
+    // to the unmap path) if the primary is missing from the cache or itself failed to lift.
+    private static boolean mirrorOwnPrimaryOntoFailedSupp(
+            final SAMRecord record, final LiftedMateInfoCache liftedMateInfoCache)
+    {
+        if(!record.getReadPairedFlag())
+            return false;
+
+        LiftedMateInfo ownPrimary = liftedMateInfoCache.getOwnPrimary(record.getReadName(), record.getFirstOfPairFlag());
+        if(ownPrimary == null || ownPrimary.Unmapped)
+            return false;
+
+        record.setReferenceName(ownPrimary.Chromosome);
+        record.setAlignmentStart(ownPrimary.AlignmentStart);
+        record.setCigarString(ownPrimary.LiftedCigar);
+        record.setMappingQuality(0);
+        record.setAttribute(XA_TAG, null);
+        // leave SA tag in place — rewriteSaTag translates any tx-contig entries to genomic coords downstream,
+        // and redux's FragmentCoords requires SA on supplementary records.
+        return true;
+    }
+
+    // derive the cached lifted mate info for a primary record from its resolved LiftBackResult.
+    // UNMAPPED/LIFT_FAILED primaries are cached as unmapped so the partner can clear proper-pair on patch.
+    static LiftedMateInfo toLiftedMateInfo(final SAMRecord record, final LiftBackResult result)
+    {
+        if(result.Category == LiftBackCategory.UNMAPPED || result.Category == LiftBackCategory.LIFT_FAILED)
+            return LiftedMateInfo.unmapped();
+
+        Cigar liftedCigar = TextCigarCodec.decode(result.FinalCigar);
+        int alignmentEnd = result.FinalPos + liftedCigar.getReferenceLength() - 1;
+        return LiftedMateInfo.mapped(result.FinalChrom, result.FinalPos, alignmentEnd, result.FinalCigar, result.NegativeStrand);
+    }
+
+    // build the bwa XA tag string from the lifted, deduped XA alts. Returns null when there are none, which
+    // tells htsjdk to drop the tag entirely.
+    static String buildLiftedXa(final LiftBackResult result)
+    {
+        // emit every alignment in the lifted set except (a) the chosen BAM primary, (b) any losers the
+        // discriminator marked Dropped. Filtering by IsPrimaryChoice (rather than Source==SELF) is what
+        // lets a swapped original-self appear in XA as an informative paralog hit.
+        String xa = result.LiftedAlignments.stream()
+                .filter(la -> !la.IsPrimaryChoice && !la.Dropped)
+                .map(SpliceLiftBack::formatXaEntry)
+                .collect(Collectors.joining());
+        return xa.isEmpty() ? null : xa;
+    }
+
+    private static String formatXaEntry(final LiftedAlignment la)
+    {
+        return la.LiftedChrom + ',' + (la.ForwardStrand ? '+' : '-') + la.LiftedPos + ','
+                + la.LiftedCigar + ',' + la.NumMismatches + ';';
     }
 
     public static void main(final String[] args)

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBack.java
@@ -31,16 +31,13 @@ public class SpliceLiftBack
 
     public void run()
     {
-        if(!mConfig.isValid())
-            System.exit(1);
-
         long startTimeMs = System.currentTimeMillis();
 
         // TODO: can make this better, just getting it to work for now (PERFORMANCE IMPROVEMENTS)
         List<ContigEntry> contigEntries = ContigSidecar.read(mConfig.ContigSidecarFile);
         Map<String, ContigEntry> contigByName = new HashMap<>();
         for(ContigEntry entry : contigEntries)
-            contigByName.put(entry.ContigName, entry);
+            contigByName.put(entry.contigName(), entry);
 
         RD_LOGGER.info("loaded {} contig entries", contigEntries.size());
 

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
@@ -1,0 +1,71 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.REF_GENOME;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeFile;
+import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
+import static com.hartwig.hmftools.common.utils.file.FileDelimiters.BAM_EXTENSION;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
+import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
+import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
+
+import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+public class SpliceLiftBackConfig
+{
+    public static final String INPUT_BAM = "input_bam";
+    public static final String INPUT_BAM_DESC = "Input BAM aligned to ref + transcript contigs";
+
+    public static final String CONTIG_SIDECAR = "contig_sidecar";
+    public static final String CONTIG_SIDECAR_DESC = "Contig sidecar TSV produced by SpliceFastaBuilder";
+
+    public final String InputBam;
+    public final String RefGenomeFile;
+    public final String ContigSidecarFile;
+    public final String OutputDir;
+    public final String OutputId;
+
+    private boolean mIsValid;
+
+    public SpliceLiftBackConfig(final ConfigBuilder configBuilder)
+    {
+        // ConfigBuilder has already enforced presence + existence of every required path before we get here
+        mIsValid = true;
+
+        InputBam = configBuilder.getValue(INPUT_BAM);
+        RefGenomeFile = configBuilder.getValue(REF_GENOME);
+        ContigSidecarFile = configBuilder.getValue(CONTIG_SIDECAR);
+        OutputDir = parseOutputDir(configBuilder);
+        OutputId = configBuilder.getValue(OUTPUT_ID);
+
+        if(OutputDir == null)
+        {
+            RD_LOGGER.error("missing required config: output_dir");
+            mIsValid = false;
+        }
+        else if(!checkCreateOutputDir(OutputDir))
+        {
+            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
+            mIsValid = false;
+        }
+    }
+
+    public boolean isValid() { return mIsValid; }
+
+    public String formOutputBam()
+    {
+        String prefix = OutputId != null ? OutputId : "splice_lifted";
+        return OutputDir + prefix + BAM_EXTENSION;
+    }
+
+    public static void addConfig(final ConfigBuilder configBuilder)
+    {
+        configBuilder.addPath(INPUT_BAM, true, INPUT_BAM_DESC);
+        addRefGenomeFile(configBuilder, true);
+        configBuilder.addPath(CONTIG_SIDECAR, true, CONTIG_SIDECAR_DESC);
+
+        addOutputOptions(configBuilder);
+        addLoggingOptions(configBuilder);
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
@@ -8,7 +8,6 @@ import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOptions;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
-import static com.hartwig.hmftools.redux.ReduxConfig.RD_LOGGER;
 
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
 
@@ -26,13 +25,8 @@ public class SpliceLiftBackConfig
     public final String OutputDir;
     public final String OutputId;
 
-    private boolean mIsValid;
-
     public SpliceLiftBackConfig(final ConfigBuilder configBuilder)
     {
-        // ConfigBuilder has already enforced presence + existence of every required path before we get here
-        mIsValid = true;
-
         InputBam = configBuilder.getValue(INPUT_BAM);
         RefGenomeFile = configBuilder.getValue(REF_GENOME);
         ContigSidecarFile = configBuilder.getValue(CONTIG_SIDECAR);
@@ -40,18 +34,11 @@ public class SpliceLiftBackConfig
         OutputId = configBuilder.getValue(OUTPUT_ID);
 
         if(OutputDir == null)
-        {
-            RD_LOGGER.error("missing required config: output_dir");
-            mIsValid = false;
-        }
-        else if(!checkCreateOutputDir(OutputDir))
-        {
-            RD_LOGGER.error("failed to create output directory: {}", OutputDir);
-            mIsValid = false;
-        }
-    }
+            throw new IllegalArgumentException("missing required config: output_dir");
 
-    public boolean isValid() { return mIsValid; }
+        if(!checkCreateOutputDir(OutputDir))
+            throw new IllegalStateException("failed to create output directory: " + OutputDir);
+    }
 
     public String formOutputBam()
     {

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
@@ -1,10 +1,13 @@
 package com.hartwig.hmftools.redux.splice;
 
+import static com.hartwig.hmftools.common.bamops.BamToolName.BAMTOOL_PATH;
 import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.ENSEMBL_DATA_DIR;
 import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.addEnsemblDir;
 import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.REF_GENOME;
 import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeFile;
 import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeVersion;
+import static com.hartwig.hmftools.common.perf.TaskExecutor.addThreadOptions;
+import static com.hartwig.hmftools.common.perf.TaskExecutor.parseThreads;
 import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
 import static com.hartwig.hmftools.common.utils.file.FileDelimiters.BAM_EXTENSION;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
@@ -12,6 +15,7 @@ import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.addOutputOp
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.checkCreateOutputDir;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutputDir;
 
+import com.hartwig.hmftools.common.bamops.BamToolName;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
 
 public class SpliceLiftBackConfig
@@ -39,6 +43,8 @@ public class SpliceLiftBackConfig
     public final boolean FilterRrna;
     public final String OutputDir;
     public final String OutputId;
+    public final String BamToolPath;
+    public final int Threads;
 
     public SpliceLiftBackConfig(final ConfigBuilder configBuilder)
     {
@@ -49,6 +55,8 @@ public class SpliceLiftBackConfig
         FilterRrna = configBuilder.hasFlag(FILTER_RRNA);
         OutputDir = parseOutputDir(configBuilder);
         OutputId = configBuilder.getValue(OUTPUT_ID);
+        BamToolPath = configBuilder.getValue(BAMTOOL_PATH);
+        Threads = parseThreads(configBuilder);
 
         if(OutputDir == null)
             throw new IllegalArgumentException("missing required config: output_dir");
@@ -58,6 +66,11 @@ public class SpliceLiftBackConfig
 
         if(!checkCreateOutputDir(OutputDir))
             throw new IllegalStateException("failed to create output directory: " + OutputDir);
+    }
+
+    public String formUnsortedBam()
+    {
+        return OutputDir + prefix() + ".unsorted" + BAM_EXTENSION;
     }
 
     public boolean hasContigSidecar()
@@ -98,8 +111,10 @@ public class SpliceLiftBackConfig
         addEnsemblDir(configBuilder, false);
         addRefGenomeVersion(configBuilder);
         configBuilder.addFlag(FILTER_RRNA, FILTER_RRNA_DESC);
+        BamToolName.addConfig(configBuilder);
 
         addOutputOptions(configBuilder);
+        addThreadOptions(configBuilder);
         addLoggingOptions(configBuilder);
     }
 }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackConfig.java
@@ -1,7 +1,10 @@
 package com.hartwig.hmftools.redux.splice;
 
+import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.ENSEMBL_DATA_DIR;
+import static com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache.addEnsemblDir;
 import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.REF_GENOME;
 import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeFile;
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource.addRefGenomeVersion;
 import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
 import static com.hartwig.hmftools.common.utils.file.FileDelimiters.BAM_EXTENSION;
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.OUTPUT_ID;
@@ -14,14 +17,26 @@ import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
 public class SpliceLiftBackConfig
 {
     public static final String INPUT_BAM = "input_bam";
-    public static final String INPUT_BAM_DESC = "Input BAM aligned to ref + transcript contigs";
+    public static final String INPUT_BAM_DESC = "Input BAM (bwa-mem2 with transcript contigs, or generic genomic BAM e.g. STAR)";
 
     public static final String CONTIG_SIDECAR = "contig_sidecar";
-    public static final String CONTIG_SIDECAR_DESC = "Contig sidecar TSV produced by SpliceFastaBuilder";
+    public static final String CONTIG_SIDECAR_DESC =
+            "Contig sidecar TSV produced by SpliceFastaBuilder. Omit for pass-through mode on a generic genomic BAM.";
+
+    public static final String FILTER_RRNA = "filter_rrna";
+    public static final String FILTER_RRNA_DESC =
+            "Drop read pairs whose post-lift coords overlap an rRNA/Mt_rRNA gene region. Requires -" + ENSEMBL_DATA_DIR;
+
+    public static final String DEFAULT_OUTPUT_PREFIX = "splice_lifted";
+    public static final String TSV_A_SUFFIX = ".liftback.records.tsv";
+    public static final String TSV_B_SUFFIX = ".liftback.alignments.tsv";
+    public static final String SUMMARY_SUFFIX = ".liftback.summary.tsv";
 
     public final String InputBam;
     public final String RefGenomeFile;
     public final String ContigSidecarFile;
+    public final String EnsemblDataDir;
+    public final boolean FilterRrna;
     public final String OutputDir;
     public final String OutputId;
 
@@ -30,27 +45,59 @@ public class SpliceLiftBackConfig
         InputBam = configBuilder.getValue(INPUT_BAM);
         RefGenomeFile = configBuilder.getValue(REF_GENOME);
         ContigSidecarFile = configBuilder.getValue(CONTIG_SIDECAR);
+        EnsemblDataDir = configBuilder.getValue(ENSEMBL_DATA_DIR);
+        FilterRrna = configBuilder.hasFlag(FILTER_RRNA);
         OutputDir = parseOutputDir(configBuilder);
         OutputId = configBuilder.getValue(OUTPUT_ID);
 
         if(OutputDir == null)
             throw new IllegalArgumentException("missing required config: output_dir");
 
+        if(FilterRrna && EnsemblDataDir == null)
+            throw new IllegalArgumentException("-" + FILTER_RRNA + " requires -" + ENSEMBL_DATA_DIR);
+
         if(!checkCreateOutputDir(OutputDir))
             throw new IllegalStateException("failed to create output directory: " + OutputDir);
     }
 
+    public boolean hasContigSidecar()
+    {
+        return ContigSidecarFile != null;
+    }
+
+    private String prefix()
+    {
+        return OutputId != null ? OutputId : DEFAULT_OUTPUT_PREFIX;
+    }
+
     public String formOutputBam()
     {
-        String prefix = OutputId != null ? OutputId : "splice_lifted";
-        return OutputDir + prefix + BAM_EXTENSION;
+        return OutputDir + prefix() + BAM_EXTENSION;
+    }
+
+    public String formTsvAFile()
+    {
+        return OutputDir + prefix() + TSV_A_SUFFIX;
+    }
+
+    public String formTsvBFile()
+    {
+        return OutputDir + prefix() + TSV_B_SUFFIX;
+    }
+
+    public String formSummaryFile()
+    {
+        return OutputDir + prefix() + SUMMARY_SUFFIX;
     }
 
     public static void addConfig(final ConfigBuilder configBuilder)
     {
         configBuilder.addPath(INPUT_BAM, true, INPUT_BAM_DESC);
         addRefGenomeFile(configBuilder, true);
-        configBuilder.addPath(CONTIG_SIDECAR, true, CONTIG_SIDECAR_DESC);
+        configBuilder.addPath(CONTIG_SIDECAR, false, CONTIG_SIDECAR_DESC);
+        addEnsemblDir(configBuilder, false);
+        addRefGenomeVersion(configBuilder);
+        configBuilder.addFlag(FILTER_RRNA, FILTER_RRNA_DESC);
 
         addOutputOptions(configBuilder);
         addLoggingOptions(configBuilder);

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
@@ -34,10 +34,19 @@ public class TranscriptContigBuilder
 
         List<BaseRegion> spans = new ArrayList<>(ordered.size());
         StringBuilder sequence = new StringBuilder();
+        int prevEnd = -1;
         for(ExonData exon : ordered)
         {
+            if(exon.Start <= prevEnd)
+            {
+                throw new IllegalStateException(String.format(
+                        "overlapping exons in transcript %s gene %s: exon [%d,%d] overlaps prior exon ending at %d",
+                        transcript.TransName, gene.GeneId, exon.Start, exon.End, prevEnd));
+            }
+
             spans.add(new BaseRegion(exon.Start, exon.End));
             sequence.append(mRefGenome.getBaseString(gene.Chromosome, exon.Start, exon.End));
+            prevEnd = exon.End;
         }
 
         String contigName = CONTIG_NAME_PREFIX + gene.GeneId

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
@@ -1,8 +1,5 @@
 package com.hartwig.hmftools.redux.splice;
 
-import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_NAME_DELIM;
-import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_NAME_PREFIX;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -13,6 +10,9 @@ import com.hartwig.hmftools.common.gene.TranscriptData;
 import com.hartwig.hmftools.common.genome.refgenome.RefGenomeInterface;
 import com.hartwig.hmftools.common.region.BaseRegion;
 
+// per-transcript exon-concatenation. Produces a forward-strand sequence and the genomic exon spans that
+// generated it. Placement of this sequence onto a per-chromosome alt contig (altStart/altEnd) is the
+// caller's job — SpliceFastaBuilder owns that packing.
 public class TranscriptContigBuilder
 {
     private final RefGenomeInterface mRefGenome;
@@ -49,24 +49,28 @@ public class TranscriptContigBuilder
             prevEnd = exon.End;
         }
 
-        String contigName = CONTIG_NAME_PREFIX + gene.GeneId
-                + CONTIG_NAME_DELIM + gene.GeneName
-                + CONTIG_NAME_DELIM + transcript.TransName;
-
-        ContigEntry entry = new ContigEntry(
-                contigName, gene.GeneId, gene.GeneName, transcript.TransName, gene.Chromosome, spans);
-
-        return new TranscriptContigResult(entry, sequence.toString());
+        return new TranscriptContigResult(
+                gene.GeneId, gene.GeneName, transcript.TransName, gene.Chromosome, spans, sequence.toString());
     }
 
     public static final class TranscriptContigResult
     {
-        public final ContigEntry Entry;
+        public final String GeneId;
+        public final String GeneName;
+        public final String TransName;
+        public final String Chromosome;
+        public final List<BaseRegion> ExonSpans;
         public final String Sequence;
 
-        public TranscriptContigResult(final ContigEntry entry, final String sequence)
+        public TranscriptContigResult(
+                final String geneId, final String geneName, final String transName, final String chromosome,
+                final List<BaseRegion> exonSpans, final String sequence)
         {
-            Entry = entry;
+            GeneId = geneId;
+            GeneName = geneName;
+            TransName = transName;
+            Chromosome = chromosome;
+            ExonSpans = exonSpans;
             Sequence = sequence;
         }
     }

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
@@ -1,0 +1,64 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_NAME_DELIM;
+import static com.hartwig.hmftools.redux.splice.SpliceCommon.CONTIG_NAME_PREFIX;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import com.hartwig.hmftools.common.gene.ExonData;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeInterface;
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+public class TranscriptContigBuilder
+{
+    private final RefGenomeInterface mRefGenome;
+
+    public TranscriptContigBuilder(final RefGenomeInterface refGenome)
+    {
+        mRefGenome = refGenome;
+    }
+
+    public TranscriptContigResult build(final GeneData gene, final TranscriptData transcript)
+    {
+        if(transcript.exons() == null || transcript.exons().isEmpty())
+            return null;
+
+        // exons are stored by Rank (transcribed order). Re-sort by genomic Start so the contig sequence is in
+        // forward-strand orientation regardless of gene strand — keeps lift-back math direct.
+        List<ExonData> ordered = new ArrayList<>(transcript.exons());
+        ordered.sort(Comparator.comparingInt(e -> e.Start));
+
+        List<BaseRegion> spans = new ArrayList<>(ordered.size());
+        StringBuilder sequence = new StringBuilder();
+        for(ExonData exon : ordered)
+        {
+            spans.add(new BaseRegion(exon.Start, exon.End));
+            sequence.append(mRefGenome.getBaseString(gene.Chromosome, exon.Start, exon.End));
+        }
+
+        String contigName = CONTIG_NAME_PREFIX + gene.GeneId
+                + CONTIG_NAME_DELIM + gene.GeneName
+                + CONTIG_NAME_DELIM + transcript.TransName;
+
+        ContigEntry entry = new ContigEntry(
+                contigName, gene.GeneId, gene.GeneName, transcript.TransName, gene.Chromosome, spans);
+
+        return new TranscriptContigResult(entry, sequence.toString());
+    }
+
+    public static final class TranscriptContigResult
+    {
+        public final ContigEntry Entry;
+        public final String Sequence;
+
+        public TranscriptContigResult(final ContigEntry entry, final String sequence)
+        {
+            Entry = entry;
+            Sequence = sequence;
+        }
+    }
+}

--- a/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilder.java
@@ -53,25 +53,13 @@ public class TranscriptContigBuilder
                 gene.GeneId, gene.GeneName, transcript.TransName, gene.Chromosome, spans, sequence.toString());
     }
 
-    public static final class TranscriptContigResult
+    public record TranscriptContigResult(
+            String geneId,
+            String geneName,
+            String transName,
+            String chromosome,
+            List<BaseRegion> exonSpans,
+            String sequence)
     {
-        public final String GeneId;
-        public final String GeneName;
-        public final String TransName;
-        public final String Chromosome;
-        public final List<BaseRegion> ExonSpans;
-        public final String Sequence;
-
-        public TranscriptContigResult(
-                final String geneId, final String geneName, final String transName, final String chromosome,
-                final List<BaseRegion> exonSpans, final String sequence)
-        {
-            GeneId = geneId;
-            GeneName = geneName;
-            TransName = transName;
-            Chromosome = chromosome;
-            ExonSpans = exonSpans;
-            Sequence = sequence;
-        }
     }
 }

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/AltContigPackerTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/AltContigPackerTest.java
@@ -1,0 +1,107 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import org.junit.Test;
+
+public class AltContigPackerTest
+{
+    private static final int SPACER = 5;
+
+    private static TranscriptContigBuilder.TranscriptContigResult txResult(
+            final String transName, final String sequence, final List<BaseRegion> exonSpans)
+    {
+        return new TranscriptContigBuilder.TranscriptContigResult(
+                "G_" + transName, "GENE_" + transName, transName, CHR_1, exonSpans, sequence);
+    }
+
+    @Test
+    public void testEmptyInputProducesEmptyResult()
+    {
+        AltContigPacker packer = new AltContigPacker(SPACER);
+        AltContigPacker.PackResult result = packer.pack(CHR_1, List.of());
+
+        assertEquals("1_tx", result.AltContig);
+        assertEquals("", result.Sequence);
+        assertTrue(result.Entries.isEmpty());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testSingleTranscriptHasNoSpacer()
+    {
+        AltContigPacker packer = new AltContigPacker(SPACER);
+        AltContigPacker.PackResult result = packer.pack(
+                CHR_1, List.of(txResult("T1", "ACGTACGT", List.of(new BaseRegion(100, 107)))));
+
+        assertEquals("ACGTACGT", result.Sequence);
+        assertEquals(1, result.Entries.size());
+
+        ContigEntry entry = result.Entries.get(0);
+        assertEquals("1_tx", entry.contigName());
+        assertEquals(1, entry.altStart());
+        assertEquals(8, entry.altEnd());
+        assertEquals("T1", entry.transName());
+    }
+
+    @Test
+    public void testTwoTranscriptsAreSeparatedBySpacer()
+    {
+        AltContigPacker packer = new AltContigPacker(SPACER);
+        AltContigPacker.PackResult result = packer.pack(CHR_1, List.of(
+                txResult("T1", "AAAA", List.of(new BaseRegion(100, 103))),
+                txResult("T2", "CCC", List.of(new BaseRegion(200, 202)))));
+
+        assertEquals("AAAA" + "NNNNN" + "CCC", result.Sequence);
+        assertEquals(2, result.Entries.size());
+
+        ContigEntry first = result.Entries.get(0);
+        assertEquals(1, first.altStart());
+        assertEquals(4, first.altEnd());
+
+        ContigEntry second = result.Entries.get(1);
+        // 4 (first transcript) + 5 (spacer) + 1 = 10
+        assertEquals(10, second.altStart());
+        assertEquals(12, second.altEnd());
+    }
+
+    @Test
+    public void testThreeTranscriptsHaveContiguousNonOverlappingRanges()
+    {
+        AltContigPacker packer = new AltContigPacker(SPACER);
+        AltContigPacker.PackResult result = packer.pack(CHR_1, List.of(
+                txResult("T1", "AAAAAA", List.of(new BaseRegion(100, 105))),
+                txResult("T2", "CCC", List.of(new BaseRegion(200, 202))),
+                txResult("T3", "GGGGGGGG", List.of(new BaseRegion(300, 307)))));
+
+        // ranges must not overlap, must lie inside the sequence, and must be spacer-separated
+        assertEquals(6 + 5 + 3 + 5 + 8, result.Sequence.length());
+        for(int i = 0; i < result.Entries.size() - 1; ++i)
+        {
+            ContigEntry a = result.Entries.get(i);
+            ContigEntry b = result.Entries.get(i + 1);
+            assertEquals(a.altEnd() + SPACER + 1, b.altStart());
+        }
+    }
+
+    @Test
+    public void testEntryMetadataIsCarriedThrough()
+    {
+        AltContigPacker packer = new AltContigPacker(SPACER);
+        AltContigPacker.PackResult result = packer.pack(
+                CHR_1, List.of(txResult("T1", "ACGT", List.of(new BaseRegion(100, 103)))));
+
+        ContigEntry entry = result.Entries.get(0);
+        assertEquals("G_T1", entry.geneId());
+        assertEquals("GENE_T1", entry.geneName());
+        assertEquals(CHR_1, entry.chromosome());
+        assertEquals(List.of(new BaseRegion(100, 103)), entry.exonSpans());
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/AltContigPackerTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/AltContigPackerTest.java
@@ -28,9 +28,9 @@ public class AltContigPackerTest
         AltContigPacker packer = new AltContigPacker(SPACER);
         AltContigPacker.PackResult result = packer.pack(CHR_1, List.of());
 
-        assertEquals("1_tx", result.AltContig);
-        assertEquals("", result.Sequence);
-        assertTrue(result.Entries.isEmpty());
+        assertEquals("1_tx", result.altContig());
+        assertEquals("", result.sequence());
+        assertTrue(result.entries().isEmpty());
         assertTrue(result.isEmpty());
     }
 
@@ -41,10 +41,10 @@ public class AltContigPackerTest
         AltContigPacker.PackResult result = packer.pack(
                 CHR_1, List.of(txResult("T1", "ACGTACGT", List.of(new BaseRegion(100, 107)))));
 
-        assertEquals("ACGTACGT", result.Sequence);
-        assertEquals(1, result.Entries.size());
+        assertEquals("ACGTACGT", result.sequence());
+        assertEquals(1, result.entries().size());
 
-        ContigEntry entry = result.Entries.get(0);
+        ContigEntry entry = result.entries().get(0);
         assertEquals("1_tx", entry.contigName());
         assertEquals(1, entry.altStart());
         assertEquals(8, entry.altEnd());
@@ -59,14 +59,14 @@ public class AltContigPackerTest
                 txResult("T1", "AAAA", List.of(new BaseRegion(100, 103))),
                 txResult("T2", "CCC", List.of(new BaseRegion(200, 202)))));
 
-        assertEquals("AAAA" + "NNNNN" + "CCC", result.Sequence);
-        assertEquals(2, result.Entries.size());
+        assertEquals("AAAA" + "NNNNN" + "CCC", result.sequence());
+        assertEquals(2, result.entries().size());
 
-        ContigEntry first = result.Entries.get(0);
+        ContigEntry first = result.entries().get(0);
         assertEquals(1, first.altStart());
         assertEquals(4, first.altEnd());
 
-        ContigEntry second = result.Entries.get(1);
+        ContigEntry second = result.entries().get(1);
         // 4 (first transcript) + 5 (spacer) + 1 = 10
         assertEquals(10, second.altStart());
         assertEquals(12, second.altEnd());
@@ -82,11 +82,11 @@ public class AltContigPackerTest
                 txResult("T3", "GGGGGGGG", List.of(new BaseRegion(300, 307)))));
 
         // ranges must not overlap, must lie inside the sequence, and must be spacer-separated
-        assertEquals(6 + 5 + 3 + 5 + 8, result.Sequence.length());
-        for(int i = 0; i < result.Entries.size() - 1; ++i)
+        assertEquals(6 + 5 + 3 + 5 + 8, result.sequence().length());
+        for(int i = 0; i < result.entries().size() - 1; ++i)
         {
-            ContigEntry a = result.Entries.get(i);
-            ContigEntry b = result.Entries.get(i + 1);
+            ContigEntry a = result.entries().get(i);
+            ContigEntry b = result.entries().get(i + 1);
             assertEquals(a.altEnd() + SPACER + 1, b.altStart());
         }
     }
@@ -98,7 +98,7 @@ public class AltContigPackerTest
         AltContigPacker.PackResult result = packer.pack(
                 CHR_1, List.of(txResult("T1", "ACGT", List.of(new BaseRegion(100, 103)))));
 
-        ContigEntry entry = result.Entries.get(0);
+        ContigEntry entry = result.entries().get(0);
         assertEquals("G_T1", entry.geneId());
         assertEquals("GENE_T1", entry.geneName());
         assertEquals(CHR_1, entry.chromosome());

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigMappingsTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigMappingsTest.java
@@ -14,12 +14,12 @@ import com.hartwig.hmftools.common.region.BaseRegion;
 
 import org.junit.Test;
 
-public class ContigSidecarTest
+public class ContigMappingsTest
 {
     @Test
     public void testRoundTrip() throws IOException
     {
-        File tempFile = Files.createTempFile("contig_sidecar_", ".tsv").toFile();
+        File tempFile = Files.createTempFile("contig_mappings_", ".tsv").toFile();
         tempFile.deleteOnExit();
 
         List<ContigEntry> entries = List.of(
@@ -30,9 +30,9 @@ public class ContigSidecarTest
                         "ensENSG0000002_GENEB_ENST0000002", "ENSG0000002", "GENEB", "ENST0000002", CHR_2,
                         List.of(new BaseRegion(1000, 1050))));
 
-        ContigSidecar.write(tempFile.getAbsolutePath(), entries);
+        ContigMappings.write(tempFile.getAbsolutePath(), entries);
 
-        List<ContigEntry> readBack = ContigSidecar.read(tempFile.getAbsolutePath());
+        List<ContigEntry> readBack = ContigMappings.read(tempFile.getAbsolutePath());
 
         assertEquals(2, readBack.size());
 

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigMappingsTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigMappingsTest.java
@@ -51,4 +51,27 @@ public class ContigMappingsTest
         assertEquals(1, second.exonSpans().size());
         assertEquals(new BaseRegion(1000, 1050), second.exonSpans().get(0));
     }
+
+    @Test
+    public void testVaryingSpanCounts() throws IOException
+    {
+        File tempFile = Files.createTempFile("contig_mappings_", ".tsv").toFile();
+        tempFile.deleteOnExit();
+
+        List<ContigEntry> entries = List.of(
+                new ContigEntry("ens1", "GENE1", "NAME1", "TRANS1", CHR_1,
+                        List.of(new BaseRegion(100, 200))),
+                new ContigEntry("ens2", "GENE2", "NAME2", "TRANS2", CHR_1,
+                        List.of(new BaseRegion(100, 200), new BaseRegion(500, 600))),
+                new ContigEntry("ens3", "GENE3", "NAME3", "TRANS3", CHR_2,
+                        List.of(new BaseRegion(10, 50), new BaseRegion(100, 150), new BaseRegion(200, 250), new BaseRegion(300, 400))));
+
+        ContigMappings.write(tempFile.getAbsolutePath(), entries);
+        List<ContigEntry> readBack = ContigMappings.read(tempFile.getAbsolutePath());
+
+        assertEquals(3, readBack.size());
+        assertEquals(1, readBack.get(0).exonSpans().size());
+        assertEquals(2, readBack.get(1).exonSpans().size());
+        assertEquals(4, readBack.get(2).exonSpans().size());
+    }
 }

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
@@ -37,18 +37,18 @@ public class ContigSidecarTest
         assertEquals(2, readBack.size());
 
         ContigEntry first = readBack.get(0);
-        assertEquals("ensENSG0000001_GENEA_ENST0000001", first.ContigName);
-        assertEquals("ENSG0000001", first.GeneId);
-        assertEquals("GENEA", first.GeneName);
-        assertEquals("ENST0000001", first.TransName);
-        assertEquals(CHR_1, first.Chromosome);
-        assertEquals(2, first.ExonSpans.size());
-        assertEquals(new BaseRegion(100, 199), first.ExonSpans.get(0));
-        assertEquals(new BaseRegion(300, 399), first.ExonSpans.get(1));
+        assertEquals("ensENSG0000001_GENEA_ENST0000001", first.contigName());
+        assertEquals("ENSG0000001", first.geneId());
+        assertEquals("GENEA", first.geneName());
+        assertEquals("ENST0000001", first.transName());
+        assertEquals(CHR_1, first.chromosome());
+        assertEquals(2, first.exonSpans().size());
+        assertEquals(new BaseRegion(100, 199), first.exonSpans().get(0));
+        assertEquals(new BaseRegion(300, 399), first.exonSpans().get(1));
 
         ContigEntry second = readBack.get(1);
-        assertEquals("ENST0000002", second.TransName);
-        assertEquals(1, second.ExonSpans.size());
-        assertEquals(new BaseRegion(1000, 1050), second.ExonSpans.get(0));
+        assertEquals("ENST0000002", second.transName());
+        assertEquals(1, second.exonSpans().size());
+        assertEquals(new BaseRegion(1000, 1050), second.exonSpans().get(0));
     }
 }

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
@@ -1,0 +1,54 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_2;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import org.junit.Test;
+
+public class ContigSidecarTest
+{
+    @Test
+    public void testRoundTrip() throws IOException
+    {
+        File tempFile = Files.createTempFile("contig_sidecar_", ".tsv").toFile();
+        tempFile.deleteOnExit();
+
+        List<ContigEntry> entries = List.of(
+                new ContigEntry(
+                        "ensENSG0000001_GENEA_ENST0000001", "ENSG0000001", "GENEA", "ENST0000001", CHR_1,
+                        List.of(new BaseRegion(100, 199), new BaseRegion(300, 399))),
+                new ContigEntry(
+                        "ensENSG0000002_GENEB_ENST0000002", "ENSG0000002", "GENEB", "ENST0000002", CHR_2,
+                        List.of(new BaseRegion(1000, 1050))));
+
+        ContigSidecar.write(tempFile.getAbsolutePath(), entries);
+
+        List<ContigEntry> readBack = ContigSidecar.read(tempFile.getAbsolutePath());
+
+        assertEquals(2, readBack.size());
+
+        ContigEntry first = readBack.get(0);
+        assertEquals("ensENSG0000001_GENEA_ENST0000001", first.ContigName);
+        assertEquals("ENSG0000001", first.GeneId);
+        assertEquals("GENEA", first.GeneName);
+        assertEquals("ENST0000001", first.TransName);
+        assertEquals(CHR_1, first.Chromosome);
+        assertEquals(2, first.ExonSpans.size());
+        assertEquals(new BaseRegion(100, 199), first.ExonSpans.get(0));
+        assertEquals(new BaseRegion(300, 399), first.ExonSpans.get(1));
+
+        ContigEntry second = readBack.get(1);
+        assertEquals("ENST0000002", second.TransName);
+        assertEquals(1, second.ExonSpans.size());
+        assertEquals(new BaseRegion(1000, 1050), second.ExonSpans.get(0));
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigSidecarTest.java
@@ -24,10 +24,10 @@ public class ContigSidecarTest
 
         List<ContigEntry> entries = List.of(
                 new ContigEntry(
-                        "ensENSG0000001_GENEA_ENST0000001", "ENSG0000001", "GENEA", "ENST0000001", CHR_1,
+                        "chr1_tx", 1, 200, "ENSG0000001", "GENEA", "ENST0000001", CHR_1,
                         List.of(new BaseRegion(100, 199), new BaseRegion(300, 399))),
                 new ContigEntry(
-                        "ensENSG0000002_GENEB_ENST0000002", "ENSG0000002", "GENEB", "ENST0000002", CHR_2,
+                        "chr2_tx", 1, 51, "ENSG0000002", "GENEB", "ENST0000002", CHR_2,
                         List.of(new BaseRegion(1000, 1050))));
 
         ContigSidecar.write(tempFile.getAbsolutePath(), entries);
@@ -37,7 +37,9 @@ public class ContigSidecarTest
         assertEquals(2, readBack.size());
 
         ContigEntry first = readBack.get(0);
-        assertEquals("ensENSG0000001_GENEA_ENST0000001", first.contigName());
+        assertEquals("chr1_tx", first.contigName());
+        assertEquals(1, first.altStart());
+        assertEquals(200, first.altEnd());
         assertEquals("ENSG0000001", first.geneId());
         assertEquals("GENEA", first.geneName());
         assertEquals("ENST0000001", first.transName());
@@ -47,6 +49,9 @@ public class ContigSidecarTest
         assertEquals(new BaseRegion(300, 399), first.exonSpans().get(1));
 
         ContigEntry second = readBack.get(1);
+        assertEquals("chr2_tx", second.contigName());
+        assertEquals(1, second.altStart());
+        assertEquals(51, second.altEnd());
         assertEquals("ENST0000002", second.transName());
         assertEquals(1, second.exonSpans().size());
         assertEquals(new BaseRegion(1000, 1050), second.exonSpans().get(0));

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigTranslatorTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigTranslatorTest.java
@@ -1,0 +1,224 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.TextCigarCodec;
+
+import org.junit.Test;
+
+public class ContigTranslatorTest
+{
+    private static final String GENE_ID = "ENSG00000000001";
+    private static final String GENE_NAME = "TESTGN";
+    private static final String TRANS_NAME = "ENST00000000001";
+    private static final String CONTIG_NAME = "ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME;
+
+    // three exon spans on chr1: 100-199 (len 100), 300-399 (len 100), 500-549 (len 50). Two introns: 200-299, 400-499.
+    private static ContigEntry threeExonContig()
+    {
+        return new ContigEntry(
+                CONTIG_NAME, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
+                List.of(new BaseRegion(100, 199), new BaseRegion(300, 399), new BaseRegion(500, 549)));
+    }
+
+    @Test
+    public void testReadEntirelyInFirstExon()
+    {
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("50M"));
+
+        assertNotNull(result);
+        assertEquals(CHR_1, result.Chromosome);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("50M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadEntirelyInLastExon()
+    {
+        // contig pos 201 is within the third span (cumulative offset is 200 after spans 1+2)
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 201, cigar("30M"));
+
+        assertNotNull(result);
+        assertEquals(500, result.GenomicStart);
+        assertEquals("30M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadCrossingOneJunction()
+    {
+        // start at contig pos 51 (genomic 150), 100M extends 100 bases. First 50 are in exon 1 (150-199),
+        // remaining 50 fall into exon 2 starting at 300. Intron is 200-299 (length 100).
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("100M"));
+
+        assertNotNull(result);
+        assertEquals(150, result.GenomicStart);
+        assertEquals("50M100N50M", result.GenomicCigar.toString());
+        assertEquals(1, result.ImpliedIntrons.size());
+        assertEquals(new BaseRegion(200, 299), result.ImpliedIntrons.get(0));
+    }
+
+    @Test
+    public void testReadCrossingTwoJunctions()
+    {
+        // start at contig pos 91 (genomic 190), 130M = 10 in exon1 + 100 in exon2 + 20 in exon3
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 91, cigar("130M"));
+
+        assertNotNull(result);
+        assertEquals(190, result.GenomicStart);
+        assertEquals("10M100N100M100N20M", result.GenomicCigar.toString());
+        assertEquals(2, result.ImpliedIntrons.size());
+        assertEquals(new BaseRegion(200, 299), result.ImpliedIntrons.get(0));
+        assertEquals(new BaseRegion(400, 499), result.ImpliedIntrons.get(1));
+    }
+
+    @Test
+    public void testReadWithSoftClip()
+    {
+        // 5S100M starting at contig pos 51. The 5S consumes query only — genomic start should still be 150.
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("5S100M"));
+
+        assertNotNull(result);
+        assertEquals(150, result.GenomicStart);
+        assertEquals("5S50M100N50M", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testReadWithInsertion()
+    {
+        // 30M5I20M starting at contig pos 1 — entirely in exon 1, no junctions
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("30M5I20M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("30M5I20M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadWithDeletion()
+    {
+        // 30M5D20M starting at contig pos 1 — D consumes ref but doesn't cross a junction (ends at genomic 154)
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("30M5D20M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("30M5D20M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadExactlyFillingFirstExon()
+    {
+        // 100M starting at contig pos 1 — fills exon 1 exactly (100-199), no spurious N at the end
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("100M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("100M", result.GenomicCigar.toString());
+        assertTrue(result.ImpliedIntrons.isEmpty());
+    }
+
+    @Test
+    public void testReadExtendingPastLastSpanIsUnliftable()
+    {
+        // start at contig pos 231 (genomic 530), 50M extends past the last span (500-549, only 20 bases remain)
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 231, cigar("50M"));
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testContigPosBeyondContigLengthReturnsNull()
+    {
+        // contig length is 250 (100+100+50). Pos 251 is past the end.
+        assertNull(ContigTranslator.translate(threeExonContig(), 251, cigar("10M")));
+    }
+
+    @Test
+    public void testInvalidContigPosReturnsNull()
+    {
+        assertNull(ContigTranslator.translate(threeExonContig(), 0, cigar("10M")));
+        assertNull(ContigTranslator.translate(threeExonContig(), -5, cigar("10M")));
+    }
+
+    @Test
+    public void testReadAtFirstBaseOfContig()
+    {
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("1M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("1M", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testReadAtLastBaseOfContig()
+    {
+        // contig length is 250, so pos 250 + 1M lands on the very last contig base
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 250, cigar("1M"));
+
+        assertNotNull(result);
+        assertEquals(549, result.GenomicStart);
+        assertEquals("1M", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testReadWithLeadingAndTrailingSoftClips()
+    {
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("10S100M10S"));
+
+        assertNotNull(result);
+        assertEquals(150, result.GenomicStart);
+        assertEquals("10S50M100N50M10S", result.GenomicCigar.toString());
+    }
+
+    @Test
+    public void testDeletionCrossingJunction()
+    {
+        // 10M5D5M starting at contig pos 91 (genomic 190): 10M fills the rest of exon 1, then 5D would consume
+        // ref starting at 200 (intron). We emit 100N for the intron, advance to exon 2 (300), then continue 5D + 5M.
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 91, cigar("10M5D5M"));
+
+        assertNotNull(result);
+        assertEquals(190, result.GenomicStart);
+        assertEquals("10M100N5D5M", result.GenomicCigar.toString());
+        assertEquals(1, result.ImpliedIntrons.size());
+    }
+
+    @Test
+    public void testTwoExonContigBoundaryCases()
+    {
+        ContigEntry twoExon = new ContigEntry(
+                "ensG_X_T", "G", "X", "T", CHR_1,
+                List.of(new BaseRegion(100, 149), new BaseRegion(200, 249)));
+
+        // M that exactly fills exon 1 — no spurious trailing N
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(twoExon, 1, cigar("50M"));
+        assertNotNull(result);
+        assertEquals(100, result.GenomicStart);
+        assertEquals("50M", result.GenomicCigar.toString());
+
+        // last base of exon 1 + 51M reaches one base into exon 2
+        result = ContigTranslator.translate(twoExon, 50, cigar("51M"));
+        assertNotNull(result);
+        assertEquals(149, result.GenomicStart);
+        assertEquals("1M50N50M", result.GenomicCigar.toString());
+    }
+
+    private static Cigar cigar(final String cigarString)
+    {
+        return TextCigarCodec.decode(cigarString);
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigTranslatorTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/ContigTranslatorTest.java
@@ -3,6 +3,7 @@ package com.hartwig.hmftools.redux.splice;
 import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -27,7 +28,7 @@ public class ContigTranslatorTest
     private static ContigEntry threeExonContig()
     {
         return new ContigEntry(
-                CONTIG_NAME, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
+                CONTIG_NAME, 1, 250, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
                 List.of(new BaseRegion(100, 199), new BaseRegion(300, 399), new BaseRegion(500, 549)));
     }
 
@@ -37,10 +38,10 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("50M"));
 
         assertNotNull(result);
-        assertEquals(CHR_1, result.Chromosome);
-        assertEquals(100, result.GenomicStart);
-        assertEquals("50M", result.GenomicCigar.toString());
-        assertTrue(result.ImpliedIntrons.isEmpty());
+        assertEquals(CHR_1, result.chromosome());
+        assertEquals(100, result.genomicStart());
+        assertEquals("50M", result.genomicCigar().toString());
+        assertTrue(result.impliedIntrons().isEmpty());
     }
 
     @Test
@@ -50,9 +51,9 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 201, cigar("30M"));
 
         assertNotNull(result);
-        assertEquals(500, result.GenomicStart);
-        assertEquals("30M", result.GenomicCigar.toString());
-        assertTrue(result.ImpliedIntrons.isEmpty());
+        assertEquals(500, result.genomicStart());
+        assertEquals("30M", result.genomicCigar().toString());
+        assertTrue(result.impliedIntrons().isEmpty());
     }
 
     @Test
@@ -63,10 +64,10 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("100M"));
 
         assertNotNull(result);
-        assertEquals(150, result.GenomicStart);
-        assertEquals("50M100N50M", result.GenomicCigar.toString());
-        assertEquals(1, result.ImpliedIntrons.size());
-        assertEquals(new BaseRegion(200, 299), result.ImpliedIntrons.get(0));
+        assertEquals(150, result.genomicStart());
+        assertEquals("50M100N50M", result.genomicCigar().toString());
+        assertEquals(1, result.impliedIntrons().size());
+        assertEquals(new BaseRegion(200, 299), result.impliedIntrons().get(0));
     }
 
     @Test
@@ -76,11 +77,11 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 91, cigar("130M"));
 
         assertNotNull(result);
-        assertEquals(190, result.GenomicStart);
-        assertEquals("10M100N100M100N20M", result.GenomicCigar.toString());
-        assertEquals(2, result.ImpliedIntrons.size());
-        assertEquals(new BaseRegion(200, 299), result.ImpliedIntrons.get(0));
-        assertEquals(new BaseRegion(400, 499), result.ImpliedIntrons.get(1));
+        assertEquals(190, result.genomicStart());
+        assertEquals("10M100N100M100N20M", result.genomicCigar().toString());
+        assertEquals(2, result.impliedIntrons().size());
+        assertEquals(new BaseRegion(200, 299), result.impliedIntrons().get(0));
+        assertEquals(new BaseRegion(400, 499), result.impliedIntrons().get(1));
     }
 
     @Test
@@ -90,8 +91,8 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("5S100M"));
 
         assertNotNull(result);
-        assertEquals(150, result.GenomicStart);
-        assertEquals("5S50M100N50M", result.GenomicCigar.toString());
+        assertEquals(150, result.genomicStart());
+        assertEquals("5S50M100N50M", result.genomicCigar().toString());
     }
 
     @Test
@@ -101,9 +102,9 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("30M5I20M"));
 
         assertNotNull(result);
-        assertEquals(100, result.GenomicStart);
-        assertEquals("30M5I20M", result.GenomicCigar.toString());
-        assertTrue(result.ImpliedIntrons.isEmpty());
+        assertEquals(100, result.genomicStart());
+        assertEquals("30M5I20M", result.genomicCigar().toString());
+        assertTrue(result.impliedIntrons().isEmpty());
     }
 
     @Test
@@ -113,9 +114,9 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("30M5D20M"));
 
         assertNotNull(result);
-        assertEquals(100, result.GenomicStart);
-        assertEquals("30M5D20M", result.GenomicCigar.toString());
-        assertTrue(result.ImpliedIntrons.isEmpty());
+        assertEquals(100, result.genomicStart());
+        assertEquals("30M5D20M", result.genomicCigar().toString());
+        assertTrue(result.impliedIntrons().isEmpty());
     }
 
     @Test
@@ -125,32 +126,46 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("100M"));
 
         assertNotNull(result);
-        assertEquals(100, result.GenomicStart);
-        assertEquals("100M", result.GenomicCigar.toString());
-        assertTrue(result.ImpliedIntrons.isEmpty());
+        assertEquals(100, result.genomicStart());
+        assertEquals("100M", result.genomicCigar().toString());
+        assertTrue(result.impliedIntrons().isEmpty());
     }
 
     @Test
-    public void testReadExtendingPastLastSpanIsUnliftable()
+    public void testReadExtendingPastLastSpanIsClampedToTrailingSoftClip()
     {
-        // start at contig pos 231 (genomic 530), 50M extends past the last span (500-549, only 20 bases remain)
+        // start at contig pos 231 (genomic 530), 50M extends past the last span (500-549, only 20 bases remain).
+        // overhang of 30 bases is converted into trailing soft-clip.
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 231, cigar("50M"));
 
-        assertNull(result);
+        assertNotNull(result);
+        assertEquals(530, result.genomicStart());
+        assertEquals("20M30S", result.genomicCigar().toString());
     }
 
     @Test
     public void testContigPosBeyondContigLengthReturnsNull()
     {
-        // contig length is 250 (100+100+50). Pos 251 is past the end.
+        // contig length is 250 (100+100+50). Pos 251 is past the end — no overhang fix possible.
         assertNull(ContigTranslator.translate(threeExonContig(), 251, cigar("10M")));
     }
 
     @Test
-    public void testInvalidContigPosReturnsNull()
+    public void testLeadingOverhangClampedToSoftClip()
     {
-        assertNull(ContigTranslator.translate(threeExonContig(), 0, cigar("10M")));
-        assertNull(ContigTranslator.translate(threeExonContig(), -5, cigar("10M")));
+        // contig pos 0 is 1 base before altStart (1); leading M absorbs the shift into soft-clip.
+        ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 0, cigar("10M"));
+
+        assertNotNull(result);
+        assertEquals(100, result.genomicStart());
+        assertEquals("1S9M", result.genomicCigar().toString());
+    }
+
+    @Test
+    public void testLeadingOverhangExceedsLeadingMReturnsNull()
+    {
+        // pos -5 is 6 below altStart, but only 4M to absorb -> unliftable
+        assertNull(ContigTranslator.translate(threeExonContig(), -5, cigar("4M10S")));
     }
 
     @Test
@@ -159,8 +174,8 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 1, cigar("1M"));
 
         assertNotNull(result);
-        assertEquals(100, result.GenomicStart);
-        assertEquals("1M", result.GenomicCigar.toString());
+        assertEquals(100, result.genomicStart());
+        assertEquals("1M", result.genomicCigar().toString());
     }
 
     @Test
@@ -170,8 +185,8 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 250, cigar("1M"));
 
         assertNotNull(result);
-        assertEquals(549, result.GenomicStart);
-        assertEquals("1M", result.GenomicCigar.toString());
+        assertEquals(549, result.genomicStart());
+        assertEquals("1M", result.genomicCigar().toString());
     }
 
     @Test
@@ -180,8 +195,8 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 51, cigar("10S100M10S"));
 
         assertNotNull(result);
-        assertEquals(150, result.GenomicStart);
-        assertEquals("10S50M100N50M10S", result.GenomicCigar.toString());
+        assertEquals(150, result.genomicStart());
+        assertEquals("10S50M100N50M10S", result.genomicCigar().toString());
     }
 
     @Test
@@ -192,29 +207,75 @@ public class ContigTranslatorTest
         ContigTranslator.TranslationResult result = ContigTranslator.translate(threeExonContig(), 91, cigar("10M5D5M"));
 
         assertNotNull(result);
-        assertEquals(190, result.GenomicStart);
-        assertEquals("10M100N5D5M", result.GenomicCigar.toString());
-        assertEquals(1, result.ImpliedIntrons.size());
+        assertEquals(190, result.genomicStart());
+        assertEquals("10M100N5D5M", result.genomicCigar().toString());
+        assertEquals(1, result.impliedIntrons().size());
     }
 
     @Test
     public void testTwoExonContigBoundaryCases()
     {
         ContigEntry twoExon = new ContigEntry(
-                "ensG_X_T", "G", "X", "T", CHR_1,
+                "ensG_X_T", 1, 100, "G", "X", "T", CHR_1,
                 List.of(new BaseRegion(100, 149), new BaseRegion(200, 249)));
 
         // M that exactly fills exon 1 — no spurious trailing N
         ContigTranslator.TranslationResult result = ContigTranslator.translate(twoExon, 1, cigar("50M"));
         assertNotNull(result);
-        assertEquals(100, result.GenomicStart);
-        assertEquals("50M", result.GenomicCigar.toString());
+        assertEquals(100, result.genomicStart());
+        assertEquals("50M", result.genomicCigar().toString());
 
         // last base of exon 1 + 51M reaches one base into exon 2
         result = ContigTranslator.translate(twoExon, 50, cigar("51M"));
         assertNotNull(result);
-        assertEquals(149, result.GenomicStart);
-        assertEquals("1M50N50M", result.GenomicCigar.toString());
+        assertEquals(149, result.genomicStart());
+        assertEquals("1M50N50M", result.genomicCigar().toString());
+    }
+
+    @Test
+    public void testSoftClipAtTrailingExonBoundary()
+    {
+        // pos 71 + 30M ends at contig pos 100 = end of exon 1 (interior boundary). 20S abuts that boundary.
+        assertTrue(ContigTranslator.hasSoftClipAtExonBoundary(threeExonContig(), 71, cigar("30M20S")));
+    }
+
+    @Test
+    public void testSoftClipAtLeadingExonBoundary()
+    {
+        // pos 101 = first base of exon 2 (cum length of exon 1 is 100). Leading 20S abuts that boundary.
+        assertTrue(ContigTranslator.hasSoftClipAtExonBoundary(threeExonContig(), 101, cigar("20S30M")));
+    }
+
+    @Test
+    public void testSoftClipNotAtBoundary()
+    {
+        // 30M ends mid-exon-1 (contig pos 89), trailing S not at any interior boundary
+        assertFalse(ContigTranslator.hasSoftClipAtExonBoundary(threeExonContig(), 60, cigar("30M20S")));
+    }
+
+    @Test
+    public void testNoSoftClipReturnsFalse()
+    {
+        assertFalse(ContigTranslator.hasSoftClipAtExonBoundary(threeExonContig(), 71, cigar("30M")));
+    }
+
+    @Test
+    public void testSingleExonContigReturnsFalse()
+    {
+        // single-exon contig has no interior boundaries; should always be false even with S
+        ContigEntry singleExon = new ContigEntry(
+                "single", 1, 100, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1, List.of(new BaseRegion(100, 199)));
+        assertFalse(ContigTranslator.hasSoftClipAtExonBoundary(singleExon, 1, cigar("50S50M")));
+        assertFalse(ContigTranslator.hasSoftClipAtExonBoundary(singleExon, 1, cigar("50M50S")));
+    }
+
+    @Test
+    public void testContigOuterEdgesNotTreatedAsBoundary()
+    {
+        // pos 1 (start of first exon) + leading S — outer edge, not an interior boundary
+        assertFalse(ContigTranslator.hasSoftClipAtExonBoundary(threeExonContig(), 1, cigar("20S30M")));
+        // 50M from pos 201 ends at contig pos 250 = last base of last exon — outer edge, not interior
+        assertFalse(ContigTranslator.hasSoftClipAtExonBoundary(threeExonContig(), 201, cigar("50M20S")));
     }
 
     private static Cigar cigar(final String cigarString)

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackResolverTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackResolverTest.java
@@ -1,0 +1,563 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+import org.junit.Test;
+
+// per-category sanity checks on LiftBackResolver + a small end-to-end smoke through LiftBackStats.
+// uses the same three-exon test contig as ContigTranslatorTest so lifted-coordinate math is consistent.
+public class LiftBackResolverTest
+{
+    private static final String GENE_ID = "ENSG_TEST";
+    private static final String GENE_NAME = "TESTG";
+    private static final String TRANS_NAME = "ENST_TEST";
+    private static final String TX_CONTIG = "ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME;
+
+    // exon spans on chr1: 100-199, 300-399, 500-549. introns: 200-299, 400-499. contig length 250.
+    // alt contig has the transcript laid down at positions 1..250 so test positions read like local coords.
+    private static ContigEntry threeExonContig()
+    {
+        return new ContigEntry(
+                TX_CONTIG, 1, 250, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
+                List.of(new BaseRegion(100, 199), new BaseRegion(300, 399), new BaseRegion(500, 549)));
+    }
+
+    private static List<ContigEntry> contigMap()
+    {
+        return List.of(threeExonContig());
+    }
+
+    private static SAMRecord newRecord(final String contig, final int pos, final String cigar)
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName("read");
+        record.setReferenceName(contig);
+        record.setAlignmentStart(pos);
+        record.setCigarString(cigar);
+        record.setMappingQuality(60);
+        return record;
+    }
+
+    private static SAMRecord newUnmappedRecord()
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName("read");
+        record.setReadUnmappedFlag(true);
+        return record;
+    }
+
+    @Test
+    public void testUnmapped()
+    {
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(newUnmappedRecord());
+
+        assertEquals(LiftBackCategory.UNMAPPED, result.Category);
+        assertTrue(result.LiftedAlignments.isEmpty());
+    }
+
+    @Test
+    public void testRefOnlyExonic()
+    {
+        SAMRecord record = newRecord(CHR_1, 1000, "150M");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.REF_SINGLE, result.Category);
+        assertEquals(CHR_1, result.FinalChrom);
+        assertEquals(1000, result.FinalPos);
+        assertEquals("150M", result.FinalCigar);
+        assertFalse(result.HasNCigar);
+        assertEquals(1, result.NumLoci);
+    }
+
+    @Test
+    public void testTxPrimaryUniqueWithinExon()
+    {
+        // contig pos 1, 50M — entirely within exon 1 (chr1:100-149)
+        SAMRecord record = newRecord(TX_CONTIG, 1, "50M");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.TX_SINGLE, result.Category);
+        assertEquals(CHR_1, result.FinalChrom);
+        assertEquals(100, result.FinalPos);
+        assertEquals("50M", result.FinalCigar);
+        assertFalse(result.HasNCigar);
+    }
+
+    @Test
+    public void testTxPrimaryUniqueJunctionCrosser()
+    {
+        // contig pos 51, 100M — crosses exon 1 -> exon 2 (intron 200-299, length 100)
+        SAMRecord record = newRecord(TX_CONTIG, 51, "100M");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.TX_SINGLE, result.Category);
+        assertEquals(CHR_1, result.FinalChrom);
+        assertEquals(150, result.FinalPos);
+        assertEquals("50M100N50M", result.FinalCigar);
+        assertTrue(result.HasNCigar);
+    }
+
+    @Test
+    public void testJunctionTxBetter()
+    {
+        // primary on Tx (junction-crosser), ref alt in XA at same lifted locus with soft-clip
+        SAMRecord record = newRecord(TX_CONTIG, 51, "100M");
+        record.setAttribute("XA", CHR_1 + ",+150,50M50S,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP, result.Category);
+        assertTrue(result.HasNCigar);
+        assertEquals(1, result.NumLoci);
+        // ref alt is dropped from the emitted set because tx wins this discriminator outcome,
+        // so only the tx CIGAR remains at the primary locus. The dropped ref alt stays in
+        // LiftedAlignments for TSV-B diagnostics.
+        assertEquals(1, result.NumDistinctCigarsAtPrimaryLocus);
+        assertEquals(2, result.LiftedAlignments.size());
+        assertEquals(1, result.LiftedAlignments.stream().filter(la -> !la.Dropped).count());
+    }
+
+    @Test
+    public void testRefTxAgree()
+    {
+        // primary on ref at chr1:100, Tx alt at contig pos 1 -> same lifted locus, same CIGAR
+        SAMRecord record = newRecord(CHR_1, 100, "50M");
+        record.setAttribute("XA", TX_CONTIG + ",+1,50M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_AGREE, result.Category);
+        assertEquals(1, result.NumLoci);
+    }
+
+    @Test
+    public void testIntronRetRefBetter()
+    {
+        // primary on ref full match overlapping exon 1 + intron 1; Tx alt soft-clipped at exon boundary
+        // ref: chr1:170, 50M -> covers chr1:170-219 (last 20 in intron)
+        // Tx: contig pos 71, 30M20S -> 30M lifts to chr1:170-199 (end of exon 1), 20S past contig boundary
+        SAMRecord record = newRecord(CHR_1, 170, "50M");
+        record.setAttribute("XA", TX_CONTIG + ",+71,30M20S,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH, result.Category);
+        assertEquals(1, result.NumLoci);
+    }
+
+    @Test
+    public void testTxSoftClipNotAtBoundaryFallsToAmbiguous()
+    {
+        // ref pos 170, 50M (chr1:170-219, full match). Tx pos 71, 25M25S — 25M lifts to chr1:170-194, ending
+        // mid exon-1 (well shy of exon-1 end 199), so trailing 25S is NOT at any interior exon boundary.
+        // Same lifted locus (chr1:170), distinct CIGARs, refFullMatch=true, txSoftClipAtBoundary=false -> BOTH_AMBIGUOUS.
+        SAMRecord record = newRecord(CHR_1, 170, "50M");
+        record.setAttribute("XA", TX_CONTIG + ",+71,25M25S,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_AMBIGUOUS, result.Category);
+        assertEquals(1, result.NumLoci);
+    }
+
+    @Test
+    public void testParalogMulti()
+    {
+        // primary on Tx, ref alt at a different chromosome -> two distinct loci, ref present
+        SAMRecord record = newRecord(TX_CONTIG, 1, "50M");
+        record.setAttribute("XA", "chr5,+5000,50M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_MULTI, result.Category);
+        assertEquals(2, result.NumLoci);
+    }
+
+    @Test
+    public void testRefOnlyMulti()
+    {
+        // primary on ref, XA alt on a different ref chromosome -> two distinct loci, no tx
+        SAMRecord record = newRecord(CHR_1, 1000, "50M");
+        record.setAttribute("XA", "chr5,+5000,50M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.REF_MULTI, result.Category);
+        assertEquals(2, result.NumLoci);
+    }
+
+    @Test
+    public void testTxPrimaryMulti()
+    {
+        // primary on Tx, alt on a different ref locus, no actual ref alt -> Tx-only multi-locus
+        // (using two distinct Tx contigs would need a second ContigEntry; instead use a different contig name
+        //  not in our map so it's treated as ref — defeats the test. Simulate with two different lifted positions
+        //  of two Tx alts. Since our map only has one contig, instead build a multi-contig test:)
+        ContigEntry entryB = new ContigEntry(
+                "ensG_OTHER_T", 1, 100, "GO", "OTHER", "TO", "chr5",
+                List.of(new BaseRegion(2000, 2099)));
+        List<ContigEntry> twoContigs = List.of(threeExonContig(), entryB);
+
+        SAMRecord record = newRecord(TX_CONTIG, 1, "50M");
+        record.setAttribute("XA", "ensG_OTHER_T,+1,50M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(twoContigs);
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.TX_MULTI, result.Category);
+        assertEquals(2, result.NumLoci);
+    }
+
+    @Test
+    public void testSupplementary()
+    {
+        SAMRecord record = newRecord(CHR_1, 1000, "60M40H");
+        record.setSupplementaryAlignmentFlag(true);
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.SUPPLEMENTARY, result.Category);
+        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.Role);
+    }
+
+    @Test
+    public void testSupplementaryOnTxContigGetsLifted()
+    {
+        SAMRecord record = newRecord(TX_CONTIG, 51, "100M");
+        record.setSupplementaryAlignmentFlag(true);
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.SUPPLEMENTARY, result.Category);
+        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.Role);
+        assertEquals(CHR_1, result.FinalChrom);
+        assertEquals(150, result.FinalPos);
+        assertEquals("50M100N50M", result.FinalCigar);
+        assertTrue(result.HasNCigar);
+    }
+
+    @Test
+    public void testSupplementaryOnTxContigUnliftablePastEnd()
+    {
+        // pos 251 is past altEnd (250) entirely — no overhang clamp can save it
+        SAMRecord record = newRecord(TX_CONTIG, 251, "10M");
+        record.setSupplementaryAlignmentFlag(true);
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.LIFT_FAILED, result.Category);
+        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.Role);
+        assertTrue(result.LiftedAlignments.isEmpty());
+    }
+
+    @Test
+    public void testPrimaryUnliftablePastEnd()
+    {
+        SAMRecord record = newRecord(TX_CONTIG, 251, "10M");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.LIFT_FAILED, result.Category);
+        assertEquals(LiftBackResult.RecordRole.PRIMARY, result.Role);
+        assertTrue(result.Notes.contains("primary_translate_failed"));
+    }
+
+    @Test
+    public void testPrimaryTrailingOverhangClampedToSoftClip()
+    {
+        // pos 200 + 100M extends 49 bases past altEnd (250) — clamp converts overhang to trailing S
+        SAMRecord record = newRecord(TX_CONTIG, 200, "100M");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.TX_SINGLE, result.Category);
+        assertTrue(result.FinalCigar.endsWith("49S"));
+    }
+
+    @Test
+    public void testIntronRetRefBetterLeadingSoftClipBoundary()
+    {
+        // Tx alt at exon-2 start (contig pos 101) with leading 20S abutting the exon-1/exon-2 boundary.
+        // ref alt at chr1:300 full match -> single locus, refFullMatch + txSoftClipAtBoundary -> BOTH_TX_SOFTCLIP_REF_MATCH.
+        SAMRecord record = newRecord(CHR_1, 300, "30M");
+        record.setAttribute("XA", TX_CONTIG + ",+101,20S30M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH, result.Category);
+        assertEquals(1, result.NumLoci);
+    }
+
+    @Test
+    public void testXaDedupDropsDuplicateAlts()
+    {
+        // two identical XA entries -> only one lifted alt retained
+        SAMRecord record = newRecord(TX_CONTIG, 1, "50M");
+        record.setAttribute("XA", "chr5,+5000,50M,0;chr5,+5000,50M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        // self + one deduped alt = 2 alignments
+        assertEquals(2, result.LiftedAlignments.size());
+        assertEquals(1, result.NumXaAlts);
+    }
+
+    @Test
+    public void testXaDedupKeepsAltMatchingSelfButDropsXaDuplicate()
+    {
+        // self at chr1:100/50M; two XA entries that both lift to the same (chr1, 100, 50M) — one Tx, one ref.
+        // Spec: dedup XA among itself only, NOT against self. The Tx alt is kept (so BOTH_AGREE can fire),
+        // the duplicate ref XA is collapsed.
+        SAMRecord record = newRecord(CHR_1, 100, "50M");
+        record.setAttribute("XA", TX_CONTIG + ",+1,50M,0;" + CHR_1 + ",+100,50M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        // self + 1 surviving XA alt (the Tx one; the chr1,100,50M XA collapses to the Tx one as both share lifted key)
+        assertEquals(2, result.LiftedAlignments.size());
+        assertEquals(1, result.NumXaAlts);
+        assertEquals(LiftBackCategory.BOTH_AGREE, result.Category);
+    }
+
+    @Test
+    public void testXaWithMalformedNmStillLifted()
+    {
+        // bwa XA NM field is sometimes garbled; alt should still be lifted, not silently dropped
+        SAMRecord record = newRecord(TX_CONTIG, 1, "50M");
+        record.setAttribute("XA", "chr5,+5000,50M,not_a_number;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(2, result.LiftedAlignments.size());
+        assertEquals(LiftBackCategory.BOTH_MULTI, result.Category);
+    }
+
+    @Test
+    public void testCrossLocusFavoursTxSwapsToTx()
+    {
+        // bwa picked an intronless paralog (ref locus chr5:5000, full match) as primary; tx XA lifts to
+        // chr1:150 with the spliced CIGAR 50M100N50M. Expect: category CROSS_LOCUS_FAVOURS_TX, BAM primary
+        // swapped to the tx locus (chr1:150 with N), original ref demoted to XA, MAPQ rescued.
+        SAMRecord record = newRecord("chr5", 5000, "100M");
+        record.setAttribute("XA", TX_CONTIG + ",+51,100M,0;");
+        record.setMappingQuality(60);
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_MULTI_TX_JUNCTION, result.Category);
+        assertEquals(CHR_1, result.FinalChrom);
+        assertEquals(150, result.FinalPos);
+        assertEquals("50M100N50M", result.FinalCigar);
+        assertTrue(result.HasNCigar);
+        assertEquals(60, result.UpdatedMapq);
+        assertTrue(result.Notes.contains("swapped_ref_to_tx"));
+
+        // self (chr5 ref) should still be in the lifted set but not the primary choice and not dropped
+        LiftedAlignment originalSelf = result.LiftedAlignments.stream()
+                .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
+                .findFirst().orElseThrow();
+        assertFalse(originalSelf.IsPrimaryChoice);
+        assertFalse(originalSelf.Dropped);
+
+        // the tx XA alt is now the primary choice
+        LiftedAlignment winner = result.LiftedAlignments.stream()
+                .filter(la -> la.IsPrimaryChoice)
+                .findFirst().orElseThrow();
+        assertTrue(winner.fromTxContig());
+        assertEquals("50M100N50M", winner.LiftedCigar);
+    }
+
+    @Test
+    public void testCrossLocusBothSplicedRemainsMultiLocus()
+    {
+        // primary on tx (junction-crosser), XA alt is a ref alignment that also has an N-CIGAR at a
+        // different locus. Both sides found splices — ambiguous, must NOT swap. Falls into MULTI_LOCUS.
+        SAMRecord record = newRecord(TX_CONTIG, 51, "100M");
+        record.setAttribute("XA", "chr5,+5000,50M100N50M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_MULTI, result.Category);
+        // self stays primary (no swap)
+        LiftedAlignment self = result.LiftedAlignments.stream()
+                .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
+                .findFirst().orElseThrow();
+        assertTrue(self.IsPrimaryChoice);
+    }
+
+    @Test
+    public void testCrossLocusFavoursTxDropsOtherRefAlts()
+    {
+        // self ref at chr5 (paralog A), tx XA at chr1:150 spliced (winner), another ref XA at chr7
+        // (paralog B). Expect winner promoted; original self goes to XA (informative paralog); chr7 ref
+        // alt gets Dropped (paralog noise).
+        SAMRecord record = newRecord("chr5", 5000, "100M");
+        record.setAttribute("XA", TX_CONTIG + ",+51,100M,0;chr7,+7000,100M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_MULTI_TX_JUNCTION, result.Category);
+
+        LiftedAlignment chr7Alt = result.LiftedAlignments.stream()
+                .filter(la -> "chr7".equals(la.LiftedChrom))
+                .findFirst().orElseThrow();
+        assertTrue(chr7Alt.Dropped);
+
+        LiftedAlignment chr5Self = result.LiftedAlignments.stream()
+                .filter(la -> "chr5".equals(la.LiftedChrom))
+                .findFirst().orElseThrow();
+        assertFalse(chr5Self.Dropped);
+        assertFalse(chr5Self.IsPrimaryChoice);
+    }
+
+    @Test
+    public void testJunctionFavoursTxSwapsWhenSelfIsRef()
+    {
+        // single-locus junction case but bwa picked ref as primary: ref self soft-clipped at chr1:150 with
+        // 50M50S, tx XA at contig pos 51 lifts to chr1:150 with 50M100N50M. Tx wins the discriminator and
+        // the BAM primary now actually swaps (previously emitted "self_was_ref_no_swap" without swapping).
+        SAMRecord record = newRecord(CHR_1, 150, "50M50S");
+        record.setAttribute("XA", TX_CONTIG + ",+51,100M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP, result.Category);
+        assertEquals("50M100N50M", result.FinalCigar);
+        assertTrue(result.HasNCigar);
+        assertTrue(result.Notes.contains("swapped_ref_to_tx"));
+    }
+
+    @Test
+    public void testJunctionRefMatchKeepsRefAndDropsTx()
+    {
+        // single-locus: ref self full-match 151M at chr1:150, tx XA at contig pos 51 lifts to 50M100N50M.
+        // Ref full-match through the supposed intron is overwhelming evidence the read is unspliced —
+        // we keep ref and drop the tx alt (opposite of BOTH_TX_JUNCTION_REF_SOFTCLIP).
+        SAMRecord record = newRecord(CHR_1, 150, "151M");
+        record.setAttribute("XA", TX_CONTIG + ",+51,100M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH, result.Category);
+        assertEquals(CHR_1, result.FinalChrom);
+        assertEquals(150, result.FinalPos);
+        assertEquals("151M", result.FinalCigar);
+        assertFalse(result.HasNCigar);
+
+        // ref self stays primary
+        LiftedAlignment self = result.LiftedAlignments.stream()
+                .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
+                .findFirst().orElseThrow();
+        assertTrue(self.IsPrimaryChoice);
+        assertFalse(self.Dropped);
+
+        // tx alt is dropped
+        LiftedAlignment txAlt = result.LiftedAlignments.stream()
+                .filter(LiftedAlignment::fromTxContig)
+                .findFirst().orElseThrow();
+        assertTrue(txAlt.Dropped);
+        assertFalse(txAlt.IsPrimaryChoice);
+    }
+
+    @Test
+    public void testJunctionRefMatchSwapsToRefWhenSelfIsTx()
+    {
+        // bwa primary is the tx alignment (51M+99M lifted to 50M100N50M), ref XA is the unspliced full-match.
+        // The discriminator should swap onto the ref locus and drop the tx alt.
+        SAMRecord record = newRecord(TX_CONTIG, 51, "100M");
+        record.setAttribute("XA", CHR_1 + ",+150,151M,0;");
+
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackResult result = resolver.resolve(record);
+
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH, result.Category);
+        assertEquals(CHR_1, result.FinalChrom);
+        assertEquals(150, result.FinalPos);
+        assertEquals("151M", result.FinalCigar);
+        assertFalse(result.HasNCigar);
+        assertTrue(result.Notes.contains("swapped_tx_to_ref"));
+
+        // tx self gets demoted (kept in XA, not dropped — informative tx hit)
+        LiftedAlignment txSelf = result.LiftedAlignments.stream()
+                .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
+                .findFirst().orElseThrow();
+        assertFalse(txSelf.IsPrimaryChoice);
+        assertFalse(txSelf.Dropped);
+
+        // ref alt is now the primary
+        LiftedAlignment winner = result.LiftedAlignments.stream()
+                .filter(la -> la.IsPrimaryChoice)
+                .findFirst().orElseThrow();
+        assertFalse(winner.fromTxContig());
+    }
+
+    @Test
+    public void testStatsEndToEndSmoke()
+    {
+        LiftBackResolver resolver = new LiftBackResolver(contigMap());
+        LiftBackStats stats = new LiftBackStats();
+
+        // r1: ref-only exonic, MAPQ=60, no XA -> REF_SINGLE, REF_ONLY, MAPQ_POS_UNIQUE
+        SAMRecord r1 = newRecord(CHR_1, 1000, "150M");
+        stats.record(r1, resolver.resolve(r1));
+
+        // r2: Tx primary junction-crosser, MAPQ=60, no XA -> TX_SINGLE, TX_ONLY, MAPQ_POS_UNIQUE
+        SAMRecord r2 = newRecord(TX_CONTIG, 51, "100M");
+        stats.record(r2, resolver.resolve(r2));
+
+        // r3: ref + Tx agree, MAPQ=0 -> BOTH_AGREE, REF_AND_TX, MAPQ_ZERO
+        SAMRecord r3 = newRecord(CHR_1, 100, "50M");
+        r3.setAttribute("XA", TX_CONTIG + ",+1,50M,0;");
+        r3.setMappingQuality(0);
+        stats.record(r3, resolver.resolve(r3));
+
+        // r4: unmapped -> UNMAPPED, NONE composition
+        SAMRecord r4 = newUnmappedRecord();
+        stats.record(r4, resolver.resolve(r4));
+
+        assertEquals(4, stats.total());
+        assertEquals(1, stats.categoryCount(LiftBackCategory.REF_SINGLE));
+        assertEquals(1, stats.categoryCount(LiftBackCategory.TX_SINGLE));
+        assertEquals(1, stats.categoryCount(LiftBackCategory.BOTH_AGREE));
+        assertEquals(1, stats.categoryCount(LiftBackCategory.UNMAPPED));
+    }
+
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackResolverTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackResolverTest.java
@@ -63,8 +63,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(newUnmappedRecord());
 
-        assertEquals(LiftBackCategory.UNMAPPED, result.Category);
-        assertTrue(result.LiftedAlignments.isEmpty());
+        assertEquals(LiftBackCategory.UNMAPPED, result.category());
+        assertTrue(result.liftedAlignments().isEmpty());
     }
 
     @Test
@@ -75,12 +75,12 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.REF_SINGLE, result.Category);
-        assertEquals(CHR_1, result.FinalChrom);
-        assertEquals(1000, result.FinalPos);
-        assertEquals("150M", result.FinalCigar);
-        assertFalse(result.HasNCigar);
-        assertEquals(1, result.NumLoci);
+        assertEquals(LiftBackCategory.REF_SINGLE, result.category());
+        assertEquals(CHR_1, result.finalChrom());
+        assertEquals(1000, result.finalPos());
+        assertEquals("150M", result.finalCigar());
+        assertFalse(result.hasNCigar());
+        assertEquals(1, result.numLoci());
     }
 
     @Test
@@ -92,11 +92,11 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.TX_SINGLE, result.Category);
-        assertEquals(CHR_1, result.FinalChrom);
-        assertEquals(100, result.FinalPos);
-        assertEquals("50M", result.FinalCigar);
-        assertFalse(result.HasNCigar);
+        assertEquals(LiftBackCategory.TX_SINGLE, result.category());
+        assertEquals(CHR_1, result.finalChrom());
+        assertEquals(100, result.finalPos());
+        assertEquals("50M", result.finalCigar());
+        assertFalse(result.hasNCigar());
     }
 
     @Test
@@ -108,11 +108,11 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.TX_SINGLE, result.Category);
-        assertEquals(CHR_1, result.FinalChrom);
-        assertEquals(150, result.FinalPos);
-        assertEquals("50M100N50M", result.FinalCigar);
-        assertTrue(result.HasNCigar);
+        assertEquals(LiftBackCategory.TX_SINGLE, result.category());
+        assertEquals(CHR_1, result.finalChrom());
+        assertEquals(150, result.finalPos());
+        assertEquals("50M100N50M", result.finalCigar());
+        assertTrue(result.hasNCigar());
     }
 
     @Test
@@ -125,15 +125,15 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP, result.Category);
-        assertTrue(result.HasNCigar);
-        assertEquals(1, result.NumLoci);
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP, result.category());
+        assertTrue(result.hasNCigar());
+        assertEquals(1, result.numLoci());
         // ref alt is dropped from the emitted set because tx wins this discriminator outcome,
         // so only the tx CIGAR remains at the primary locus. The dropped ref alt stays in
         // LiftedAlignments for TSV-B diagnostics.
-        assertEquals(1, result.NumDistinctCigarsAtPrimaryLocus);
-        assertEquals(2, result.LiftedAlignments.size());
-        assertEquals(1, result.LiftedAlignments.stream().filter(la -> !la.Dropped).count());
+        assertEquals(1, result.numDistinctCigarsAtPrimaryLocus());
+        assertEquals(2, result.liftedAlignments().size());
+        assertEquals(1, result.liftedAlignments().stream().filter(la -> !la.Dropped).count());
     }
 
     @Test
@@ -146,8 +146,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_AGREE, result.Category);
-        assertEquals(1, result.NumLoci);
+        assertEquals(LiftBackCategory.BOTH_AGREE, result.category());
+        assertEquals(1, result.numLoci());
     }
 
     @Test
@@ -162,8 +162,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH, result.Category);
-        assertEquals(1, result.NumLoci);
+        assertEquals(LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH, result.category());
+        assertEquals(1, result.numLoci());
     }
 
     @Test
@@ -178,8 +178,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_AMBIGUOUS, result.Category);
-        assertEquals(1, result.NumLoci);
+        assertEquals(LiftBackCategory.BOTH_AMBIGUOUS, result.category());
+        assertEquals(1, result.numLoci());
     }
 
     @Test
@@ -192,8 +192,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_MULTI, result.Category);
-        assertEquals(2, result.NumLoci);
+        assertEquals(LiftBackCategory.BOTH_MULTI, result.category());
+        assertEquals(2, result.numLoci());
     }
 
     @Test
@@ -206,8 +206,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.REF_MULTI, result.Category);
-        assertEquals(2, result.NumLoci);
+        assertEquals(LiftBackCategory.REF_MULTI, result.category());
+        assertEquals(2, result.numLoci());
     }
 
     @Test
@@ -228,8 +228,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(twoContigs);
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.TX_MULTI, result.Category);
-        assertEquals(2, result.NumLoci);
+        assertEquals(LiftBackCategory.TX_MULTI, result.category());
+        assertEquals(2, result.numLoci());
     }
 
     @Test
@@ -241,8 +241,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.SUPPLEMENTARY, result.Category);
-        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.Role);
+        assertEquals(LiftBackCategory.SUPPLEMENTARY, result.category());
+        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.role());
     }
 
     @Test
@@ -254,12 +254,12 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.SUPPLEMENTARY, result.Category);
-        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.Role);
-        assertEquals(CHR_1, result.FinalChrom);
-        assertEquals(150, result.FinalPos);
-        assertEquals("50M100N50M", result.FinalCigar);
-        assertTrue(result.HasNCigar);
+        assertEquals(LiftBackCategory.SUPPLEMENTARY, result.category());
+        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.role());
+        assertEquals(CHR_1, result.finalChrom());
+        assertEquals(150, result.finalPos());
+        assertEquals("50M100N50M", result.finalCigar());
+        assertTrue(result.hasNCigar());
     }
 
     @Test
@@ -272,9 +272,9 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.LIFT_FAILED, result.Category);
-        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.Role);
-        assertTrue(result.LiftedAlignments.isEmpty());
+        assertEquals(LiftBackCategory.LIFT_FAILED, result.category());
+        assertEquals(LiftBackResult.RecordRole.SUPPLEMENTARY, result.role());
+        assertTrue(result.liftedAlignments().isEmpty());
     }
 
     @Test
@@ -285,9 +285,9 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.LIFT_FAILED, result.Category);
-        assertEquals(LiftBackResult.RecordRole.PRIMARY, result.Role);
-        assertTrue(result.Notes.contains("primary_translate_failed"));
+        assertEquals(LiftBackCategory.LIFT_FAILED, result.category());
+        assertEquals(LiftBackResult.RecordRole.PRIMARY, result.role());
+        assertTrue(result.notes().contains("primary_translate_failed"));
     }
 
     @Test
@@ -299,8 +299,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.TX_SINGLE, result.Category);
-        assertTrue(result.FinalCigar.endsWith("49S"));
+        assertEquals(LiftBackCategory.TX_SINGLE, result.category());
+        assertTrue(result.finalCigar().endsWith("49S"));
     }
 
     @Test
@@ -314,8 +314,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH, result.Category);
-        assertEquals(1, result.NumLoci);
+        assertEquals(LiftBackCategory.BOTH_TX_SOFTCLIP_REF_MATCH, result.category());
+        assertEquals(1, result.numLoci());
     }
 
     @Test
@@ -329,8 +329,8 @@ public class LiftBackResolverTest
         LiftBackResult result = resolver.resolve(record);
 
         // self + one deduped alt = 2 alignments
-        assertEquals(2, result.LiftedAlignments.size());
-        assertEquals(1, result.NumXaAlts);
+        assertEquals(2, result.liftedAlignments().size());
+        assertEquals(1, result.numXaAlts());
     }
 
     @Test
@@ -346,9 +346,9 @@ public class LiftBackResolverTest
         LiftBackResult result = resolver.resolve(record);
 
         // self + 1 surviving XA alt (the Tx one; the chr1,100,50M XA collapses to the Tx one as both share lifted key)
-        assertEquals(2, result.LiftedAlignments.size());
-        assertEquals(1, result.NumXaAlts);
-        assertEquals(LiftBackCategory.BOTH_AGREE, result.Category);
+        assertEquals(2, result.liftedAlignments().size());
+        assertEquals(1, result.numXaAlts());
+        assertEquals(LiftBackCategory.BOTH_AGREE, result.category());
     }
 
     @Test
@@ -361,8 +361,8 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(2, result.LiftedAlignments.size());
-        assertEquals(LiftBackCategory.BOTH_MULTI, result.Category);
+        assertEquals(2, result.liftedAlignments().size());
+        assertEquals(LiftBackCategory.BOTH_MULTI, result.category());
     }
 
     @Test
@@ -378,23 +378,23 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_MULTI_TX_JUNCTION, result.Category);
-        assertEquals(CHR_1, result.FinalChrom);
-        assertEquals(150, result.FinalPos);
-        assertEquals("50M100N50M", result.FinalCigar);
-        assertTrue(result.HasNCigar);
-        assertEquals(60, result.UpdatedMapq);
-        assertTrue(result.Notes.contains("swapped_ref_to_tx"));
+        assertEquals(LiftBackCategory.BOTH_MULTI_TX_JUNCTION, result.category());
+        assertEquals(CHR_1, result.finalChrom());
+        assertEquals(150, result.finalPos());
+        assertEquals("50M100N50M", result.finalCigar());
+        assertTrue(result.hasNCigar());
+        assertEquals(60, result.updatedMapq());
+        assertTrue(result.notes().contains("swapped_ref_to_tx"));
 
         // self (chr5 ref) should still be in the lifted set but not the primary choice and not dropped
-        LiftedAlignment originalSelf = result.LiftedAlignments.stream()
+        LiftedAlignment originalSelf = result.liftedAlignments().stream()
                 .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
                 .findFirst().orElseThrow();
         assertFalse(originalSelf.IsPrimaryChoice);
         assertFalse(originalSelf.Dropped);
 
         // the tx XA alt is now the primary choice
-        LiftedAlignment winner = result.LiftedAlignments.stream()
+        LiftedAlignment winner = result.liftedAlignments().stream()
                 .filter(la -> la.IsPrimaryChoice)
                 .findFirst().orElseThrow();
         assertTrue(winner.fromTxContig());
@@ -412,9 +412,9 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_MULTI, result.Category);
+        assertEquals(LiftBackCategory.BOTH_MULTI, result.category());
         // self stays primary (no swap)
-        LiftedAlignment self = result.LiftedAlignments.stream()
+        LiftedAlignment self = result.liftedAlignments().stream()
                 .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
                 .findFirst().orElseThrow();
         assertTrue(self.IsPrimaryChoice);
@@ -432,14 +432,14 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_MULTI_TX_JUNCTION, result.Category);
+        assertEquals(LiftBackCategory.BOTH_MULTI_TX_JUNCTION, result.category());
 
-        LiftedAlignment chr7Alt = result.LiftedAlignments.stream()
+        LiftedAlignment chr7Alt = result.liftedAlignments().stream()
                 .filter(la -> "chr7".equals(la.LiftedChrom))
                 .findFirst().orElseThrow();
         assertTrue(chr7Alt.Dropped);
 
-        LiftedAlignment chr5Self = result.LiftedAlignments.stream()
+        LiftedAlignment chr5Self = result.liftedAlignments().stream()
                 .filter(la -> "chr5".equals(la.LiftedChrom))
                 .findFirst().orElseThrow();
         assertFalse(chr5Self.Dropped);
@@ -458,10 +458,10 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP, result.Category);
-        assertEquals("50M100N50M", result.FinalCigar);
-        assertTrue(result.HasNCigar);
-        assertTrue(result.Notes.contains("swapped_ref_to_tx"));
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_SOFTCLIP, result.category());
+        assertEquals("50M100N50M", result.finalCigar());
+        assertTrue(result.hasNCigar());
+        assertTrue(result.notes().contains("swapped_ref_to_tx"));
     }
 
     @Test
@@ -476,21 +476,21 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH, result.Category);
-        assertEquals(CHR_1, result.FinalChrom);
-        assertEquals(150, result.FinalPos);
-        assertEquals("151M", result.FinalCigar);
-        assertFalse(result.HasNCigar);
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH, result.category());
+        assertEquals(CHR_1, result.finalChrom());
+        assertEquals(150, result.finalPos());
+        assertEquals("151M", result.finalCigar());
+        assertFalse(result.hasNCigar());
 
         // ref self stays primary
-        LiftedAlignment self = result.LiftedAlignments.stream()
+        LiftedAlignment self = result.liftedAlignments().stream()
                 .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
                 .findFirst().orElseThrow();
         assertTrue(self.IsPrimaryChoice);
         assertFalse(self.Dropped);
 
         // tx alt is dropped
-        LiftedAlignment txAlt = result.LiftedAlignments.stream()
+        LiftedAlignment txAlt = result.liftedAlignments().stream()
                 .filter(LiftedAlignment::fromTxContig)
                 .findFirst().orElseThrow();
         assertTrue(txAlt.Dropped);
@@ -508,22 +508,22 @@ public class LiftBackResolverTest
         LiftBackResolver resolver = new LiftBackResolver(contigMap());
         LiftBackResult result = resolver.resolve(record);
 
-        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH, result.Category);
-        assertEquals(CHR_1, result.FinalChrom);
-        assertEquals(150, result.FinalPos);
-        assertEquals("151M", result.FinalCigar);
-        assertFalse(result.HasNCigar);
-        assertTrue(result.Notes.contains("swapped_tx_to_ref"));
+        assertEquals(LiftBackCategory.BOTH_TX_JUNCTION_REF_MATCH, result.category());
+        assertEquals(CHR_1, result.finalChrom());
+        assertEquals(150, result.finalPos());
+        assertEquals("151M", result.finalCigar());
+        assertFalse(result.hasNCigar());
+        assertTrue(result.notes().contains("swapped_tx_to_ref"));
 
         // tx self gets demoted (kept in XA, not dropped — informative tx hit)
-        LiftedAlignment txSelf = result.LiftedAlignments.stream()
+        LiftedAlignment txSelf = result.liftedAlignments().stream()
                 .filter(la -> la.Source == LiftedAlignment.AlignmentSource.SELF)
                 .findFirst().orElseThrow();
         assertFalse(txSelf.IsPrimaryChoice);
         assertFalse(txSelf.Dropped);
 
         // ref alt is now the primary
-        LiftedAlignment winner = result.LiftedAlignments.stream()
+        LiftedAlignment winner = result.liftedAlignments().stream()
                 .filter(la -> la.IsPrimaryChoice)
                 .findFirst().orElseThrow();
         assertFalse(winner.fromTxContig());

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackStatsTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackStatsTest.java
@@ -1,0 +1,149 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+// covers LiftBackStats counter mechanics, composition / MAPQ tier derivation, and the summary TSV layout.
+public class LiftBackStatsTest
+{
+    private Path mSummary;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        mSummary = Files.createTempFile("liftback_summary_", ".tsv");
+    }
+
+    @After
+    public void tearDown() throws IOException
+    {
+        Files.deleteIfExists(mSummary);
+    }
+
+    private static SAMRecord newRecord(final int mapq)
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName("read");
+        record.setMappingQuality(mapq);
+        return record;
+    }
+
+    private static LiftBackResult resultWith(final LiftBackCategory category, final int numXaAlts,
+            final List<LiftedAlignment> alignments)
+    {
+        return new LiftBackResult(
+                category, LiftBackResult.Composition.NONE,
+                LiftBackResult.RecordRole.PRIMARY,
+                "1", 0, "*",
+                false,
+                false, 0, 0,
+                numXaAlts, 0, 0,
+                0, 0,
+                false, false, false, false,
+                "", "",
+                alignments);
+    }
+
+    private static LiftedAlignment refAlignment()
+    {
+        return new LiftedAlignment(
+                LiftedAlignment.AlignmentSource.SELF, "1", 100, "50M",
+                "1", 100, "50M",
+                0, 0,
+                null, null, null,
+                false, true);
+    }
+
+    private static LiftedAlignment txAlignment()
+    {
+        return new LiftedAlignment(
+                LiftedAlignment.AlignmentSource.SELF, "txContig", 1, "50M",
+                "1", 100, "50M",
+                0, 0,
+                "ENST_X", "ENSG_X", "GENEX",
+                false, true);
+    }
+
+    @Test
+    public void testRecordsIncrementCountersByCategory()
+    {
+        LiftBackStats stats = new LiftBackStats();
+        stats.record(newRecord(60), resultWith(LiftBackCategory.REF_SINGLE, 0, List.of(refAlignment())));
+        stats.record(newRecord(60), resultWith(LiftBackCategory.REF_SINGLE, 0, List.of(refAlignment())));
+        stats.record(newRecord(0), resultWith(LiftBackCategory.UNMAPPED, 0, List.of()));
+
+        assertEquals(3, stats.total());
+        assertEquals(2, stats.categoryCount(LiftBackCategory.REF_SINGLE));
+        assertEquals(1, stats.categoryCount(LiftBackCategory.UNMAPPED));
+    }
+
+    @Test
+    public void testCompositionDerivation()
+    {
+        assertEquals(LiftBackResult.Composition.NONE,
+                LiftBackResult.Composition.fromAlignments(List.of()));
+
+        assertEquals(LiftBackResult.Composition.REF_ONLY,
+                LiftBackResult.Composition.fromAlignments(List.of(refAlignment())));
+
+        assertEquals(LiftBackResult.Composition.TX_ONLY,
+                LiftBackResult.Composition.fromAlignments(List.of(txAlignment())));
+
+        assertEquals(LiftBackResult.Composition.REF_AND_TX,
+                LiftBackResult.Composition.fromAlignments(List.of(refAlignment(), txAlignment())));
+    }
+
+    @Test
+    public void testMapqTierDerivation()
+    {
+        LiftBackResult result = resultWith(LiftBackCategory.REF_SINGLE, 0, List.of(refAlignment()));
+
+        assertEquals(LiftBackStats.MapqTier.MAPQ_ZERO,
+                LiftBackStats.deriveMapqTier(newRecord(0), result));
+        assertEquals(LiftBackStats.MapqTier.MAPQ_POS_UNIQUE,
+                LiftBackStats.deriveMapqTier(newRecord(60), result));
+
+        LiftBackResult withAlts = resultWith(LiftBackCategory.REF_SINGLE, 1, List.of(refAlignment()));
+        assertEquals(LiftBackStats.MapqTier.MAPQ_POS_MULTI,
+                LiftBackStats.deriveMapqTier(newRecord(60), withAlts));
+    }
+
+    @Test
+    public void testWriteSummaryEmitsExpectedTsvLayout() throws IOException
+    {
+        LiftBackStats stats = new LiftBackStats();
+        stats.record(newRecord(60), resultWith(LiftBackCategory.REF_SINGLE, 0, List.of(refAlignment())));
+        stats.record(newRecord(0), resultWith(LiftBackCategory.UNMAPPED, 0, List.of()));
+
+        stats.writeSummary(mSummary.toString());
+
+        List<String> lines = Files.readAllLines(mSummary);
+        // header + at least one composition row + one category row
+        assertTrue(lines.size() >= 3);
+        assertEquals("Section\tRowKey\tColumnKey\tCount", lines.get(0));
+
+        boolean hasRefOnlyMapqUnique = false;
+        boolean hasARefGenome = false;
+        for(String line : lines)
+        {
+            if(line.equals("composition_x_mapq\tREF_ONLY\tMAPQ_POS_UNIQUE\t1"))
+                hasRefOnlyMapqUnique = true;
+            if(line.equals("category_x_mapq\tREF_SINGLE\tMAPQ_POS_UNIQUE\t1"))
+                hasARefGenome = true;
+        }
+        assertTrue(hasRefOnlyMapqUnique);
+        assertTrue(hasARefGenome);
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackWriterTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftBackWriterTest.java
@@ -1,0 +1,172 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+// verifies LiftBackWriter produces the exact TSV layout consumers expect: stable header columns
+// and one row per record (TSV-A) / one row per lifted alignment (TSV-B), with MateNum derived from
+// the record's first-of-pair flag.
+public class LiftBackWriterTest
+{
+    private static SAMRecord pairedRecord(final String readName, final boolean firstOfPair)
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName(readName);
+        record.setReadPairedFlag(true);
+        record.setFirstOfPairFlag(firstOfPair);
+        record.setSecondOfPairFlag(!firstOfPair);
+        return record;
+    }
+
+    private static SAMRecord unpairedRecord(final String readName)
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName(readName);
+        record.setReadPairedFlag(false);
+        return record;
+    }
+
+    private Path mTsvA;
+    private Path mTsvB;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        mTsvA = Files.createTempFile("liftback_a_", ".tsv");
+        mTsvB = Files.createTempFile("liftback_b_", ".tsv");
+    }
+
+    @After
+    public void tearDown() throws IOException
+    {
+        Files.deleteIfExists(mTsvA);
+        Files.deleteIfExists(mTsvB);
+    }
+
+    @Test
+    public void testHeadersAndRowsForRefOnlyResult() throws IOException
+    {
+        LiftedAlignment selfAlignment = new LiftedAlignment(
+                LiftedAlignment.AlignmentSource.SELF, "1", 1000, "50M",
+                "1", 1000, "50M",
+                100, 0,
+                null, null, null,
+                false, true);
+
+        LiftBackResult result = new LiftBackResult(
+                LiftBackCategory.REF_SINGLE, LiftBackResult.Composition.REF_ONLY,
+                LiftBackResult.RecordRole.PRIMARY,
+                "1", 1000, "50M",
+                false,
+                false, 60, 60,
+                0, 1, 0,
+                1, 1,
+                false, false, false, true,
+                "", "",
+                List.of(selfAlignment));
+
+        try(LiftBackWriter writer = new LiftBackWriter(mTsvA.toString(), mTsvB.toString()))
+        {
+            writer.write(pairedRecord("read1", true), result, false);
+        }
+
+        List<String> aLines = Files.readAllLines(mTsvA);
+        List<String> bLines = Files.readAllLines(mTsvB);
+
+        assertEquals(2, aLines.size());
+        assertEquals("ReadName\tMateNum\tRecordRole\tPrimaryBucket\tComposition\tDecisionCategory"
+                + "\tBwaMapq\tUpdatedMapq\tNumXaAlts\tNumRefAlts\tNumTxAlts\tNumLoci"
+                + "\tNumDistinctCigarsAtPrimaryLocus\tTxHasNCigar\tTxSoftClipAtBoundary"
+                + "\tRefSoftClipped\tRefFullMatch\tFinalChrom\tFinalPos\tFinalCigar\tHasNCigar"
+                + "\tGeneIds\tNotes\tFiltered", aLines.get(0));
+        assertEquals("read1\t1\tPRIMARY\tRESOLVED\tREF_ONLY\tREF_SINGLE\t60\t60\t0\t1\t0\t1\t1\tfalse\tfalse\tfalse\ttrue\t1\t1000\t50M\tfalse\t\t\tfalse", aLines.get(1));
+
+        assertEquals(2, bLines.size());
+        assertEquals("ReadName\tMateNum\tRecordRole\tSource\tOrigContig\tOrigPos\tOrigCigar"
+                + "\tLiftedChrom\tLiftedPos\tLiftedCigar\tAlignmentScore\tNumMismatches"
+                + "\tTransName\tGeneId\tGeneName", bLines.get(0));
+        assertEquals("read1\t1\tPRIMARY\tSELF\t1\t1000\t50M\t1\t1000\t50M\t100\t0\t\t\t", bLines.get(1));
+    }
+
+    @Test
+    public void testTsvBHasOneRowPerLiftedAlignment() throws IOException
+    {
+        LiftedAlignment self = new LiftedAlignment(
+                LiftedAlignment.AlignmentSource.SELF, "txContig", 1, "50M",
+                "1", 100, "50M",
+                100, 0,
+                "ENST_X", "ENSG_X", "GENEX",
+                false, true);
+
+        LiftedAlignment xa = new LiftedAlignment(
+                LiftedAlignment.AlignmentSource.XA_INPUT, "1", 5000, "50M",
+                "1", 5000, "50M",
+                0, 1,
+                null, null, null,
+                false, true);
+
+        LiftBackResult result = new LiftBackResult(
+                LiftBackCategory.BOTH_MULTI, LiftBackResult.Composition.REF_AND_TX,
+                LiftBackResult.RecordRole.PRIMARY,
+                "1", 100, "50M",
+                false,
+                false, 0, 0,
+                1, 1, 1,
+                2, 1,
+                false, false, false, true,
+                "ENSG_X", "",
+                List.of(self, xa));
+
+        try(LiftBackWriter writer = new LiftBackWriter(mTsvA.toString(), mTsvB.toString()))
+        {
+            writer.write(pairedRecord("read2", false), result, false);
+        }
+
+        List<String> bLines = Files.readAllLines(mTsvB);
+        // header + 2 alignment rows
+        assertEquals(3, bLines.size());
+        assertTrue(bLines.get(1).startsWith("read2\t2\tPRIMARY\tSELF\t"));
+        assertTrue(bLines.get(2).startsWith("read2\t2\tPRIMARY\tXA_INPUT\t"));
+    }
+
+    @Test
+    public void testEmptyAlignmentSetStillEmitsTsvARow() throws IOException
+    {
+        // UNMAPPED / LIFT_FAILED -> TSV-A still gets a row, TSV-B gets nothing
+        LiftBackResult result = new LiftBackResult(
+                LiftBackCategory.UNMAPPED, LiftBackResult.Composition.NONE,
+                LiftBackResult.RecordRole.PRIMARY,
+                "*", 0, "*",
+                false,
+                false, 0, 0,
+                0, 0, 0,
+                0, 0,
+                false, false, false, false,
+                "", "",
+                List.<LiftedAlignment>of());
+
+        try(LiftBackWriter writer = new LiftBackWriter(mTsvA.toString(), mTsvB.toString()))
+        {
+            writer.write(unpairedRecord("read3"), result, false);
+        }
+
+        List<String> aLines = Files.readAllLines(mTsvA);
+        List<String> bLines = Files.readAllLines(mTsvB);
+
+        assertEquals(2, aLines.size());
+        assertTrue(aLines.get(1).startsWith("read3\t0\tPRIMARY\tNON_PRIMARY\tNONE\tUNMAPPED\t"));
+        assertEquals(1, bLines.size()); // header only
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftedAlignmentTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftedAlignmentTest.java
@@ -1,0 +1,87 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+// covers LiftedAlignment.cigarHasRealNJunction — the anchor-aware N detector used by the
+// discriminator. A 1-3 bp M anchor on either side of an N is the failure mode that previously
+// caused BOTH_TX_JUNCTION_REF_MATCH to swap off a clean ref full-match.
+public class LiftedAlignmentTest
+{
+    private static final int MIN_ANCHOR = 8;
+
+    private static LiftedAlignment alignmentWithCigar(final String cigar)
+    {
+        return new LiftedAlignment(
+                LiftedAlignment.AlignmentSource.SELF, "ctg", 1, cigar,
+                "chr1", 100, cigar,
+                0, 0,
+                null, null, null,
+                false, true);
+    }
+
+    @Test
+    public void testNoNReturnsFalse()
+    {
+        assertFalse(alignmentWithCigar("151M").cigarHasRealNJunction(MIN_ANCHOR));
+        assertFalse(alignmentWithCigar("100M51S").cigarHasRealNJunction(MIN_ANCHOR));
+    }
+
+    @Test
+    public void testTinyTrailingAnchorRejected()
+    {
+        // the chr9 KLF4 case: 128M before N is fine, but 2M after N is not a real junction
+        assertFalse(alignmentWithCigar("128M102N2M21S").cigarHasRealNJunction(MIN_ANCHOR));
+        assertFalse(alignmentWithCigar("147M3309N1M3S").cigarHasRealNJunction(MIN_ANCHOR));
+        assertFalse(alignmentWithCigar("130M172N3M18S").cigarHasRealNJunction(MIN_ANCHOR));
+    }
+
+    @Test
+    public void testTinyLeadingAnchorRejected()
+    {
+        assertFalse(alignmentWithCigar("2M102N128M21S").cigarHasRealNJunction(MIN_ANCHOR));
+        // soft-clip in front of the leading M doesn't rescue a too-short M anchor
+        assertFalse(alignmentWithCigar("20S5M102N128M").cigarHasRealNJunction(MIN_ANCHOR));
+    }
+
+    @Test
+    public void testThresholdBoundary()
+    {
+        // exactly 8M on both sides — accepted
+        assertTrue(alignmentWithCigar("8M100N8M").cigarHasRealNJunction(MIN_ANCHOR));
+        // 7M on one side — rejected
+        assertFalse(alignmentWithCigar("8M100N7M").cigarHasRealNJunction(MIN_ANCHOR));
+        assertFalse(alignmentWithCigar("7M100N8M").cigarHasRealNJunction(MIN_ANCHOR));
+    }
+
+    @Test
+    public void testMultipleNJunctionsAllMustPass()
+    {
+        // every N must have valid anchors on both sides
+        assertTrue(alignmentWithCigar("20M100N20M100N50M").cigarHasRealNJunction(MIN_ANCHOR));
+        // second junction has 5M middle anchor — rejected
+        assertFalse(alignmentWithCigar("20M100N5M100N50M").cigarHasRealNJunction(MIN_ANCHOR));
+        // first junction has 5M middle anchor — rejected
+        assertFalse(alignmentWithCigar("5M100N5M100N50M").cigarHasRealNJunction(MIN_ANCHOR));
+    }
+
+    @Test
+    public void testNonAdjacentMNotAnchor()
+    {
+        // 10M then 5I then N — the I breaks adjacency, so the N's leading anchor is 0
+        assertFalse(alignmentWithCigar("10M5I100N20M").cigarHasRealNJunction(MIN_ANCHOR));
+        // D after N before the M — trailing anchor is 0
+        assertFalse(alignmentWithCigar("20M100N5D20M").cigarHasRealNJunction(MIN_ANCHOR));
+    }
+
+    @Test
+    public void testRealJunctionAccepted()
+    {
+        // clean 50M + intron + 50M
+        assertTrue(alignmentWithCigar("50M1000N50M").cigarHasRealNJunction(MIN_ANCHOR));
+        // realistic 75bp+30bp split read
+        assertTrue(alignmentWithCigar("75M5000N76M").cigarHasRealNJunction(MIN_ANCHOR));
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftedMateInfoCacheTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftedMateInfoCacheTest.java
@@ -1,0 +1,54 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class LiftedMateInfoCacheTest
+{
+    @Test
+    public void testGetPartnerReturnsOpposite()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+
+        LiftedMateInfo r1 = LiftedMateInfo.mapped("1", 100, 199, "50M", false);
+        LiftedMateInfo r2 = LiftedMateInfo.mapped("1", 400, 499, "50M", true);
+
+        cache.recordPrimaryAlignment("read1", true, r1);
+        cache.recordPrimaryAlignment("read1", false, r2);
+
+        // looking up partner of R1 returns R2
+        assertEquals(r2, cache.getPartnerMateInfo("read1", true));
+        // looking up partner of R2 returns R1
+        assertEquals(r1, cache.getPartnerMateInfo("read1", false));
+    }
+
+    @Test
+    public void testGetPartnerReturnsNullWhenPartnerMissing()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        cache.recordPrimaryAlignment("read1", true, LiftedMateInfo.mapped("1", 100, 199, "50M", false));
+
+        // R2 never recorded → partner-of-R1 is null
+        assertNull(cache.getPartnerMateInfo("read1", true));
+    }
+
+    @Test
+    public void testGetPartnerForUnknownReadIsNull()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        assertNull(cache.getPartnerMateInfo("missing", true));
+    }
+
+    @Test
+    public void testUnmappedFactory()
+    {
+        LiftedMateInfo unmapped = LiftedMateInfo.unmapped();
+        assertTrue(unmapped.Unmapped);
+        assertNull(unmapped.Chromosome);
+        assertEquals(0, unmapped.AlignmentStart);
+        assertEquals(0, unmapped.AlignmentEnd);
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftedMateInfoCacheTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/LiftedMateInfoCacheTest.java
@@ -43,12 +43,12 @@ public class LiftedMateInfoCacheTest
     }
 
     @Test
-    public void testUnmappedFactory()
+    public void testUnmappedConstant()
     {
-        LiftedMateInfo unmapped = LiftedMateInfo.unmapped();
-        assertTrue(unmapped.Unmapped);
-        assertNull(unmapped.Chromosome);
-        assertEquals(0, unmapped.AlignmentStart);
-        assertEquals(0, unmapped.AlignmentEnd);
+        LiftedMateInfo unmapped = LiftedMateInfo.UNMAPPED;
+        assertTrue(unmapped.unmapped());
+        assertNull(unmapped.chromosome());
+        assertEquals(0, unmapped.alignmentStart());
+        assertEquals(0, unmapped.alignmentEnd());
     }
 }

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/MateFieldPatcherTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/MateFieldPatcherTest.java
@@ -71,7 +71,7 @@ public class MateFieldPatcherTest
     public void testMateCigarClearedWhenPartnerUnmapped()
     {
         LiftedMateInfoCache cache = new LiftedMateInfoCache();
-        cache.recordPrimaryAlignment("read1", false, LiftedMateInfo.unmapped());
+        cache.recordPrimaryAlignment("read1", false, LiftedMateInfo.UNMAPPED);
 
         SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
         r1.setAttribute(MATE_CIGAR_ATTRIBUTE, "50M");
@@ -115,7 +115,7 @@ public class MateFieldPatcherTest
     public void testPatchWithUnmappedPartner()
     {
         LiftedMateInfoCache cache = new LiftedMateInfoCache();
-        cache.recordPrimaryAlignment("read1", false, LiftedMateInfo.unmapped());
+        cache.recordPrimaryAlignment("read1", false, LiftedMateInfo.UNMAPPED);
 
         SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
         r1.setProperPairFlag(true);

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/MateFieldPatcherTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/MateFieldPatcherTest.java
@@ -1,0 +1,188 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.bam.SamRecordUtils.MATE_CIGAR_ATTRIBUTE;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+import org.junit.Test;
+
+public class MateFieldPatcherTest
+{
+    private static SAMRecord pairedMappedRecord(
+            final String readName, final boolean firstOfPair,
+            final String chromosome, final int alignmentStart, final String cigar, final boolean negStrand)
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName(readName);
+        record.setReadPairedFlag(true);
+        record.setFirstOfPairFlag(firstOfPair);
+        record.setSecondOfPairFlag(!firstOfPair);
+        record.setReadUnmappedFlag(false);
+        record.setReferenceName(chromosome);
+        record.setAlignmentStart(alignmentStart);
+        record.setCigarString(cigar);
+        record.setReadNegativeStrandFlag(negStrand);
+        record.setMappingQuality(60);
+        return record;
+    }
+
+    @Test
+    public void testPatchSamePairSameChromSetsTlenAndMateFields()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        LiftedMateInfo r2Info = LiftedMateInfo.mapped("1", 400, 499, "50M", true);
+        cache.recordPrimaryAlignment("read1", false, r2Info);
+
+        SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
+        MateFieldPatcher.patchMateFields(r1, cache);
+
+        assertEquals("1", r1.getMateReferenceName());
+        assertEquals(400, r1.getMateAlignmentStart());
+        assertTrue(r1.getMateNegativeStrandFlag());
+        assertFalse(r1.getMateUnmappedFlag());
+        // leftmost is R1 at 100, rightmost end is R2 at 499 → span = 400, positive on R1
+        assertEquals(400, r1.getInferredInsertSize());
+        // MC must reflect the partner's lifted CIGAR for redux mate-CIGAR consumers
+        assertEquals("50M", r1.getStringAttribute(MATE_CIGAR_ATTRIBUTE));
+    }
+
+    @Test
+    public void testMateCigarWrittenAsLiftedNCigar()
+    {
+        // simulate a junction-spanning partner whose lifted CIGAR contains an N operator
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        LiftedMateInfo r2Info = LiftedMateInfo.mapped("1", 400, 999, "20M500N30M", true);
+        cache.recordPrimaryAlignment("read1", false, r2Info);
+
+        SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
+        r1.setAttribute(MATE_CIGAR_ATTRIBUTE, "50M"); // stale pre-lift MC bwa/fixmate may have set
+        MateFieldPatcher.patchMateFields(r1, cache);
+
+        assertEquals("20M500N30M", r1.getStringAttribute(MATE_CIGAR_ATTRIBUTE));
+    }
+
+    @Test
+    public void testMateCigarClearedWhenPartnerUnmapped()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        cache.recordPrimaryAlignment("read1", false, LiftedMateInfo.unmapped());
+
+        SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
+        r1.setAttribute(MATE_CIGAR_ATTRIBUTE, "50M");
+        MateFieldPatcher.patchMateFields(r1, cache);
+
+        assertNull(r1.getStringAttribute(MATE_CIGAR_ATTRIBUTE));
+    }
+
+    @Test
+    public void testPatchRightmostReadGetsNegativeTlen()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        LiftedMateInfo r1Info = LiftedMateInfo.mapped("1", 100, 149, "50M", false);
+        cache.recordPrimaryAlignment("read1", true, r1Info);
+
+        SAMRecord r2 = pairedMappedRecord("read1", false, "1", 400, "50M", true);
+        MateFieldPatcher.patchMateFields(r2, cache);
+
+        // span = 449 - 100 + 1 = 350; R2 is to the right so negative
+        assertEquals(-350, r2.getInferredInsertSize());
+    }
+
+    @Test
+    public void testPatchDifferentChromsZeroesTlenAndClearsProperPair()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        LiftedMateInfo r2Info = LiftedMateInfo.mapped("2", 400, 499, "50M", true);
+        cache.recordPrimaryAlignment("read1", false, r2Info);
+
+        SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
+        r1.setProperPairFlag(true);
+        MateFieldPatcher.patchMateFields(r1, cache);
+
+        assertEquals("2", r1.getMateReferenceName());
+        assertEquals(400, r1.getMateAlignmentStart());
+        assertEquals(0, r1.getInferredInsertSize());
+        assertFalse(r1.getProperPairFlag());
+    }
+
+    @Test
+    public void testPatchWithUnmappedPartner()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        cache.recordPrimaryAlignment("read1", false, LiftedMateInfo.unmapped());
+
+        SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
+        r1.setProperPairFlag(true);
+        MateFieldPatcher.patchMateFields(r1, cache);
+
+        assertTrue(r1.getMateUnmappedFlag());
+        // SAM convention: place unmapped mate at the read's own position
+        assertEquals("1", r1.getMateReferenceName());
+        assertEquals(100, r1.getMateAlignmentStart());
+        assertEquals(0, r1.getInferredInsertSize());
+        assertFalse(r1.getProperPairFlag());
+    }
+
+    @Test
+    public void testPatchMissingPartnerClearsProperPair()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        // partner never recorded
+
+        SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
+        r1.setProperPairFlag(true);
+        MateFieldPatcher.patchMateFields(r1, cache);
+
+        assertFalse(r1.getProperPairFlag());
+    }
+
+    @Test
+    public void testPatchUnpairedRecordIsNoOp()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName("read1");
+        record.setReadPairedFlag(false);
+        record.setReferenceName("1");
+        record.setAlignmentStart(100);
+
+        // should not throw or attempt to read first-of-pair flag
+        MateFieldPatcher.patchMateFields(record, cache);
+    }
+
+    @Test
+    public void testPatchSuppRecordPatchedFromPartnerPrimary()
+    {
+        // supplementary alignment for R1 — patcher must still pick up R2's primary info
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        LiftedMateInfo r2Info = LiftedMateInfo.mapped("1", 400, 499, "50M", true);
+        cache.recordPrimaryAlignment("read1", false, r2Info);
+
+        SAMRecord r1Supp = pairedMappedRecord("read1", true, "1", 200, "30M20S", false);
+        r1Supp.setSupplementaryAlignmentFlag(true);
+        MateFieldPatcher.patchMateFields(r1Supp, cache);
+
+        assertEquals("1", r1Supp.getMateReferenceName());
+        assertEquals(400, r1Supp.getMateAlignmentStart());
+        assertTrue(r1Supp.getMateNegativeStrandFlag());
+    }
+
+    @Test
+    public void testPatchTiedStartFirstOfPairIsPositive()
+    {
+        LiftedMateInfoCache cache = new LiftedMateInfoCache();
+        cache.recordPrimaryAlignment("read1", false, LiftedMateInfo.mapped("1", 100, 199, "50M", true));
+
+        SAMRecord r1 = pairedMappedRecord("read1", true, "1", 100, "50M", false);
+        MateFieldPatcher.patchMateFields(r1, cache);
+
+        // span = 199 - 100 + 1 = 100; tie on start so first-of-pair is positive
+        assertEquals(100, r1.getInferredInsertSize());
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/RrnaRegionIndexTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/RrnaRegionIndexTest.java
@@ -1,0 +1,181 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.hartwig.hmftools.common.ensemblcache.EnsemblDataCache;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
+
+import org.junit.Test;
+
+// covers RrnaRegionIndex build (biotype filter, merge of overlapping gene ranges) and overlaps lookup boundaries.
+public class RrnaRegionIndexTest
+{
+    private static final byte POS_STRAND = 1;
+
+    @Test
+    public void testBuildPicksUpRrnaAndMtRrnaBiotypes()
+    {
+        final EnsemblDataCache cache = new EnsemblDataCache("", RefGenomeVersion.V38);
+
+        addGene(cache, "ENSG_RRNA", "RRNA_GENE", "1", 100, 200);
+        addTranscript(cache, "ENSG_RRNA", "ENST_RRNA", "rRNA");
+
+        addGene(cache, "ENSG_MT", "MT_RRNA_GENE", "MT", 1000, 1500);
+        addTranscript(cache, "ENSG_MT", "ENST_MT", "Mt_rRNA");
+
+        addGene(cache, "ENSG_CODING", "CODING_GENE", "1", 300, 400);
+        addTranscript(cache, "ENSG_CODING", "ENST_CODING", "protein_coding");
+
+        addGene(cache, "ENSG_PSEUDO", "RRNA_PSEUDO", "1", 500, 600);
+        addTranscript(cache, "ENSG_PSEUDO", "ENST_PSEUDO", "rRNA_pseudogene");
+
+        final RrnaRegionIndex index = RrnaRegionIndex.build(cache, RefGenomeVersion.V37);
+
+        assertEquals(2, index.geneCount());
+        assertTrue(index.overlaps("1", 100, 100));
+        assertTrue(index.overlaps("1", 200, 200));
+        assertTrue(index.overlaps("1", 50, 150));
+        assertTrue(index.overlaps("1", 150, 250));
+        assertTrue(index.overlaps("MT", 1200, 1300));
+
+        // pseudogene biotype must not match — common confusion point
+        assertFalse(index.overlaps("1", 500, 600));
+        // coding gene unaffected
+        assertFalse(index.overlaps("1", 350, 360));
+        // outside any rRNA region
+        assertFalse(index.overlaps("1", 201, 299));
+        assertFalse(index.overlaps("1", 50, 99));
+        // unknown chromosome
+        assertFalse(index.overlaps("99", 100, 200));
+    }
+
+    @Test
+    public void testBuildMergesOverlappingAdjacentRrnaGenes()
+    {
+        final EnsemblDataCache cache = new EnsemblDataCache("", RefGenomeVersion.V38);
+
+        addGene(cache, "ENSG_A", "A", "5", 100, 200);
+        addTranscript(cache, "ENSG_A", "ENST_A", "rRNA");
+
+        // overlap with A
+        addGene(cache, "ENSG_B", "B", "5", 150, 250);
+        addTranscript(cache, "ENSG_B", "ENST_B", "rRNA");
+
+        // adjacent to merged [100..250] — touch should also merge
+        addGene(cache, "ENSG_C", "C", "5", 251, 300);
+        addTranscript(cache, "ENSG_C", "ENST_C", "rRNA");
+
+        // disjoint
+        addGene(cache, "ENSG_D", "D", "5", 1000, 1100);
+        addTranscript(cache, "ENSG_D", "ENST_D", "rRNA");
+
+        final RrnaRegionIndex index = RrnaRegionIndex.build(cache, RefGenomeVersion.V37);
+
+        assertEquals(4, index.geneCount());
+        // any point inside the merged 100..300 range hits
+        assertTrue(index.overlaps("5", 200, 200));
+        assertTrue(index.overlaps("5", 250, 251));
+        assertTrue(index.overlaps("5", 300, 300));
+        // gap between merged region and D
+        assertFalse(index.overlaps("5", 301, 999));
+        // D
+        assertTrue(index.overlaps("5", 1050, 1050));
+    }
+
+    @Test
+    public void testV38AddsAcrocentricPArms()
+    {
+        final EnsemblDataCache cache = new EnsemblDataCache("", RefGenomeVersion.V38);
+        final RrnaRegionIndex index = RrnaRegionIndex.build(cache, RefGenomeVersion.V38);
+
+        // empty cache + V38 -> biotype geneCount is 0 but acrocentric ranges are present
+        assertEquals(0, index.geneCount());
+        assertTrue(index.overlaps("chr13", 1, 1));
+        assertTrue(index.overlaps("chr13", 15_999_999, 16_000_000));
+        assertFalse(index.overlaps("chr13", 16_000_001, 16_000_001));
+        assertTrue(index.overlaps("chr14", 5_000_000, 5_000_000));
+        assertTrue(index.overlaps("chr15", 17_000_000, 17_000_000));
+        assertTrue(index.overlaps("chr21", 11_999_999, 12_000_001));
+        assertTrue(index.overlaps("chr22", 13_500_000, 13_500_000));
+        // q-arms unaffected
+        assertFalse(index.overlaps("chr13", 50_000_000, 50_000_001));
+        // non-acrocentric chromosomes unaffected
+        assertFalse(index.overlaps("chr1", 1_000_000, 1_000_000));
+    }
+
+    @Test
+    public void testV38ExcludesChr22AndChrUnContigsByPrefix()
+    {
+        final EnsemblDataCache cache = new EnsemblDataCache("", RefGenomeVersion.V38);
+        final RrnaRegionIndex index = RrnaRegionIndex.build(cache, RefGenomeVersion.V38);
+
+        // wholesale exclusion regardless of position
+        assertTrue(index.overlaps("chr22_KI270733v1_random", 1, 1));
+        assertTrue(index.overlaps("chr22_KI270733v1_random", 100_000, 200_000));
+        assertTrue(index.overlaps("chrUn_GL000220v1", 1, 1));
+        assertTrue(index.overlaps("chrUn_GL000219v1", 5_000, 6_000));
+
+        // main chr22 still falls under the acrocentric range, not the prefix rule
+        assertTrue(index.overlaps("chr22", 1, 1));
+        // chr22 q-arm not excluded
+        assertFalse(index.overlaps("chr22", 30_000_000, 30_000_001));
+
+        // chr13_/chr14_/chr15_/chr21_ random contigs are NOT excluded by prefix (only chr22_ / chrUn_)
+        assertFalse(index.overlaps("chr21_KI270873v1_alt", 5_000, 6_000));
+    }
+
+    @Test
+    public void testV37FallsBackToBiotypeOnly()
+    {
+        final EnsemblDataCache cache = new EnsemblDataCache("", RefGenomeVersion.V37);
+        final RrnaRegionIndex index = RrnaRegionIndex.build(cache, RefGenomeVersion.V37);
+
+        // V37 does NOT get acrocentric or prefix exclusions
+        assertFalse(index.overlaps("chr13", 5_000_000, 5_000_000));
+        assertFalse(index.overlaps("13", 5_000_000, 5_000_000));
+        assertFalse(index.overlaps("chr22_KI270733v1_random", 1, 1));
+        assertFalse(index.overlaps("chrUn_GL000220v1", 1, 1));
+    }
+
+    @Test
+    public void testBuildSkipsGenesWithNoRrnaTranscript()
+    {
+        final EnsemblDataCache cache = new EnsemblDataCache("", RefGenomeVersion.V38);
+
+        addGene(cache, "ENSG_MIXED", "MIXED", "1", 100, 200);
+        // a gene with only non-rRNA transcripts is not added
+        addTranscript(cache, "ENSG_MIXED", "ENST_A", "protein_coding");
+        addTranscript(cache, "ENSG_MIXED", "ENST_B", "lncRNA");
+
+        final RrnaRegionIndex index = RrnaRegionIndex.build(cache, RefGenomeVersion.V37);
+
+        assertEquals(0, index.geneCount());
+        assertFalse(index.overlaps("1", 150, 150));
+    }
+
+    private static void addGene(
+            final EnsemblDataCache cache, final String geneId, final String geneName,
+            final String chromosome, final int start, final int end)
+    {
+        final GeneData gene = new GeneData(geneId, geneName, chromosome, POS_STRAND, start, end, "");
+        cache.getChrGeneDataMap().computeIfAbsent(chromosome, k -> new ArrayList<>()).add(gene);
+    }
+
+    private static void addTranscript(
+            final EnsemblDataCache cache, final String geneId, final String transName, final String biotype)
+    {
+        final List<TranscriptData> transcripts = cache.getTranscriptDataMap()
+                .computeIfAbsent(geneId, k -> new ArrayList<>());
+        final TranscriptData transcript = new TranscriptData(
+                transcripts.size() + 1, transName, geneId, false, POS_STRAND,
+                0, 0, null, null, biotype, null);
+        transcripts.add(transcript);
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/SaTagRewriterTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/SaTagRewriterTest.java
@@ -1,0 +1,88 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import org.junit.Test;
+
+// covers SaTagRewriter: ref pass-through, Tx-contig lift, malformed entry skip,
+// dedup of post-lift duplicates, null/empty input, and the all-fail -> null contract.
+public class SaTagRewriterTest
+{
+    private static final String GENE_ID = "ENSG_TEST";
+    private static final String GENE_NAME = "TESTG";
+    private static final String TRANS_NAME = "ENST_TEST";
+    private static final String TX_CONTIG = "ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME;
+
+    // same three-exon contig as LiftBackResolverTest: exons chr1:100-199, 300-399, 500-549; contig length 250.
+    private static LiftBackResolver newResolver()
+    {
+        ContigEntry entry = new ContigEntry(
+                TX_CONTIG, 1, 250, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
+                List.of(new BaseRegion(100, 199), new BaseRegion(300, 399), new BaseRegion(500, 549)));
+        return new LiftBackResolver(List.of(entry));
+    }
+
+    @Test
+    public void testNullOrEmptyInputReturnsNull()
+    {
+        LiftBackResolver resolver = newResolver();
+        assertNull(SaTagRewriter.rewriteSaTag(null, resolver));
+        assertNull(SaTagRewriter.rewriteSaTag("", resolver));
+    }
+
+    @Test
+    public void testRefContigPassesThrough()
+    {
+        LiftBackResolver resolver = newResolver();
+        String sa = CHR_1 + ",1000,+,50M,60,2;";
+        String rewritten = SaTagRewriter.rewriteSaTag(sa, resolver);
+        assertEquals(sa, rewritten);
+    }
+
+    @Test
+    public void testTxContigLifted()
+    {
+        LiftBackResolver resolver = newResolver();
+        // alt-contig pos 1 corresponds to exon 1 start (chr1:100). 50M stays 50M (no junction crossed).
+        String sa = TX_CONTIG + ",1,+,50M,60,2;";
+        String rewritten = SaTagRewriter.rewriteSaTag(sa, resolver);
+        assertEquals(CHR_1 + ",100,+,50M,60,2;", rewritten);
+    }
+
+    @Test
+    public void testMalformedEntriesSkipped()
+    {
+        LiftBackResolver resolver = newResolver();
+        // too few fields, non-numeric position, then a valid ref entry
+        String sa = "junk;"
+                + CHR_1 + ",notanumber,+,50M,60,0;"
+                + CHR_1 + ",1000,+,50M,60,2;";
+        String rewritten = SaTagRewriter.rewriteSaTag(sa, resolver);
+        assertEquals(CHR_1 + ",1000,+,50M,60,2;", rewritten);
+    }
+
+    @Test
+    public void testDuplicateLiftedEntriesDeduped()
+    {
+        LiftBackResolver resolver = newResolver();
+        String entry = CHR_1 + ",1000,+,50M,60,2;";
+        String rewritten = SaTagRewriter.rewriteSaTag(entry + entry, resolver);
+        assertEquals(entry, rewritten);
+    }
+
+    @Test
+    public void testAllEntriesFailReturnsNull()
+    {
+        LiftBackResolver resolver = newResolver();
+        // position past exon 3 end on the tx contig -> outside any transcript span -> findSegment returns null
+        String sa = TX_CONTIG + ",10000,+,50M,60,0;malformed;";
+        assertNull(SaTagRewriter.rewriteSaTag(sa, resolver));
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackApplyTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackApplyTest.java
@@ -1,0 +1,105 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+import org.junit.Test;
+
+// covers SpliceLiftBack.applyResultToRecord — the SAMRecord-level mutation step. Verifies that
+// chrom/pos/CIGAR are rewritten correctly, that LIFT_FAILED marks the record unmapped without
+// dropping it, and that XA is replaced with lifted, deduped genomic alts (Stage 4).
+public class SpliceLiftBackApplyTest
+{
+    private static final String GENE_ID = "ENSG_TEST";
+    private static final String GENE_NAME = "TESTG";
+    private static final String TRANS_NAME = "ENST_TEST";
+    private static final String TX_CONTIG = "ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME;
+    private static final String XA_TAG = "XA";
+
+    private static ContigEntry threeExonContig()
+    {
+        return new ContigEntry(
+                TX_CONTIG, 1, 250, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
+                List.of(new BaseRegion(100, 199), new BaseRegion(300, 399), new BaseRegion(500, 549)));
+    }
+
+    private static SAMRecord newRecord(final String contig, final int pos, final String cigar)
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName("read");
+        record.setReferenceName(contig);
+        record.setAlignmentStart(pos);
+        record.setCigarString(cigar);
+        record.setMappingQuality(60);
+        return record;
+    }
+
+    @Test
+    public void testTxPrimaryRewrittenToGenomicCoords()
+    {
+        SAMRecord record = newRecord(TX_CONTIG, 51, "100M");
+        LiftBackResolver resolver = new LiftBackResolver(List.of(threeExonContig()));
+
+        SpliceLiftBack.applyResultToRecord(record, resolver.resolve(record), new LiftedMateInfoCache());
+
+        assertEquals(CHR_1, record.getReferenceName());
+        assertEquals(150, record.getAlignmentStart());
+        assertEquals("50M100N50M", record.getCigarString());
+        assertNull(record.getStringAttribute(XA_TAG));
+    }
+
+    @Test
+    public void testUnliftableRecordMarkedUnmappedAndStripped()
+    {
+        // pos 251 is entirely past altEnd (250) — no overhang clamp can save it -> translate fails
+        SAMRecord record = newRecord(TX_CONTIG, 251, "10M");
+        LiftBackResolver resolver = new LiftBackResolver(List.of(threeExonContig()));
+
+        SpliceLiftBack.applyResultToRecord(record, resolver.resolve(record), new LiftedMateInfoCache());
+
+        assertTrue(record.getReadUnmappedFlag());
+        assertEquals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME, record.getReferenceName());
+        assertEquals(SAMRecord.NO_ALIGNMENT_START, record.getAlignmentStart());
+        assertEquals(SAMRecord.NO_ALIGNMENT_CIGAR, record.getCigarString());
+        assertEquals(0, record.getMappingQuality());
+        assertNull(record.getStringAttribute(XA_TAG));
+    }
+
+    @Test
+    public void testXaTagRewrittenWithLiftedCoords()
+    {
+        SAMRecord record = newRecord(CHR_1, 1000, "50M");
+        record.setAttribute(XA_TAG, TX_CONTIG + ",+1,50M,0;");
+        LiftBackResolver resolver = new LiftBackResolver(List.of(threeExonContig()));
+
+        SpliceLiftBack.applyResultToRecord(record, resolver.resolve(record), new LiftedMateInfoCache());
+
+        // ref primary unchanged; Tx XA alt rewritten to genomic chr1:100/50M
+        assertEquals(CHR_1, record.getReferenceName());
+        assertEquals(1000, record.getAlignmentStart());
+        assertEquals(CHR_1 + ",+100,50M,0;", record.getStringAttribute(XA_TAG));
+    }
+
+    @Test
+    public void testUnmappedRecordLeftUntouched()
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName("read");
+        record.setReadUnmappedFlag(true);
+        LiftBackResolver resolver = new LiftBackResolver(List.of(threeExonContig()));
+
+        SpliceLiftBack.applyResultToRecord(record, resolver.resolve(record), new LiftedMateInfoCache());
+
+        assertTrue(record.getReadUnmappedFlag());
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackEndToEndTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/SpliceLiftBackEndToEndTest.java
@@ -1,0 +1,195 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+import static com.hartwig.hmftools.redux.splice.MateFieldPatcher.patchMateFields;
+import static com.hartwig.hmftools.redux.splice.SaTagRewriter.SA_ATTRIBUTE;
+import static com.hartwig.hmftools.redux.splice.SaTagRewriter.rewriteSaTag;
+import static com.hartwig.hmftools.redux.splice.SpliceLiftBack.applyResultToRecord;
+import static com.hartwig.hmftools.redux.splice.SpliceLiftBack.toLiftedMateInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+import org.junit.Test;
+
+// black-box end-to-end harness around the full SpliceLiftBack record pipeline (resolver + apply + SA
+// rewrite + mate patch). A test prepares a fragment (R1, optional R2, optional supplementary R1), hands
+// it to processFragment(), then asserts on the final emitted SAMRecord fields. No inner-class poking,
+// no resolver wiring — write scenarios in terms of "what bwa produced" and "what should land in the
+// output BAM".
+public class SpliceLiftBackEndToEndTest
+{
+    private static final String GENE_ID = "ENSG_TEST";
+    private static final String GENE_NAME = "TESTG";
+    private static final String TRANS_NAME = "ENST_TEST";
+    private static final String TX_CONTIG = "ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME;
+    private static final String XA_TAG = "XA";
+
+    // exon spans on chr1: 100-199, 300-399, 500-549. introns: 200-299, 400-499. contig len 250.
+    private static ContigEntry threeExonContig()
+    {
+        return new ContigEntry(
+                TX_CONTIG, 1, 250, GENE_ID, GENE_NAME, TRANS_NAME, CHR_1,
+                List.of(new BaseRegion(100, 199), new BaseRegion(300, 399), new BaseRegion(500, 549)));
+    }
+
+    private static SAMRecord newPrimary(
+            final String readName, final boolean firstOfPair, final String contig, final int pos, final String cigar)
+    {
+        final SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName(readName);
+        record.setReferenceName(contig);
+        record.setAlignmentStart(pos);
+        record.setCigarString(cigar);
+        record.setMappingQuality(60);
+        record.setReadPairedFlag(true);
+        record.setFirstOfPairFlag(firstOfPair);
+        record.setProperPairFlag(true);
+        return record;
+    }
+
+    private static SAMRecord newSupplementary(
+            final String readName, final boolean firstOfPair, final String contig, final int pos, final String cigar)
+    {
+        final SAMRecord record = newPrimary(readName, firstOfPair, contig, pos, cigar);
+        record.setSupplementaryAlignmentFlag(true);
+        return record;
+    }
+
+    // runs the full per-record pipeline (resolver + apply + SA rewrite + mate patch) over a list of
+    // records belonging to the SAME read pair, mirroring what pass 1 + pass 2 of SpliceLiftBack do.
+    // Mutates the input records in place and returns them in input order.
+    private static List<SAMRecord> processFragment(final List<ContigEntry> entries, final List<SAMRecord> records)
+    {
+        final LiftBackResolver resolver = new LiftBackResolver(entries);
+        final LiftedMateInfoCache cache = new LiftedMateInfoCache();
+
+        // pass 1: cache lifted primary info per paired primary
+        for(final SAMRecord record : records)
+        {
+            if(!record.getReadPairedFlag() || record.isSecondaryOrSupplementary())
+                continue;
+            final LiftBackResult result = resolver.resolve(record);
+            cache.recordPrimaryAlignment(record.getReadName(), record.getFirstOfPairFlag(), toLiftedMateInfo(record, result));
+        }
+
+        // pass 2: lift, rewrite SA, patch mate fields
+        for(final SAMRecord record : records)
+        {
+            final LiftBackResult result = resolver.resolve(record);
+            applyResultToRecord(record, result, cache);
+            record.setAttribute(SA_ATTRIBUTE, rewriteSaTag(record.getStringAttribute(SA_ATTRIBUTE), resolver));
+            patchMateFields(record, cache);
+        }
+
+        return records;
+    }
+
+    @Test
+    public void txPrimaryReadsBecomeGenomicWithJunctionCigar()
+    {
+        // single R1, primary on tx contig spanning exon1 -> exon2
+        final SAMRecord r1 = newPrimary("read1", true, TX_CONTIG, 51, "100M");
+        // R2 mate placeholder — kept simple, on the same tx contig in the next exon
+        final SAMRecord r2 = newPrimary("read1", false, TX_CONTIG, 200, "50M");
+
+        processFragment(List.of(threeExonContig()), List.of(r1, r2));
+
+        // R1: junction-crossing CIGAR
+        assertEquals(CHR_1, r1.getReferenceName());
+        assertEquals(150, r1.getAlignmentStart());
+        assertEquals("50M100N50M", r1.getCigarString());
+
+        // R1 mate fields refer to R2's lifted coords on chr1
+        assertEquals(CHR_1, r1.getMateReferenceName());
+        assertEquals(399, r1.getMateAlignmentStart());
+
+        // R2 lifted into exon2/intron2/exon3 region with its own junction
+        assertEquals(CHR_1, r2.getReferenceName());
+        assertEquals(399, r2.getAlignmentStart());
+        assertTrue(r2.getCigarString().contains("N"));
+
+        // R2 mate fields refer back to R1
+        assertEquals(150, r2.getMateAlignmentStart());
+    }
+
+    @Test
+    public void supplementarySaTagRewrittenToGenomicCoords()
+    {
+        // R1 primary on tx contig with a supplementary on the same tx contig further along
+        final SAMRecord r1 = newPrimary("read2", true, TX_CONTIG, 51, "100M");
+        r1.setAttribute(SA_ATTRIBUTE, TX_CONTIG + ",200,+,50M,60,0;");
+
+        final SAMRecord r1Supp = newSupplementary("read2", true, TX_CONTIG, 200, "50M");
+        r1Supp.setAttribute(SA_ATTRIBUTE, TX_CONTIG + ",51,+,100M,60,0;");
+
+        final SAMRecord r2 = newPrimary("read2", false, CHR_1, 600, "50M");
+
+        processFragment(List.of(threeExonContig()), List.of(r1, r1Supp, r2));
+
+        // r1's SA entry pointed to (TX_CONTIG, 200, +, 50M) which lifts to (chr1, 399, +, ...) per the exon spans
+        final String r1Sa = r1.getStringAttribute(SA_ATTRIBUTE);
+        assertTrue("expected lifted SA entry on chr1, got: " + r1Sa, r1Sa != null && r1Sa.startsWith(CHR_1 + ","));
+        // no _tx contig name should leak through
+        assertFalse(r1Sa.contains(TX_CONTIG));
+
+        // supplementary primary itself is lifted to chr1 too
+        assertEquals(CHR_1, r1Supp.getReferenceName());
+        assertEquals(399, r1Supp.getAlignmentStart());
+
+        // r1 and r1Supp share the same mate (r2 on chr1:600), so both carry consistent mate info
+        assertEquals(CHR_1, r1.getMateReferenceName());
+        assertEquals(600, r1.getMateAlignmentStart());
+        assertEquals(CHR_1, r1Supp.getMateReferenceName());
+        assertEquals(600, r1Supp.getMateAlignmentStart());
+    }
+
+    @Test
+    public void unliftablePrimaryFlagsRecordUnmappedAndClearsMatesProperPair()
+    {
+        // R1 starts past altEnd — translation fails -> emit as unmapped
+        final SAMRecord r1 = newPrimary("read3", true, TX_CONTIG, 251, "50M");
+        // R2 lifts cleanly on the genome
+        final SAMRecord r2 = newPrimary("read3", false, CHR_1, 600, "50M");
+
+        processFragment(List.of(threeExonContig()), List.of(r1, r2));
+
+        assertTrue(r1.getReadUnmappedFlag());
+        assertEquals(SAMRecord.NO_ALIGNMENT_CIGAR, r1.getCigarString());
+        assertNull(r1.getStringAttribute(XA_TAG));
+
+        // R2 stays mapped, but its mate (R1) is unmapped -> proper-pair must be cleared
+        assertEquals(CHR_1, r2.getReferenceName());
+        assertFalse(r2.getProperPairFlag());
+        assertTrue(r2.getMateUnmappedFlag());
+    }
+
+    @Test
+    public void txPrimaryWithRefXaAltAtSameLocusEmitsSplicedCigar()
+    {
+        // bwa primary on tx (spliced) with a ref XA at the same locus showing the alignment soft-clipped
+        // around the junction. discriminator favours tx; XA emitted from the result should drop the ref
+        // alt because it was Dropped by the discriminator.
+        final SAMRecord r1 = newPrimary("read4", true, TX_CONTIG, 51, "100M");
+        r1.setAttribute(XA_TAG, CHR_1 + ",+150,50M50S,0;");
+
+        final SAMRecord r2 = newPrimary("read4", false, CHR_1, 700, "50M");
+
+        processFragment(List.of(threeExonContig()), List.of(r1, r2));
+
+        assertEquals(CHR_1, r1.getReferenceName());
+        assertEquals(150, r1.getAlignmentStart());
+        assertEquals("50M100N50M", r1.getCigarString());
+        // ref alt was Dropped — XA tag is null (only one kept alignment, which is the primary itself)
+        assertNull(r1.getStringAttribute(XA_TAG));
+    }
+}

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
@@ -35,18 +35,18 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(GENE_ID, result.GeneId);
-        assertEquals(GENE_NAME, result.GeneName);
-        assertEquals(TRANS_NAME, result.TransName);
-        assertEquals(CHR_1, result.Chromosome);
+        assertEquals(GENE_ID, result.geneId());
+        assertEquals(GENE_NAME, result.geneName());
+        assertEquals(TRANS_NAME, result.transName());
+        assertEquals(CHR_1, result.chromosome());
 
-        assertEquals(3, result.ExonSpans.size());
-        assertEquals(new BaseRegion(100, 199), result.ExonSpans.get(0));
-        assertEquals(new BaseRegion(300, 399), result.ExonSpans.get(1));
-        assertEquals(new BaseRegion(500, 549), result.ExonSpans.get(2));
+        assertEquals(3, result.exonSpans().size());
+        assertEquals(new BaseRegion(100, 199), result.exonSpans().get(0));
+        assertEquals(new BaseRegion(300, 399), result.exonSpans().get(1));
+        assertEquals(new BaseRegion(500, 549), result.exonSpans().get(2));
 
         // sequence length equals total exonic bases (no introns)
-        assertEquals(100 + 100 + 50, result.Sequence.length());
+        assertEquals(100 + 100 + 50, result.sequence().length());
     }
 
     @Test
@@ -63,9 +63,9 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(NEG_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(100, result.ExonSpans.get(0).start());
-        assertEquals(300, result.ExonSpans.get(1).start());
-        assertEquals(500, result.ExonSpans.get(2).start());
+        assertEquals(100, result.exonSpans().get(0).start());
+        assertEquals(300, result.exonSpans().get(1).start());
+        assertEquals(500, result.exonSpans().get(2).start());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class TranscriptContigBuilderTest
         String expected = ref.getBaseString(CHR_1, 100, 199)
                 + ref.getBaseString(CHR_1, 300, 399)
                 + ref.getBaseString(CHR_1, 500, 549);
-        assertEquals(expected, result.Sequence);
+        assertEquals(expected, result.sequence());
     }
 
     @Test
@@ -108,15 +108,15 @@ public class TranscriptContigBuilderTest
         assertNotNull(resultA);
         assertNotNull(resultB);
 
-        assertEquals("ENST00000001", resultA.TransName);
-        assertEquals("ENST00000002", resultB.TransName);
+        assertEquals("ENST00000001", resultA.transName());
+        assertEquals("ENST00000002", resultB.transName());
 
-        assertEquals(2, resultA.ExonSpans.size());
-        assertEquals(2, resultB.ExonSpans.size());
+        assertEquals(2, resultA.exonSpans().size());
+        assertEquals(2, resultB.exonSpans().size());
 
         // contig A spans 100-199 + 300-399, contig B spans 100-199 + 500-549. Different lengths confirm they're independent.
-        assertEquals(200, resultA.Sequence.length());
-        assertEquals(150, resultB.Sequence.length());
+        assertEquals(200, resultA.sequence().length());
+        assertEquals(150, resultB.sequence().length());
     }
 
     @Test
@@ -137,8 +137,8 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(1, result.ExonSpans.size());
-        assertEquals(101, result.Sequence.length());
+        assertEquals(1, result.exonSpans().size());
+        assertEquals(101, result.sequence().length());
     }
 
     private static GeneData gene(final byte strand)

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
@@ -35,19 +35,18 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME, result.Entry.contigName());
-        assertEquals(GENE_ID, result.Entry.geneId());
-        assertEquals(GENE_NAME, result.Entry.geneName());
-        assertEquals(TRANS_NAME, result.Entry.transName());
+        assertEquals(GENE_ID, result.GeneId);
+        assertEquals(GENE_NAME, result.GeneName);
+        assertEquals(TRANS_NAME, result.TransName);
+        assertEquals(CHR_1, result.Chromosome);
 
-        assertEquals(3, result.Entry.exonSpans().size());
-        assertEquals(new BaseRegion(100, 199), result.Entry.exonSpans().get(0));
-        assertEquals(new BaseRegion(300, 399), result.Entry.exonSpans().get(1));
-        assertEquals(new BaseRegion(500, 549), result.Entry.exonSpans().get(2));
+        assertEquals(3, result.ExonSpans.size());
+        assertEquals(new BaseRegion(100, 199), result.ExonSpans.get(0));
+        assertEquals(new BaseRegion(300, 399), result.ExonSpans.get(1));
+        assertEquals(new BaseRegion(500, 549), result.ExonSpans.get(2));
 
         // sequence length equals total exonic bases (no introns)
         assertEquals(100 + 100 + 50, result.Sequence.length());
-        assertEquals(result.Entry.contigLength(), result.Sequence.length());
     }
 
     @Test
@@ -64,9 +63,9 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(NEG_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(100, result.Entry.exonSpans().get(0).start());
-        assertEquals(300, result.Entry.exonSpans().get(1).start());
-        assertEquals(500, result.Entry.exonSpans().get(2).start());
+        assertEquals(100, result.ExonSpans.get(0).start());
+        assertEquals(300, result.ExonSpans.get(1).start());
+        assertEquals(500, result.ExonSpans.get(2).start());
     }
 
     @Test
@@ -109,15 +108,15 @@ public class TranscriptContigBuilderTest
         assertNotNull(resultA);
         assertNotNull(resultB);
 
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000001", resultA.Entry.contigName());
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000002", resultB.Entry.contigName());
+        assertEquals("ENST00000001", resultA.TransName);
+        assertEquals("ENST00000002", resultB.TransName);
 
-        assertEquals(2, resultA.Entry.exonSpans().size());
-        assertEquals(2, resultB.Entry.exonSpans().size());
+        assertEquals(2, resultA.ExonSpans.size());
+        assertEquals(2, resultB.ExonSpans.size());
 
         // contig A spans 100-199 + 300-399, contig B spans 100-199 + 500-549. Different lengths confirm they're independent.
-        assertEquals(200, resultA.Entry.contigLength());
-        assertEquals(150, resultB.Entry.contigLength());
+        assertEquals(200, resultA.Sequence.length());
+        assertEquals(150, resultB.Sequence.length());
     }
 
     @Test
@@ -138,7 +137,7 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(1, result.Entry.exonSpans().size());
+        assertEquals(1, result.ExonSpans.size());
         assertEquals(101, result.Sequence.length());
     }
 

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
@@ -35,15 +35,15 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME, result.Entry.ContigName);
-        assertEquals(GENE_ID, result.Entry.GeneId);
-        assertEquals(GENE_NAME, result.Entry.GeneName);
-        assertEquals(TRANS_NAME, result.Entry.TransName);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME, result.Entry.contigName());
+        assertEquals(GENE_ID, result.Entry.geneId());
+        assertEquals(GENE_NAME, result.Entry.geneName());
+        assertEquals(TRANS_NAME, result.Entry.transName());
 
-        assertEquals(3, result.Entry.ExonSpans.size());
-        assertEquals(new BaseRegion(100, 199), result.Entry.ExonSpans.get(0));
-        assertEquals(new BaseRegion(300, 399), result.Entry.ExonSpans.get(1));
-        assertEquals(new BaseRegion(500, 549), result.Entry.ExonSpans.get(2));
+        assertEquals(3, result.Entry.exonSpans().size());
+        assertEquals(new BaseRegion(100, 199), result.Entry.exonSpans().get(0));
+        assertEquals(new BaseRegion(300, 399), result.Entry.exonSpans().get(1));
+        assertEquals(new BaseRegion(500, 549), result.Entry.exonSpans().get(2));
 
         // sequence length equals total exonic bases (no introns)
         assertEquals(100 + 100 + 50, result.Sequence.length());
@@ -64,9 +64,9 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(NEG_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(100, result.Entry.ExonSpans.get(0).start());
-        assertEquals(300, result.Entry.ExonSpans.get(1).start());
-        assertEquals(500, result.Entry.ExonSpans.get(2).start());
+        assertEquals(100, result.Entry.exonSpans().get(0).start());
+        assertEquals(300, result.Entry.exonSpans().get(1).start());
+        assertEquals(500, result.Entry.exonSpans().get(2).start());
     }
 
     @Test
@@ -109,11 +109,11 @@ public class TranscriptContigBuilderTest
         assertNotNull(resultA);
         assertNotNull(resultB);
 
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000001", resultA.Entry.ContigName);
-        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000002", resultB.Entry.ContigName);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000001", resultA.Entry.contigName());
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000002", resultB.Entry.contigName());
 
-        assertEquals(2, resultA.Entry.ExonSpans.size());
-        assertEquals(2, resultB.Entry.ExonSpans.size());
+        assertEquals(2, resultA.Entry.exonSpans().size());
+        assertEquals(2, resultB.Entry.exonSpans().size());
 
         // contig A spans 100-199 + 300-399, contig B spans 100-199 + 500-549. Different lengths confirm they're independent.
         assertEquals(200, resultA.Entry.contigLength());
@@ -138,7 +138,7 @@ public class TranscriptContigBuilderTest
         TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
 
         assertNotNull(result);
-        assertEquals(1, result.Entry.ExonSpans.size());
+        assertEquals(1, result.Entry.exonSpans().size());
         assertEquals(101, result.Sequence.length());
     }
 

--- a/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/splice/TranscriptContigBuilderTest.java
@@ -1,0 +1,172 @@
+package com.hartwig.hmftools.redux.splice;
+
+import static com.hartwig.hmftools.common.genome.region.Strand.NEG_STRAND;
+import static com.hartwig.hmftools.common.genome.region.Strand.POS_STRAND;
+import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.hartwig.hmftools.common.gene.ExonData;
+import com.hartwig.hmftools.common.gene.GeneData;
+import com.hartwig.hmftools.common.gene.TranscriptData;
+import com.hartwig.hmftools.common.region.BaseRegion;
+import com.hartwig.hmftools.common.test.MockRefGenome;
+
+import org.junit.Test;
+
+public class TranscriptContigBuilderTest
+{
+    private static final String GENE_ID = "ENSG00000171862";
+    private static final String GENE_NAME = "PTEN";
+    private static final String TRANS_NAME = "ENST00000399770";
+
+    @Test
+    public void testThreeExonForwardStrandTranscript()
+    {
+        // exons stored in transcribed (Rank) order, which equals genomic-ascending for a forward-strand gene
+        TranscriptData transcript = transcript();
+        addExon(transcript, 100, 199, 1);
+        addExon(transcript, 300, 399, 2);
+        addExon(transcript, 500, 549, 3);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
+
+        assertNotNull(result);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_" + TRANS_NAME, result.Entry.ContigName);
+        assertEquals(GENE_ID, result.Entry.GeneId);
+        assertEquals(GENE_NAME, result.Entry.GeneName);
+        assertEquals(TRANS_NAME, result.Entry.TransName);
+
+        assertEquals(3, result.Entry.ExonSpans.size());
+        assertEquals(new BaseRegion(100, 199), result.Entry.ExonSpans.get(0));
+        assertEquals(new BaseRegion(300, 399), result.Entry.ExonSpans.get(1));
+        assertEquals(new BaseRegion(500, 549), result.Entry.ExonSpans.get(2));
+
+        // sequence length equals total exonic bases (no introns)
+        assertEquals(100 + 100 + 50, result.Sequence.length());
+        assertEquals(result.Entry.contigLength(), result.Sequence.length());
+    }
+
+    @Test
+    public void testNegativeStrandTranscriptStoresExonsInGenomicOrder()
+    {
+        // Rank-ordered exons for a negative-strand transcript run genomic-descending. The builder must re-sort to
+        // genomic-ascending so the contig sequence mirrors the forward strand.
+        TranscriptData transcript = transcript();
+        addExon(transcript, 500, 549, 1); // 5' end of mRNA, but genomic-high
+        addExon(transcript, 300, 399, 2);
+        addExon(transcript, 100, 199, 3);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(NEG_STRAND), transcript);
+
+        assertNotNull(result);
+        assertEquals(100, result.Entry.ExonSpans.get(0).start());
+        assertEquals(300, result.Entry.ExonSpans.get(1).start());
+        assertEquals(500, result.Entry.ExonSpans.get(2).start());
+    }
+
+    @Test
+    public void testEmittedSequenceMatchesExonConcatenation()
+    {
+        TranscriptData transcript = transcript();
+        addExon(transcript, 100, 199, 1);
+        addExon(transcript, 300, 399, 2);
+        addExon(transcript, 500, 549, 3);
+
+        MockRefGenome ref = buildMockRef();
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(ref);
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
+
+        assertNotNull(result);
+
+        String expected = ref.getBaseString(CHR_1, 100, 199)
+                + ref.getBaseString(CHR_1, 300, 399)
+                + ref.getBaseString(CHR_1, 500, 549);
+        assertEquals(expected, result.Sequence);
+    }
+
+    @Test
+    public void testMultipleTranscriptsEachGetTheirOwnContig()
+    {
+        // simulate two isoforms of the same gene with different exon sets — each should be built independently
+        // (caller iterates transcripts; the builder is per-transcript)
+        TranscriptData transA = new TranscriptData(1, "ENST00000001", GENE_ID, true, POS_STRAND, 0, 0, null, null, "protein_coding", null);
+        addExon(transA, 100, 199, 1);
+        addExon(transA, 300, 399, 2);
+
+        TranscriptData transB = new TranscriptData(2, "ENST00000002", GENE_ID, false, POS_STRAND, 0, 0, null, null, "protein_coding", null);
+        addExon(transB, 100, 199, 1);
+        addExon(transB, 500, 549, 2);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult resultA = builder.build(gene(POS_STRAND), transA);
+        TranscriptContigBuilder.TranscriptContigResult resultB = builder.build(gene(POS_STRAND), transB);
+
+        assertNotNull(resultA);
+        assertNotNull(resultB);
+
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000001", resultA.Entry.ContigName);
+        assertEquals("ens" + GENE_ID + "_" + GENE_NAME + "_ENST00000002", resultB.Entry.ContigName);
+
+        assertEquals(2, resultA.Entry.ExonSpans.size());
+        assertEquals(2, resultB.Entry.ExonSpans.size());
+
+        // contig A spans 100-199 + 300-399, contig B spans 100-199 + 500-549. Different lengths confirm they're independent.
+        assertEquals(200, resultA.Entry.contigLength());
+        assertEquals(150, resultB.Entry.contigLength());
+    }
+
+    @Test
+    public void testTranscriptWithNoExonsReturnsNull()
+    {
+        TranscriptData empty = transcript();
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        assertNull(builder.build(gene(POS_STRAND), empty));
+    }
+
+    @Test
+    public void testSingleExonTranscriptHasNoIntrons()
+    {
+        TranscriptData transcript = transcript();
+        addExon(transcript, 100, 200, 1);
+
+        TranscriptContigBuilder builder = new TranscriptContigBuilder(buildMockRef());
+        TranscriptContigBuilder.TranscriptContigResult result = builder.build(gene(POS_STRAND), transcript);
+
+        assertNotNull(result);
+        assertEquals(1, result.Entry.ExonSpans.size());
+        assertEquals(101, result.Sequence.length());
+    }
+
+    private static GeneData gene(final byte strand)
+    {
+        return new GeneData(GENE_ID, GENE_NAME, CHR_1, strand, 100, 549, "");
+    }
+
+    private static TranscriptData transcript()
+    {
+        return new TranscriptData(1, TRANS_NAME, GENE_ID, true, POS_STRAND, 0, 0, null, null, "protein_coding", null);
+    }
+
+    private static void addExon(final TranscriptData transcript, int start, int end, int rank)
+    {
+        transcript.exons().add(new ExonData(transcript.TransId, start, end, rank, -1, -1));
+    }
+
+    private static MockRefGenome buildMockRef()
+    {
+        // position-distinguishable bases so sequence-content assertions actually catch bad concatenations
+        MockRefGenome refGenome = new MockRefGenome(true);
+        char[] alphabet = { 'A', 'C', 'G', 'T' };
+        StringBuilder bases = new StringBuilder();
+        bases.append('N'); // pad index 0
+        for(int i = 1; i <= 1000; ++i)
+            bases.append(alphabet[i % 4]);
+        refGenome.RefGenomeMap.put(CHR_1, bases.toString());
+        return refGenome;
+    }
+}


### PR DESCRIPTION
### SpliceFastaBuilder

Added to Redux for generating transcript contig FASTA files from Ensembl data, enabling splice-aware alignment with `bwa-mem2`. This is a core component of the RNA splice-resolver prototype to replace STAR with a more lightweight junction-based approach.

###   Changes

- Tool location: `redux/src/main/java/com/hartwig/hmftools/redux/splice/SpliceFastaBuilder.java`

- Outputs: r`ef_genome_vXX_rna_contigs.fasta` (contig sequences) and `.rna_contigs_mappings.tsv` (contig→gene/transcript/exon metadata for lift-back)

- How it works: processes multi-exon transcripts from Ensembl, skips single-exon transcripts (`bwa-mem2` already aligns these correctly to genomic ref), excludes contigs where all exonic positions are masked to 'N' in the reference

### SpliceLiftBack

Added to complete the splice-aware alignment pipeline. Reads bwa-mem2 alignments to synthetic transcript contigs and translates them back to genome coordinates with N-gapped CIGAR strings across introns. This is the final step in the RNA splice-resolver prototype to replace STAR.

### Changes

- SpliceLiftBack: translates bwa-mem2 transcript-contig alignment reads back to genome coordinates with updated records
  - LiftBackResolver: core logic for contig-to-genome mapping using exon span metadata
  - LiftBackStats: tracks alignment translation metrics (unmapped, ambiguous, successful)
  - LiftBackWriter: outputs lifted BAM with proper mate-pair and supplementary alignment patching
- Immutable data carriers
- Output handling: writes unsorted BAM then sorts and indexes via bam-tools