### PR TITLE
BamTools: BamCompare diff buckets, cigar-tolerant compare, mate-diff columns

### DIFF
--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/BamCompare.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/BamCompare.java
@@ -88,9 +88,6 @@ public class BamCompare
 
         BT_LOGGER.info("splitting {} partitions across {} threads", partitionTasks.size(), mConfig.Threads);
 
-        // pre-pass: scan both BAMs over each partition and collect readnames whose any alignment overlaps
-        // an ignore region by > 50% of its reference span. Populates the shared ignoredReadNames set used
-        // by excludeRead in the compare wave below.
         if(ignoreRegionIndex != null)
         {
             long scanStartMs = System.currentTimeMillis();

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/BamCompare.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/BamCompare.java
@@ -9,10 +9,12 @@ import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -51,6 +53,11 @@ public class BamCompare
 
         UnmatchedReadHandler unmatchedReadHandler = new UnmatchedReadHandler(mConfig);
 
+        final IgnoreRegionIndex ignoreRegionIndex = mConfig.IgnoreRegionFiles.isEmpty()
+                ? null : IgnoreRegionIndex.load(mConfig.IgnoreRegionFiles);
+        final Set<String> ignoredReadNames = ignoreRegionIndex != null
+                ? Collections.newSetFromMap(new ConcurrentHashMap<>()) : null;
+
         List<PartitionReader> partitionTasks = new ArrayList<>();
 
         File origBamFile = new File(mConfig.OrigBamFile);
@@ -61,7 +68,8 @@ public class BamCompare
         for(ChrBaseRegion partition : partitions)
         {
             PartitionReader partitionReader = new PartitionReader(
-                    partition.toString(), mConfig, partition, origBamFile, newBamFile, readWriter, unmatchedReadHandler);
+                    partition.toString(), mConfig, partition, origBamFile, newBamFile, readWriter, unmatchedReadHandler,
+                    ignoreRegionIndex, ignoredReadNames);
 
             partitionTasks.add(partitionReader);
         }
@@ -72,12 +80,33 @@ public class BamCompare
         if(includeFullyUnmapped)
         {
             PartitionReader partitionReader = new PartitionReader(
-                    FULLY_UNMAPPED_PARTITION, mConfig, null, origBamFile, newBamFile, readWriter, unmatchedReadHandler);
+                    FULLY_UNMAPPED_PARTITION, mConfig, null, origBamFile, newBamFile, readWriter, unmatchedReadHandler,
+                    ignoreRegionIndex, ignoredReadNames);
 
             partitionTasks.add(partitionReader);
         }
 
         BT_LOGGER.info("splitting {} partitions across {} threads", partitionTasks.size(), mConfig.Threads);
+
+        // pre-pass: scan both BAMs over each partition and collect readnames whose any alignment overlaps
+        // an ignore region by > 50% of its reference span. Populates the shared ignoredReadNames set used
+        // by excludeRead in the compare wave below.
+        if(ignoreRegionIndex != null)
+        {
+            long scanStartMs = System.currentTimeMillis();
+            BT_LOGGER.info("ignore-region pre-pass: scanning {} partitions for readnames to drop", partitionTasks.size());
+
+            List<Callable<Void>> scanCallables = partitionTasks.stream()
+                    .map(p -> (Callable<Void>) () -> { p.scanIgnoredReadNames(); return null; })
+                    .collect(Collectors.toList());
+
+            if(!TaskExecutor.executeTasks(scanCallables, mConfig.Threads))
+                System.exit(1);
+
+            long scanSecs = (System.currentTimeMillis() - scanStartMs) / 1000;
+            BT_LOGGER.info("ignore-region pre-pass complete: {} readname(s) flagged, {} sec",
+                    ignoredReadNames.size(), scanSecs);
+        }
 
         List<Callable<Void>> callableList = partitionTasks.stream().collect(Collectors.toList());
 
@@ -104,7 +133,8 @@ public class BamCompare
                 Pair<File,File> hashBamPair = hashBamPairEntries.getValue();
 
                 partitionTasks.add(new PartitionReader(String.format("hash bam %d", hashBamPairEntries.getKey()),
-                        mConfig, null, hashBamPair.getLeft(), hashBamPair.getRight(), readWriter, null));
+                        mConfig, null, hashBamPair.getLeft(), hashBamPair.getRight(), readWriter, null,
+                        ignoreRegionIndex, ignoredReadNames));
            }
 
             callableList = partitionTasks.stream().collect(Collectors.toList());
@@ -117,8 +147,9 @@ public class BamCompare
 
         readWriter.close();
 
-        BT_LOGGER.printf(Level.INFO, "summary: reads(orig=%,d new=%,d) matched(%,d) diffs(%,d)",
-                combinedStats.OrigReadCount, combinedStats.NewReadCount, combinedStats.Matched, combinedStats.DiffCount);
+        BT_LOGGER.printf(Level.INFO, "summary: reads(orig=%,d new=%,d) matched(%,d) diffs(%,d) ignored(%,d)",
+                combinedStats.OrigReadCount, combinedStats.NewReadCount, combinedStats.Matched, combinedStats.DiffCount,
+                combinedStats.IgnoredReadRecords);
 
         BT_LOGGER.info("BamCompare complete, mins({})", runTimeMinsStr(startTimeMs));
     }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareConfig.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareConfig.java
@@ -14,6 +14,8 @@ import static com.hartwig.hmftools.common.utils.config.CommonConfig.LOG_READ_IDS
 import static com.hartwig.hmftools.common.utils.config.CommonConfig.parseLogReadIds;
 import static com.hartwig.hmftools.common.utils.config.ConfigUtils.addLoggingOptions;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -50,6 +52,11 @@ public class CompareConfig
     public final int Threads;
     public final List<String> LogReadIds;
 
+    // comma-separated list of TSV paths (Chromosome / PosStart / PosEnd headers; extra columns ignored).
+    // any readname whose any alignment overlaps an ignore region by > 50% of its reference span is dropped
+    // from comparison in both BAMs.
+    public final List<String> IgnoreRegionFiles;
+
     // debug
     public final SpecificRegions SpecificChrRegions;
 
@@ -67,6 +74,7 @@ public class CompareConfig
     private static final String IGNORE_CONSENSUS_READS = "ignore_consensus_reads";
     private static final String IGNORE_REDUX_UNMAPPED = "ignore_redux_unmapped";
     private static final String IGNORE_REDUX_DIFFS = "ignore_redux_diffs";
+    private static final String IGNORE_REGIONS_FILES = "ignore_regions";
     private static final String CIGAR_BOUNDARY_TOLERANCE = "cigar_boundary_tolerance";
     private static final String COORDS_ONLY = "coords_only";
     private static final String CHECK_BASES_QUALS = "check_bases_quals";
@@ -149,6 +157,17 @@ public class CompareConfig
 
         ExcludeRegions = configBuilder.hasFlag(EXCLUDE_REGIONS);
 
+        final String ignoreRegionFiles = configBuilder.getValue(IGNORE_REGIONS_FILES);
+        if(ignoreRegionFiles != null && !ignoreRegionFiles.isEmpty())
+        {
+            IgnoreRegionFiles = Arrays.asList(ignoreRegionFiles.split(","));
+            BT_LOGGER.info("ignore-region TSV file(s): {}", IgnoreRegionFiles);
+        }
+        else
+        {
+            IgnoreRegionFiles = Collections.emptyList();
+        }
+
         Threads = max(parseThreads(configBuilder), 1);
 
         LogReadIds = parseLogReadIds(configBuilder);
@@ -195,6 +214,11 @@ public class CompareConfig
         configBuilder.addInteger(CIGAR_BOUNDARY_TOLERANCE,
                 "Tolerate up to N bp drift on M-block boundaries when comparing CIGARs (0 = strict)", 0);
 
+        configBuilder.addConfigItem(IGNORE_REGIONS_FILES,
+                "Comma-separated TSV path(s) with Chromosome/PosStart/PosEnd columns; readnames whose any"
+                        + " alignment overlaps these regions by more than half its reference span are dropped"
+                        + " from comparison in both BAMs.");
+
         addRefGenomeFile(configBuilder, false);
         addSpecificChromosomesRegionsConfig(configBuilder);
         addLoggingOptions(configBuilder);
@@ -233,5 +257,6 @@ public class CompareConfig
         Threads = 0;
         LogReadIds = null;
         SpecificChrRegions = null;
+        IgnoreRegionFiles = Collections.emptyList();
     }
 }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareConfig.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareConfig.java
@@ -43,6 +43,7 @@ public class CompareConfig
     public final boolean CompareCoordsOnly;
     public final boolean CheckBasesAndQuals;
     public final boolean StandardChromosomes;
+    public final int CigarBoundaryTolerance;
 
     public final boolean IgnoreReduxAlterations; // consensus reads and internal unmappings
 
@@ -66,6 +67,7 @@ public class CompareConfig
     private static final String IGNORE_CONSENSUS_READS = "ignore_consensus_reads";
     private static final String IGNORE_REDUX_UNMAPPED = "ignore_redux_unmapped";
     private static final String IGNORE_REDUX_DIFFS = "ignore_redux_diffs";
+    private static final String CIGAR_BOUNDARY_TOLERANCE = "cigar_boundary_tolerance";
     private static final String COORDS_ONLY = "coords_only";
     private static final String CHECK_BASES_QUALS = "check_bases_quals";
     protected static final String STANDARD_CHROMOSOMES = "std_chromosomes";
@@ -94,6 +96,8 @@ public class CompareConfig
         int maxCachedReadsPerThread = configBuilder.getInteger(MAX_CACHED_READS_PER_THREAD);
 
         CompareCoordsOnly = configBuilder.hasFlag(COORDS_ONLY);
+
+        CigarBoundaryTolerance = configBuilder.getInteger(CIGAR_BOUNDARY_TOLERANCE);
 
         if(configBuilder.hasFlag(IGNORE_REDUX_DIFFS))
         {
@@ -188,6 +192,9 @@ public class CompareConfig
         configBuilder.addFlag(CHECK_BASES_QUALS, "Ignore differences in consensus read bases and quals");
         configBuilder.addFlag(STANDARD_CHROMOSOMES, "Only process standard human chromosomes");
 
+        configBuilder.addInteger(CIGAR_BOUNDARY_TOLERANCE,
+                "Tolerate up to N bp drift on M-block boundaries when comparing CIGARs (0 = strict)", 0);
+
         addRefGenomeFile(configBuilder, false);
         addSpecificChromosomesRegionsConfig(configBuilder);
         addLoggingOptions(configBuilder);
@@ -213,6 +220,7 @@ public class CompareConfig
 
         CompareCoordsOnly = false;
         StandardChromosomes = false;
+        CigarBoundaryTolerance = 0;
 
         OutputFile = null;
         OrigBamFile = null;

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareConfig.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareConfig.java
@@ -52,9 +52,6 @@ public class CompareConfig
     public final int Threads;
     public final List<String> LogReadIds;
 
-    // comma-separated list of TSV paths (Chromosome / PosStart / PosEnd headers; extra columns ignored).
-    // any readname whose any alignment overlaps an ignore region by > 50% of its reference span is dropped
-    // from comparison in both BAMs.
     public final List<String> IgnoreRegionFiles;
 
     // debug

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareUtils.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareUtils.java
@@ -13,135 +13,229 @@ import java.util.List;
 import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.TextCigarCodec;
 import htsjdk.samtools.ValidationStringency;
 
 public class CompareUtils
 {
-    private static final List<String> KEY_ATTRIBUTES = List.of(SUPPLEMENTARY_ATTRIBUTE, MATE_CIGAR_ATTRIBUTE);
-
     @VisibleForTesting
-    public static List<String> compareReads(final SAMRecord origRead, final SAMRecord newRead, final CompareConfig config)
+    public static List<String> compareReads(final SAMRecord orig, final SAMRecord newRead, final CompareConfig config)
     {
-        boolean bothUnmapped = origRead.getReadUnmappedFlag() && newRead.getReadUnmappedFlag();
-
-        if(bothUnmapped)
+        if(orig.getReadUnmappedFlag() && newRead.getReadUnmappedFlag())
             return Collections.emptyList();
 
-        List<String> diffs = Lists.newArrayList();
+        boolean unmappedDiff = orig.getReadUnmappedFlag() != newRead.getReadUnmappedFlag();
+        boolean mateUnmappedDiff = orig.getMateUnmappedFlag() != newRead.getMateUnmappedFlag();
+        boolean skipUnmapping = config.IgnoreReduxUnmapped && (unmappedDiff || mateUnmappedDiff);
 
-        boolean hasUnmappedDifference = origRead.getReadUnmappedFlag() != newRead.getReadUnmappedFlag();
-        boolean hasMateUnmappedDifference = origRead.getMateUnmappedFlag() != newRead.getMateUnmappedFlag();
-        boolean skipUnmappingDifference = config.IgnoreReduxUnmapped && (hasUnmappedDifference || hasMateUnmappedDifference);
+        boolean ownCigarsEquiv = config.CigarBoundaryTolerance > 0
+                && !orig.getReadUnmappedFlag() && !newRead.getReadUnmappedFlag()
+                && cigarsEquivalent(orig, newRead, config.CigarBoundaryTolerance);
 
-        if(!skipUnmappingDifference)
-        {
-            boolean coordsDiffer = false;
+        boolean mateCigarsEquiv = config.CigarBoundaryTolerance > 0
+                && mateCigarsEquivalent(orig, newRead, config.CigarBoundaryTolerance);
 
-            if(origRead.getAlignmentStart() != newRead.getAlignmentStart())
-            {
-                coordsDiffer = true;
-            }
-            else if(origRead.getAlignmentEnd() != newRead.getAlignmentEnd())
-            {
-                coordsDiffer = true;
-            }
-            else
-            {
-                coordsDiffer = origRead.getContig() != null && newRead.getContig() != null
-                        && !origRead.getContig().equals(newRead.getContig());
-            }
+        List<String> diffs = new ArrayList<>();
 
-            if(coordsDiffer)
-            {
-                diffs.add(format("coords(%s/%s)", readCoords(origRead), readCoords(newRead)));
-            }
-        }
+        if(!skipUnmapping && !ownCigarsEquiv && coordsDiffer(orig, newRead))
+            diffs.add(format("coords(%s/%s)", readCoords(orig), readCoords(newRead)));
 
         if(config.CompareCoordsOnly)
             return diffs;
 
-        if(!skipUnmappingDifference)
-        {
-            if(origRead.getInferredInsertSize() != newRead.getInferredInsertSize())
-                diffs.add(format("insertSize(%d/%d)", origRead.getInferredInsertSize(), newRead.getInferredInsertSize()));
+        if(!skipUnmapping && !ownCigarsEquiv && !mateCigarsEquiv
+                && orig.getInferredInsertSize() != newRead.getInferredInsertSize())
+            diffs.add(format("insertSize(%d/%d)", orig.getInferredInsertSize(), newRead.getInferredInsertSize()));
 
-            if(!origRead.getCigarString().equals(newRead.getCigarString()))
-                diffs.add(format("cigar(%s/%s)", origRead.getCigarString(), newRead.getCigarString()));
+        if(!skipUnmapping && !ownCigarsEquiv && !orig.getCigarString().equals(newRead.getCigarString()))
+            diffs.add(format("cigar(%s/%s)", orig.getCigarString(), newRead.getCigarString()));
 
-            if(origRead.getMappingQuality() != newRead.getMappingQuality())
-                diffs.add(format("mapQuality(%d/%d)", origRead.getMappingQuality(), newRead.getMappingQuality()));
-        }
+        if(!skipUnmapping && orig.getMappingQuality() != newRead.getMappingQuality())
+            diffs.add(format("mapQuality(%d/%d)", orig.getMappingQuality(), newRead.getMappingQuality()));
 
-        if(origRead.getFlags() != newRead.getFlags())
-        {
-            if(origRead.getReadNegativeStrandFlag() != newRead.getReadNegativeStrandFlag())
-                diffs.add(format("negStrand(%s/%s)", origRead.getReadNegativeStrandFlag(), newRead.getReadNegativeStrandFlag()));
+        if(orig.getFlags() != newRead.getFlags())
+            addFlagDiffs(orig, newRead, diffs, config, skipUnmapping, unmappedDiff, mateUnmappedDiff);
 
-            if(!config.IgnoreDupDiffs && origRead.getDuplicateReadFlag() != newRead.getDuplicateReadFlag())
-                diffs.add(format("duplicate(%s/%s)", origRead.getDuplicateReadFlag(), newRead.getDuplicateReadFlag()));
+        if(!skipUnmapping && orig.getReadPairedFlag() && newRead.getReadPairedFlag()
+                && !orig.getMateUnmappedFlag() && !newRead.getMateUnmappedFlag())
+            addMateFieldDiffs(orig, newRead, diffs, config.CigarBoundaryTolerance);
 
-            if(!skipUnmappingDifference)
-            {
-                if(hasUnmappedDifference)
-                    diffs.add(format("unmapped(%s/%s)", origRead.getReadUnmappedFlag(), newRead.getReadUnmappedFlag()));
-
-                if(hasMateUnmappedDifference)
-                    diffs.add(format("mateUnmapped(%s/%s)", origRead.getMateUnmappedFlag(), newRead.getMateUnmappedFlag()));
-            }
-        }
-
-        // check key attributes:
-        for(String attribute : KEY_ATTRIBUTES)
-        {
-            if(attribute.equals(SUPPLEMENTARY_ATTRIBUTE))
-            {
-                if(config.IgnoreSupplementaryAttribute)
-                    continue;
-
-                if(origRead.hasAttribute(UNMAP_ATTRIBUTE) || newRead.hasAttribute(UNMAP_ATTRIBUTE))
-                    continue;
-            }
-
-            if(skipUnmappingDifference && attribute.equals(MATE_CIGAR_ATTRIBUTE))
-                continue;
-
-            String readAttr1 = origRead.getStringAttribute(attribute);
-            String readAttr2 = newRead.getStringAttribute(attribute);
-
-            if(!Objects.equals(readAttr1, readAttr2)) // Objects.equals handles null case
-            {
-                diffs.add(format("attrib_%s(%s/%s)", attribute,
-                        readAttr1 == null ? "missing" : readAttr1,
-                        readAttr2 == null ? "missing" : readAttr2));
-            }
-        }
+        addAttributeDiffs(orig, newRead, diffs, config, skipUnmapping, mateCigarsEquiv);
 
         if(config.CheckBasesAndQuals)
-        {
-            if(!origRead.getReadString().equals(newRead.getReadString()))
-            {
-                diffs.add(format("bases(%s/%s)", origRead.getReadString(), newRead.getReadString()));
-            }
-
-            if(!origRead.getBaseQualityString().equals(newRead.getBaseQualityString()))
-            {
-                diffs.add(format("baseQual(%s/%s)", origRead.getBaseQualityString(), newRead.getBaseQualityString()));
-            }
-        }
+            addBasesAndQualsDiffs(orig, newRead, diffs);
 
         return diffs;
+    }
+
+    private static boolean coordsDiffer(final SAMRecord orig, final SAMRecord newRead)
+    {
+        if(orig.getAlignmentStart() != newRead.getAlignmentStart())
+            return true;
+        if(orig.getAlignmentEnd() != newRead.getAlignmentEnd())
+            return true;
+        return orig.getContig() != null && newRead.getContig() != null
+                && !orig.getContig().equals(newRead.getContig());
+    }
+
+    private static void addFlagDiffs(final SAMRecord orig, final SAMRecord newRead, final List<String> diffs,
+            final CompareConfig config, final boolean skipUnmapping, final boolean unmappedDiff, final boolean mateUnmappedDiff)
+    {
+        // strand flag is undefined on an unmapped record per SAM spec
+        if(!skipUnmapping && !unmappedDiff && orig.getReadNegativeStrandFlag() != newRead.getReadNegativeStrandFlag())
+            diffs.add(format("negStrand(%s/%s)", orig.getReadNegativeStrandFlag(), newRead.getReadNegativeStrandFlag()));
+
+        if(!config.IgnoreDupDiffs && orig.getDuplicateReadFlag() != newRead.getDuplicateReadFlag())
+            diffs.add(format("duplicate(%s/%s)", orig.getDuplicateReadFlag(), newRead.getDuplicateReadFlag()));
+
+        if(skipUnmapping)
+            return;
+
+        if(unmappedDiff)
+            diffs.add(format("unmapped(%s/%s)", orig.getReadUnmappedFlag(), newRead.getReadUnmappedFlag()));
+
+        if(mateUnmappedDiff)
+            diffs.add(format("mateUnmapped(%s/%s)", orig.getMateUnmappedFlag(), newRead.getMateUnmappedFlag()));
+    }
+
+    private static void addMateFieldDiffs(final SAMRecord orig, final SAMRecord newRead, final List<String> diffs, final int tolerance)
+    {
+        if(!Objects.equals(orig.getMateReferenceName(), newRead.getMateReferenceName()))
+            diffs.add(format("mateChr(%s/%s)", orig.getMateReferenceName(), newRead.getMateReferenceName()));
+
+        int pnextDelta = Math.abs(orig.getMateAlignmentStart() - newRead.getMateAlignmentStart());
+        if(pnextDelta > 0 && pnextDelta > tolerance)
+            diffs.add(format("matePos(%d/%d)", orig.getMateAlignmentStart(), newRead.getMateAlignmentStart()));
+
+        if(orig.getMateNegativeStrandFlag() != newRead.getMateNegativeStrandFlag())
+            diffs.add(format("mateNegStrand(%s/%s)", orig.getMateNegativeStrandFlag(), newRead.getMateNegativeStrandFlag()));
+    }
+
+    private static void addAttributeDiffs(final SAMRecord orig, final SAMRecord newRead, final List<String> diffs,
+            final CompareConfig config, final boolean skipUnmapping, final boolean mateCigarsEquiv)
+    {
+        if(!config.IgnoreSupplementaryAttribute
+                && !orig.hasAttribute(UNMAP_ATTRIBUTE) && !newRead.hasAttribute(UNMAP_ATTRIBUTE))
+            addAttribDiff(orig, newRead, diffs, SUPPLEMENTARY_ATTRIBUTE);
+
+        if(!skipUnmapping && !mateCigarsEquiv)
+            addAttribDiff(orig, newRead, diffs, MATE_CIGAR_ATTRIBUTE);
+    }
+
+    private static void addAttribDiff(final SAMRecord orig, final SAMRecord newRead, final List<String> diffs, final String attr)
+    {
+        String origValue = orig.getStringAttribute(attr);
+        String newValue = newRead.getStringAttribute(attr);
+        if(!Objects.equals(origValue, newValue))
+            diffs.add(format("attrib_%s(%s/%s)", attr,
+                    origValue == null ? "missing" : origValue,
+                    newValue == null ? "missing" : newValue));
+    }
+
+    private static void addBasesAndQualsDiffs(final SAMRecord orig, final SAMRecord newRead, final List<String> diffs)
+    {
+        if(!orig.getReadString().equals(newRead.getReadString()))
+            diffs.add(format("bases(%s/%s)", orig.getReadString(), newRead.getReadString()));
+
+        if(!orig.getBaseQualityString().equals(newRead.getBaseQualityString()))
+            diffs.add(format("baseQual(%s/%s)", orig.getBaseQualityString(), newRead.getBaseQualityString()));
     }
 
     private static String readCoords(final SAMRecord read)
     {
         if(!read.getReadUnmappedFlag())
             return format("%s:%d-%d:%s", read.getContig(), read.getAlignmentStart(), read.getAlignmentEnd(), read.getCigarString());
-        else
-            return format("%s:%d", read.getContig(), read.getAlignmentStart());
+        return format("%s:%d", read.getContig(), read.getAlignmentStart());
+    }
+
+    static boolean cigarsEquivalent(final SAMRecord orig, final SAMRecord newRead, final int toleranceBp)
+    {
+        if(orig.getReadNegativeStrandFlag() != newRead.getReadNegativeStrandFlag())
+            return false;
+        if(orig.getContig() == null || newRead.getContig() == null || !orig.getContig().equals(newRead.getContig()))
+            return false;
+        return cigarElementsEquivalent(orig.getCigar(), newRead.getCigar(), toleranceBp);
+    }
+
+    static boolean mateCigarsEquivalent(final SAMRecord orig, final SAMRecord newRead, final int toleranceBp)
+    {
+        if(!orig.getReadPairedFlag() || !newRead.getReadPairedFlag())
+            return false;
+        if(orig.getMateUnmappedFlag() || newRead.getMateUnmappedFlag())
+            return false;
+        if(Math.abs(orig.getMateAlignmentStart() - newRead.getMateAlignmentStart()) > toleranceBp)
+            return false;
+        if(orig.getMateNegativeStrandFlag() != newRead.getMateNegativeStrandFlag())
+            return false;
+        if(!Objects.equals(orig.getMateReferenceName(), newRead.getMateReferenceName()))
+            return false;
+
+        String origMc = orig.getStringAttribute(MATE_CIGAR_ATTRIBUTE);
+        String newMc = newRead.getStringAttribute(MATE_CIGAR_ATTRIBUTE);
+        if(origMc == null || newMc == null)
+            return false;
+        if(origMc.equals(newMc))
+            return true;
+        return cigarElementsEquivalent(TextCigarCodec.decode(origMc), TextCigarCodec.decode(newMc), toleranceBp);
+    }
+
+    private static boolean cigarElementsEquivalent(final Cigar a, final Cigar b, final int toleranceBp)
+    {
+        List<CigarElement> elementsA = absorbEndSoftClips(a.getCigarElements(), toleranceBp);
+        List<CigarElement> elementsB = absorbEndSoftClips(b.getCigarElements(), toleranceBp);
+        if(elementsA.size() != elementsB.size() || elementsA.isEmpty())
+            return false;
+
+        for(int i = 0; i < elementsA.size(); ++i)
+        {
+            CigarElement ea = elementsA.get(i);
+            CigarElement eb = elementsB.get(i);
+            if(ea.getOperator() != eb.getOperator())
+                return false;
+            if(Math.abs(ea.getLength() - eb.getLength()) > toleranceBp)
+                return false;
+        }
+        return true;
+    }
+
+    // merge a leading or trailing soft-clip of length <= toleranceBp into its adjacent M-class op
+    private static List<CigarElement> absorbEndSoftClips(final List<CigarElement> elements, final int toleranceBp)
+    {
+        if(elements.size() < 2)
+            return elements;
+
+        List<CigarElement> result = new ArrayList<>(elements);
+        int last = result.size() - 1;
+        if(isAbsorbableSoftClip(result.get(last), toleranceBp) && isMatchClass(result.get(last - 1).getOperator()))
+        {
+            CigarElement neighbour = result.get(last - 1);
+            result.set(last - 1, new CigarElement(neighbour.getLength() + result.get(last).getLength(), neighbour.getOperator()));
+            result.remove(last);
+        }
+
+        if(result.size() >= 2 && isAbsorbableSoftClip(result.get(0), toleranceBp) && isMatchClass(result.get(1).getOperator()))
+        {
+            CigarElement neighbour = result.get(1);
+            result.set(1, new CigarElement(neighbour.getLength() + result.get(0).getLength(), neighbour.getOperator()));
+            result.remove(0);
+        }
+        return result;
+    }
+
+    private static boolean isAbsorbableSoftClip(final CigarElement element, final int toleranceBp)
+    {
+        return element.getOperator() == CigarOperator.S && element.getLength() <= toleranceBp;
+    }
+
+    private static boolean isMatchClass(final CigarOperator op)
+    {
+        return op == CigarOperator.M || op == CigarOperator.EQ || op == CigarOperator.X;
     }
 
     public static SamReaderFactory makeSamReaderFactory(final CompareConfig config)
@@ -149,9 +243,7 @@ public class CompareUtils
         SamReaderFactory readerFactory = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT);
         if(config.RefGenomeFile != null && !config.RefGenomeFile.isEmpty())
-        {
             readerFactory.referenceSequence(new File(config.RefGenomeFile));
-        }
         return readerFactory;
     }
 }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareUtils.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareUtils.java
@@ -71,6 +71,23 @@ public class CompareUtils
         if(config.CheckBasesAndQuals)
             addBasesAndQualsDiffs(orig, newRead, diffs);
 
+        // surface boundary-tolerance absorption as its own diff when nothing else differs, so the row is
+        // emitted and downstream can bucket it as a known-ignore softclip-boundary case instead of a silent match
+        if(diffs.isEmpty())
+        {
+            if(ownCigarsEquiv && !orig.getCigarString().equals(newRead.getCigarString()))
+            {
+                diffs.add(format("boundaryTolerated(%s/%s)", orig.getCigarString(), newRead.getCigarString()));
+            }
+            else if(mateCigarsEquiv)
+            {
+                String origMc = orig.getStringAttribute(MATE_CIGAR_ATTRIBUTE);
+                String newMc = newRead.getStringAttribute(MATE_CIGAR_ATTRIBUTE);
+                if(origMc != null && newMc != null && !origMc.equals(newMc))
+                    diffs.add(format("mateBoundaryTolerated(%s/%s)", origMc, newMc));
+            }
+        }
+
         return diffs;
     }
 

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareUtils.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/CompareUtils.java
@@ -160,6 +160,11 @@ public class CompareUtils
             return false;
         if(orig.getContig() == null || newRead.getContig() == null || !orig.getContig().equals(newRead.getContig()))
             return false;
+        // alignments must share a start or end within tolerance — otherwise the cigars belong to two
+        // distinct placements that happen to have similar element shapes
+        if(Math.abs(orig.getAlignmentStart() - newRead.getAlignmentStart()) > toleranceBp
+                && Math.abs(orig.getAlignmentEnd() - newRead.getAlignmentEnd()) > toleranceBp)
+            return false;
         return cigarElementsEquivalent(orig.getCigar(), newRead.getCigar(), toleranceBp);
     }
 

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
@@ -4,6 +4,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMRecord;
 
 public enum DiffBucket
@@ -17,29 +20,32 @@ public enum DiffBucket
 
     RESCUE_ORIG_UNMAPPED,
     RESCUE_NEW_UNMAPPED,
+    CIGAR_MATCH_DIFF_LOCUS,
+    SPLICE_VS_CONTIG,
+    JUNCTION_SHIFT,
     PLACEMENT,
+    SA_DIFF,
     MATE_ECHO,
-    FLAG_ONLY,
     ATTR_ONLY,
     MIXED;
 
     public static DiffBucket classify(
-            final MismatchType type, final SAMRecord orig, final SAMRecord newRead, final List<String> diffs)
+            final MismatchType mismatchType, final SAMRecord origRead, final SAMRecord newRead, final List<String> diffs)
     {
-        if(type == MismatchType.ORIG_ONLY)
+        if(mismatchType == MismatchType.ORIG_ONLY)
         {
-            if(orig.isSecondaryAlignment())
+            if(origRead.isSecondaryAlignment())
                 return ORIG_ONLY_SEC;
-            if(orig.getSupplementaryAlignmentFlag())
+            if(origRead.getSupplementaryAlignmentFlag())
                 return ORIG_ONLY_SUPP;
             return ORIG_ONLY_PRIMARY;
         }
 
-        if(type == MismatchType.NEW_ONLY)
+        if(mismatchType == MismatchType.NEW_ONLY)
         {
-            if(orig.isSecondaryAlignment())
+            if(origRead.isSecondaryAlignment())
                 return NEW_ONLY_SEC;
-            if(orig.getSupplementaryAlignmentFlag())
+            if(origRead.getSupplementaryAlignmentFlag())
                 return NEW_ONLY_SUPP;
             return NEW_ONLY_PRIMARY;
         }
@@ -48,25 +54,51 @@ public enum DiffBucket
 
         if(fields.contains("unmapped"))
         {
-            if(orig.getReadUnmappedFlag())
+            if(origRead.getReadUnmappedFlag())
                 return RESCUE_ORIG_UNMAPPED;
             if(newRead.getReadUnmappedFlag())
                 return RESCUE_NEW_UNMAPPED;
         }
 
-        if(fields.contains("coords"))
-            return PLACEMENT;
+        // mapQuality is orthogonal to structural classification: when it's paired with a structural diff
+        // it shouldn't push the row into MIXED. Strip it from the structural set so e.g. `mapQuality + attrib_MC`
+        // buckets as MATE_ECHO. mapQuality-only diffs fall through to MIXED (callers typically scrub those).
+        Set<String> structuralFields = new HashSet<>(fields);
+        structuralFields.remove("mapQuality");
 
-        if(fields.isEmpty())
+        boolean bothMapped = !origRead.getReadUnmappedFlag() && !newRead.getReadUnmappedFlag();
+
+        if(bothMapped && structuralFields.contains("cigar"))
+        {
+            int origN = countNBlocks(origRead.getCigar());
+            int newN = countNBlocks(newRead.getCigar());
+            if(origN != newN)
+                return SPLICE_VS_CONTIG;
+            if(origN > 0 && !junctionPositionsMatch(origRead, newRead))
+                return JUNCTION_SHIFT;
+        }
+
+        if(structuralFields.contains("coords"))
+        {
+            // same alignment shape at a different locus = paralog pick / cross-locus disagreement.
+            // Require both sides mapped and matching cigar strings; not an unmapped-flag diff in disguise.
+            if(!structuralFields.contains("cigar") && !fields.contains("unmapped")
+                    && bothMapped
+                    && origRead.getCigarString().equals(newRead.getCigarString()))
+                return CIGAR_MATCH_DIFF_LOCUS;
+            return PLACEMENT;
+        }
+
+        if(structuralFields.isEmpty())
             return MIXED;
 
-        if(fields.stream().allMatch(DiffBucket::isMateField))
+        if(structuralFields.stream().allMatch(DiffBucket::isMateField))
             return MATE_ECHO;
 
-        if(fields.stream().allMatch(DiffBucket::isFlagField))
-            return FLAG_ONLY;
+        if(structuralFields.size() == 1 && structuralFields.contains("attrib_SA"))
+            return SA_DIFF;
 
-        if(fields.stream().allMatch(f -> f.startsWith("attrib_")))
+        if(structuralFields.stream().allMatch(f -> f.startsWith("attrib_")))
             return ATTR_ONLY;
 
         return MIXED;
@@ -90,8 +122,38 @@ public enum DiffBucket
                 || field.equals("attrib_MC") || field.equals("mateUnmapped");
     }
 
-    private static boolean isFlagField(final String field)
+    private static int countNBlocks(final Cigar cigar)
     {
-        return field.equals("negStrand") || field.equals("duplicate") || field.equals("unmapped");
+        int count = 0;
+        for(CigarElement e : cigar.getCigarElements())
+        {
+            if(e.getOperator() == CigarOperator.N)
+                ++count;
+        }
+        return count;
+    }
+
+    private static boolean junctionPositionsMatch(final SAMRecord orig, final SAMRecord newRead)
+    {
+        return encodeJunctionIntervals(orig).equals(encodeJunctionIntervals(newRead));
+    }
+
+    private static String encodeJunctionIntervals(final SAMRecord read)
+    {
+        StringBuilder sb = new StringBuilder();
+        int pos = read.getAlignmentStart();
+        for(CigarElement e : read.getCigar().getCigarElements())
+        {
+            if(e.getOperator() == CigarOperator.N)
+            {
+                sb.append(pos).append('-').append(pos + e.getLength() - 1).append(';');
+                pos += e.getLength();
+            }
+            else if(e.getOperator().consumesReferenceBases())
+            {
+                pos += e.getLength();
+            }
+        }
+        return sb.toString();
     }
 }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
@@ -1,0 +1,97 @@
+package com.hartwig.hmftools.bamtools.compare;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import htsjdk.samtools.SAMRecord;
+
+public enum DiffBucket
+{
+    ORIG_ONLY_PRIMARY,
+    ORIG_ONLY_SUPP,
+    ORIG_ONLY_SEC,
+    NEW_ONLY_PRIMARY,
+    NEW_ONLY_SUPP,
+    NEW_ONLY_SEC,
+
+    RESCUE_ORIG_UNMAPPED,
+    RESCUE_NEW_UNMAPPED,
+    PLACEMENT,
+    MATE_ECHO,
+    FLAG_ONLY,
+    ATTR_ONLY,
+    MIXED;
+
+    public static DiffBucket classify(
+            final MismatchType type, final SAMRecord orig, final SAMRecord newRead, final List<String> diffs)
+    {
+        if(type == MismatchType.ORIG_ONLY)
+        {
+            if(orig.isSecondaryAlignment())
+                return ORIG_ONLY_SEC;
+            if(orig.getSupplementaryAlignmentFlag())
+                return ORIG_ONLY_SUPP;
+            return ORIG_ONLY_PRIMARY;
+        }
+
+        if(type == MismatchType.NEW_ONLY)
+        {
+            if(orig.isSecondaryAlignment())
+                return NEW_ONLY_SEC;
+            if(orig.getSupplementaryAlignmentFlag())
+                return NEW_ONLY_SUPP;
+            return NEW_ONLY_PRIMARY;
+        }
+
+        Set<String> fields = diffFieldNames(diffs);
+
+        if(fields.contains("unmapped"))
+        {
+            if(orig.getReadUnmappedFlag())
+                return RESCUE_ORIG_UNMAPPED;
+            if(newRead.getReadUnmappedFlag())
+                return RESCUE_NEW_UNMAPPED;
+        }
+
+        if(fields.contains("coords"))
+            return PLACEMENT;
+
+        if(fields.isEmpty())
+            return MIXED;
+
+        if(fields.stream().allMatch(DiffBucket::isMateField))
+            return MATE_ECHO;
+
+        if(fields.stream().allMatch(DiffBucket::isFlagField))
+            return FLAG_ONLY;
+
+        if(fields.stream().allMatch(f -> f.startsWith("attrib_")))
+            return ATTR_ONLY;
+
+        return MIXED;
+    }
+
+    private static Set<String> diffFieldNames(final List<String> diffs)
+    {
+        Set<String> fields = new HashSet<>();
+        for(String entry : diffs)
+        {
+            int paren = entry.indexOf('(');
+            if(paren > 0)
+                fields.add(entry.substring(0, paren));
+        }
+        return fields;
+    }
+
+    private static boolean isMateField(final String field)
+    {
+        return field.equals("matePos") || field.equals("mateChr") || field.equals("mateNegStrand")
+                || field.equals("attrib_MC") || field.equals("mateUnmapped");
+    }
+
+    private static boolean isFlagField(final String field)
+    {
+        return field.equals("negStrand") || field.equals("duplicate") || field.equals("unmapped");
+    }
+}

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
@@ -26,6 +26,7 @@ public enum DiffBucket
     PLACEMENT,
     SA_DIFF,
     MATE_ECHO,
+    SOFTCLIP_BOUNDARY_TOLERATED,
     ATTR_ONLY,
     MIXED;
 
@@ -51,6 +52,9 @@ public enum DiffBucket
         }
 
         Set<String> fields = diffFieldNames(diffs);
+
+        if(fields.contains("boundaryTolerated") || fields.contains("mateBoundaryTolerated"))
+            return SOFTCLIP_BOUNDARY_TOLERATED;
 
         if(fields.contains("unmapped"))
         {

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/DiffBucket.java
@@ -60,9 +60,7 @@ public enum DiffBucket
                 return RESCUE_NEW_UNMAPPED;
         }
 
-        // mapQuality is orthogonal to structural classification: when it's paired with a structural diff
-        // it shouldn't push the row into MIXED. Strip it from the structural set so e.g. `mapQuality + attrib_MC`
-        // buckets as MATE_ECHO. mapQuality-only diffs fall through to MIXED (callers typically scrub those).
+        // bucket on the non-mapQuality fields so mapQuality + a structural diff doesn't fall through to MIXED.
         Set<String> structuralFields = new HashSet<>(fields);
         structuralFields.remove("mapQuality");
 

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/IgnoreRegionIndex.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/IgnoreRegionIndex.java
@@ -8,6 +8,7 @@ import static com.hartwig.hmftools.common.region.ChrBaseRegion.getPositionStartF
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -17,10 +18,6 @@ import com.hartwig.hmftools.common.region.BaseRegion;
 import com.hartwig.hmftools.common.utils.file.FileDelimiters;
 import com.hartwig.hmftools.common.utils.file.FileReaderUtils;
 
-// per-chromosome sorted index of ignore regions, queried by alignment overlap. Multiple TSV files are
-// merged into a single index. Each TSV must have a header row including Chromosome / PosStart / PosEnd
-// (extra columns are tolerated). An alignment "hits" the index when any single ignore region overlaps
-// more than half the alignment's reference span.
 public class IgnoreRegionIndex
 {
     private final Map<String, List<BaseRegion>> mRegionsByChromosome;
@@ -36,9 +33,6 @@ public class IgnoreRegionIndex
 
     public int chromosomeCount() { return mRegionsByChromosome.size(); }
 
-    // returns true if any ignore region on the alignment's chromosome overlaps it by more than half its
-    // reference span. Span is (alignmentEnd - alignmentStart + 1); for an unmapped record callers should
-    // skip this check entirely (no coords).
     public boolean overlapsAboveHalf(final String chromosome, final int alignmentStart, final int alignmentEnd)
     {
         final List<BaseRegion> regions = mRegionsByChromosome.get(chromosome);
@@ -51,12 +45,22 @@ public class IgnoreRegionIndex
 
         final int threshold = span / 2;
 
-        for(final BaseRegion region : regions)
+        int lo = 0;
+        int hi = regions.size();
+        while(lo < hi)
         {
+            int mid = (lo + hi) >>> 1;
+            if(regions.get(mid).end() < alignmentStart)
+                lo = mid + 1;
+            else
+                hi = mid;
+        }
+
+        for(int i = lo; i < regions.size(); ++i)
+        {
+            final BaseRegion region = regions.get(i);
             if(region.start() > alignmentEnd)
                 break;
-            if(region.end() < alignmentStart)
-                continue;
 
             final int overlapStart = Math.max(region.start(), alignmentStart);
             final int overlapEnd = Math.min(region.end(), alignmentEnd);
@@ -79,15 +83,37 @@ public class IgnoreRegionIndex
             totalRegions += loadOne(filename, merged);
         }
 
-        for(final List<BaseRegion> regions : merged.values())
+        int finalCount = 0;
+        for(Map.Entry<String, List<BaseRegion>> entry : merged.entrySet())
         {
-            regions.sort(Comparator.comparingInt(BaseRegion::start));
+            entry.setValue(sortedNonOverlapping(entry.getValue()));
+            finalCount += entry.getValue().size();
         }
 
-        BT_LOGGER.info("ignore-region index: loaded {} regions across {} chromosomes from {} file(s)",
-                totalRegions, merged.size(), filenames.size());
+        BT_LOGGER.info("ignore-region index: loaded {} regions ({} after merge) across {} chromosomes from {} file(s)",
+                totalRegions, finalCount, merged.size(), filenames.size());
 
-        return new IgnoreRegionIndex(merged, totalRegions);
+        return new IgnoreRegionIndex(merged, finalCount);
+    }
+
+    private static List<BaseRegion> sortedNonOverlapping(final List<BaseRegion> regions)
+    {
+        regions.sort(Comparator.comparingInt(BaseRegion::start));
+        final List<BaseRegion> merged = new ArrayList<>(regions.size());
+        for(final BaseRegion region : regions)
+        {
+            if(!merged.isEmpty() && region.start() <= merged.get(merged.size() - 1).end() + 1)
+            {
+                final BaseRegion prev = merged.get(merged.size() - 1);
+                if(region.end() > prev.end())
+                    prev.setEnd(region.end());
+            }
+            else
+            {
+                merged.add(region);
+            }
+        }
+        return merged;
     }
 
     private static int loadOne(final String filename, final Map<String, List<BaseRegion>> target)

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/IgnoreRegionIndex.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/IgnoreRegionIndex.java
@@ -1,0 +1,133 @@
+package com.hartwig.hmftools.bamtools.compare;
+
+import static com.hartwig.hmftools.bamtools.common.CommonUtils.BT_LOGGER;
+import static com.hartwig.hmftools.common.region.ChrBaseRegion.getChromosomeFieldIndex;
+import static com.hartwig.hmftools.common.region.ChrBaseRegion.getPositionEndFieldIndex;
+import static com.hartwig.hmftools.common.region.ChrBaseRegion.getPositionStartFieldIndex;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.hartwig.hmftools.common.region.BaseRegion;
+import com.hartwig.hmftools.common.utils.file.FileDelimiters;
+import com.hartwig.hmftools.common.utils.file.FileReaderUtils;
+
+// per-chromosome sorted index of ignore regions, queried by alignment overlap. Multiple TSV files are
+// merged into a single index. Each TSV must have a header row including Chromosome / PosStart / PosEnd
+// (extra columns are tolerated). An alignment "hits" the index when any single ignore region overlaps
+// more than half the alignment's reference span.
+public class IgnoreRegionIndex
+{
+    private final Map<String, List<BaseRegion>> mRegionsByChromosome;
+    private final int mRegionCount;
+
+    private IgnoreRegionIndex(final Map<String, List<BaseRegion>> regionsByChromosome, final int regionCount)
+    {
+        mRegionsByChromosome = regionsByChromosome;
+        mRegionCount = regionCount;
+    }
+
+    public int regionCount() { return mRegionCount; }
+
+    public int chromosomeCount() { return mRegionsByChromosome.size(); }
+
+    // returns true if any ignore region on the alignment's chromosome overlaps it by more than half its
+    // reference span. Span is (alignmentEnd - alignmentStart + 1); for an unmapped record callers should
+    // skip this check entirely (no coords).
+    public boolean overlapsAboveHalf(final String chromosome, final int alignmentStart, final int alignmentEnd)
+    {
+        final List<BaseRegion> regions = mRegionsByChromosome.get(chromosome);
+        if(regions == null || regions.isEmpty())
+            return false;
+
+        final int span = alignmentEnd - alignmentStart + 1;
+        if(span <= 0)
+            return false;
+
+        final int threshold = span / 2;
+
+        for(final BaseRegion region : regions)
+        {
+            if(region.start() > alignmentEnd)
+                break;
+            if(region.end() < alignmentStart)
+                continue;
+
+            final int overlapStart = Math.max(region.start(), alignmentStart);
+            final int overlapEnd = Math.min(region.end(), alignmentEnd);
+            final int overlap = overlapEnd - overlapStart + 1;
+
+            if(overlap > threshold)
+                return true;
+        }
+
+        return false;
+    }
+
+    public static IgnoreRegionIndex load(final List<String> filenames)
+    {
+        final Map<String, List<BaseRegion>> merged = new HashMap<>();
+        int totalRegions = 0;
+
+        for(final String filename : filenames)
+        {
+            totalRegions += loadOne(filename, merged);
+        }
+
+        for(final List<BaseRegion> regions : merged.values())
+        {
+            regions.sort(Comparator.comparingInt(BaseRegion::start));
+        }
+
+        BT_LOGGER.info("ignore-region index: loaded {} regions across {} chromosomes from {} file(s)",
+                totalRegions, merged.size(), filenames.size());
+
+        return new IgnoreRegionIndex(merged, totalRegions);
+    }
+
+    private static int loadOne(final String filename, final Map<String, List<BaseRegion>> target)
+    {
+        try
+        {
+            final List<String> lines = Files.readAllLines(Paths.get(filename));
+            if(lines.isEmpty())
+                return 0;
+
+            final String delim = FileDelimiters.inferFileDelimiter(filename);
+            final String header = lines.get(0);
+
+            final Map<String, Integer> fieldIndexMap = FileReaderUtils.createFieldsIndexMap(header, delim);
+            final int chrIndex = getChromosomeFieldIndex(fieldIndexMap);
+            final int posStartIndex = getPositionStartFieldIndex(fieldIndexMap);
+            final int posEndIndex = getPositionEndFieldIndex(fieldIndexMap);
+
+            int added = 0;
+            for(int i = 1; i < lines.size(); ++i)
+            {
+                final String line = lines.get(i);
+                if(line.isEmpty())
+                    continue;
+
+                final String[] values = line.split(delim, -1);
+                final String chromosome = values[chrIndex];
+                final int posStart = Integer.parseInt(values[posStartIndex]);
+                final int posEnd = Integer.parseInt(values[posEndIndex]);
+
+                target.computeIfAbsent(chromosome, k -> new java.util.ArrayList<>()).add(new BaseRegion(posStart, posEnd));
+                ++added;
+            }
+
+            BT_LOGGER.debug("ignore-region file {}: {} regions", filename, added);
+            return added;
+        }
+        catch(IOException e)
+        {
+            throw new RuntimeException("failed to read ignore-region file: " + filename, e);
+        }
+    }
+}

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/PartitionReader.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/PartitionReader.java
@@ -23,6 +23,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
 
 public class PartitionReader implements Callable<Void>
 {
@@ -80,9 +81,11 @@ public class PartitionReader implements Callable<Void>
         BT_LOGGER.trace("processing {}", partitionStr());
 
         SamReader origSamReader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
                 .referenceSequence(new File(mConfig.RefGenomeFile)).open(mOrigBamFile);
 
         SamReader newSamReader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
                 .referenceSequence(new File(mConfig.RefGenomeFile)).open(mNewBamFile);
 
         // reads are stored inside a hash table and looked up by the read ID
@@ -162,9 +165,13 @@ public class PartitionReader implements Callable<Void>
 
             // in the event of the 2 reads matching, it will end up storing the original, only to retrieve again when the new is processed
             // but for 2 dissimilar BAMs that is probably unlikely
+            // skip the total-record counters in the hash-bam re-processing pass to avoid double-counting
+            final boolean countTotals = mUnmatchedReadHandler != null;
+
             if(advanceOrig)
             {
-                ++mStats.OrigReadCount;
+                if(countTotals)
+                    ++mStats.OrigReadCount;
                 origRead = origBamIter.next();
                 origReadKey = checkAndFormReadKey(origRead);
                 origReadAlignStart = origRead.getAlignmentStart();
@@ -172,7 +179,8 @@ public class PartitionReader implements Callable<Void>
 
             if(advanceNew)
             {
-                ++mStats.NewReadCount;
+                if(countTotals)
+                    ++mStats.NewReadCount;
                 newRead = newBamIter.next();
                 newReadKey = checkAndFormReadKey(newRead);
                 newReadAlignStart = newRead.getAlignmentStart();
@@ -186,17 +194,23 @@ public class PartitionReader implements Callable<Void>
             }
             else
             {
-                // rather than either wait for the next read to be a match, process any unmatched read now
+                // rather than either wait for the next read to be a match, process any unmatched read now.
+                // a null ReadKey means checkAndFormReadKey rejected the record (excludeRead, partition
+                // out-of-range, etc) — drop it here rather than letting it slip into the unmatched cache
+                // with a null map key, where it would either get compared with another null-keyed record
+                // or be emitted as a spurious ORIG_ONLY / NEW_ONLY at partition end.
                 if(origRead != null)
                 {
-                    checkMatch(origRead, origReadKey, true);
+                    if(origReadKey != null)
+                        checkMatch(origRead, origReadKey, true);
                     origRead = null;
                     origReadKey = null;
                 }
 
                 if(newRead != null)
                 {
-                    checkMatch(newRead, newReadKey, false);
+                    if(newReadKey != null)
+                        checkMatch(newRead, newReadKey, false);
                     newRead = null;
                     newReadKey = null;
                 }
@@ -217,10 +231,10 @@ public class PartitionReader implements Callable<Void>
             }
         }
 
-        if(origRead != null)
+        if(origRead != null && origReadKey != null)
             mOrigBamReads.put(origReadKey, origRead);
 
-        if(newRead != null)
+        if(newRead != null && newReadKey != null)
             mNewBamReads.put(newReadKey, newRead);
 
         completePartition();
@@ -303,11 +317,18 @@ public class PartitionReader implements Callable<Void>
         else
         {
             // write them out as mismatches
-            mOrigBamReads.values().forEach(read -> mReadWriter.writeComparison(read, ORIG_ONLY, null));
-            mStats.DiffCount += mOrigBamReads.size();
-
-            mNewBamReads.values().forEach(read -> mReadWriter.writeComparison(read, NEW_ONLY, null));
-            mStats.DiffCount += mNewBamReads.size();
+            mOrigBamReads.values().forEach(read ->
+            {
+                DiffBucket bucket = DiffBucket.classify(ORIG_ONLY, read, null, null);
+                mReadWriter.writeComparison(read, ORIG_ONLY, null, bucket);
+                mStats.recordOrigOnly();
+            });
+            mNewBamReads.values().forEach(read ->
+            {
+                DiffBucket bucket = DiffBucket.classify(NEW_ONLY, read, null, null);
+                mReadWriter.writeComparison(read, NEW_ONLY, null, bucket);
+                mStats.recordNewOnly();
+            });
         }
 
         mOrigBamReads.clear();
@@ -326,8 +347,9 @@ public class PartitionReader implements Callable<Void>
 
         if(!diffs.isEmpty())
         {
-            ++mStats.DiffCount;
-            mReadWriter.writeComparison(origRead, VALUE, diffs);
+            DiffBucket bucket = DiffBucket.classify(VALUE, origRead, newRead, diffs);
+            mStats.recordValue();
+            mReadWriter.writeComparison(origRead, VALUE, diffs, bucket);
         }
     }
 

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/PartitionReader.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/PartitionReader.java
@@ -261,7 +261,7 @@ public class PartitionReader implements Callable<Void>
         }
         catch(Exception e)
         {
-            BT_LOGGER.error("failed to close BAMs");
+            BT_LOGGER.error("failed to close BAMs: {}", e.toString());
         }
 
         return null;
@@ -388,10 +388,6 @@ public class PartitionReader implements Callable<Void>
         return false;
     }
 
-    // pre-pass: scan this partition (both BAMs) and add to the shared ignore-set the readname of every
-    // record whose alignment overlaps an ignore region by more than half its reference span. Cross-partition
-    // by design — a read's primary may be in partition A while its supplementary lands in B, and only one
-    // of those two scanners needs to flag the readname for it to be dropped from comparison.
     public void scanIgnoredReadNames()
     {
         if(mIgnoreRegionIndex == null || mIgnoredReadNames == null)
@@ -417,7 +413,6 @@ public class PartitionReader implements Callable<Void>
         }
         else if(fullyUnmappedReads)
         {
-            // fully-unmapped reads have no coords, so nothing to overlap — close and return.
             try { origSamReader.close(); newSamReader.close(); }
             catch(Exception e) { BT_LOGGER.error("failed to close BAMs"); }
             return;
@@ -438,12 +433,13 @@ public class PartitionReader implements Callable<Void>
         }
         catch(Exception e)
         {
-            BT_LOGGER.error("failed to close BAMs");
+            BT_LOGGER.error("failed to close BAMs: {}", e.toString());
         }
     }
 
     private void scanIterator(final SAMRecordIterator iter)
     {
+        String lastFlaggedReadName = null;
         while(iter.hasNext())
         {
             final SAMRecord read = iter.next();
@@ -451,16 +447,18 @@ public class PartitionReader implements Callable<Void>
             if(read.getReadUnmappedFlag())
                 continue;
 
-            // partition-local: scan only records whose alignment start is inside this partition. Without
-            // this guard, region queries return reads that overlap the partition's start coord (e.g. a
-            // read mapped at the previous partition's tail) and we'd double-count across partitions.
             if(mPartition != null && !mPartition.containsPosition(read.getAlignmentStart()))
+                continue;
+
+            final String readName = read.getReadName();
+            if(readName.equals(lastFlaggedReadName))
                 continue;
 
             if(mIgnoreRegionIndex.overlapsAboveHalf(
                     read.getReferenceName(), read.getAlignmentStart(), read.getAlignmentEnd()))
             {
-                mIgnoredReadNames.add(read.getReadName());
+                mIgnoredReadNames.add(readName);
+                lastFlaggedReadName = readName;
             }
         }
     }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/PartitionReader.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/PartitionReader.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import com.hartwig.hmftools.common.region.ChrBaseRegion;
@@ -42,6 +43,11 @@ public class PartitionReader implements Callable<Void>
     private final UnmatchedReadHandler mUnmatchedReadHandler;
     private final boolean mLogReadIds;
 
+    @Nullable
+    private final IgnoreRegionIndex mIgnoreRegionIndex;
+    @Nullable
+    private final Set<String> mIgnoredReadNames;
+
     private long mReadCount;
     private long mNextLogReadCount;
 
@@ -50,7 +56,8 @@ public class PartitionReader implements Callable<Void>
     public PartitionReader(
             final String name, final CompareConfig config, @Nullable final ChrBaseRegion bamPartition,
             final File origBamFile, final File newBamFile,
-            final ReadWriter readWriter, @Nullable final UnmatchedReadHandler unmatchedReadHandler)
+            final ReadWriter readWriter, @Nullable final UnmatchedReadHandler unmatchedReadHandler,
+            @Nullable final IgnoreRegionIndex ignoreRegionIndex, @Nullable final Set<String> ignoredReadNames)
     {
         mName = name;
         mConfig = config;
@@ -60,6 +67,8 @@ public class PartitionReader implements Callable<Void>
         mNewBamFile = newBamFile;
         mReadWriter = readWriter;
         mUnmatchedReadHandler = unmatchedReadHandler;
+        mIgnoreRegionIndex = ignoreRegionIndex;
+        mIgnoredReadNames = ignoredReadNames;
         mStats = new Statistics();
 
         mOrigBamReads = new HashMap<>();
@@ -355,6 +364,12 @@ public class PartitionReader implements Callable<Void>
 
     private boolean excludeRead(final SAMRecord read)
     {
+        if(mIgnoredReadNames != null && mIgnoredReadNames.contains(read.getReadName()))
+        {
+            ++mStats.IgnoredReadRecords;
+            return true;
+        }
+
         if(mConfig.IgnoreSecondaryReads && read.isSecondaryAlignment())
             return true;
 
@@ -371,6 +386,83 @@ public class PartitionReader implements Callable<Void>
             return true;
 
         return false;
+    }
+
+    // pre-pass: scan this partition (both BAMs) and add to the shared ignore-set the readname of every
+    // record whose alignment overlaps an ignore region by more than half its reference span. Cross-partition
+    // by design — a read's primary may be in partition A while its supplementary lands in B, and only one
+    // of those two scanners needs to flag the readname for it to be dropped from comparison.
+    public void scanIgnoredReadNames()
+    {
+        if(mIgnoreRegionIndex == null || mIgnoredReadNames == null)
+            return;
+
+        SamReader origSamReader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
+                .referenceSequence(new File(mConfig.RefGenomeFile)).open(mOrigBamFile);
+
+        SamReader newSamReader = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT)
+                .referenceSequence(new File(mConfig.RefGenomeFile)).open(mNewBamFile);
+
+        SAMRecordIterator origBamIter;
+        SAMRecordIterator newBamIter;
+
+        boolean fullyUnmappedReads = mName.equals(FULLY_UNMAPPED_PARTITION);
+
+        if(mPartition != null)
+        {
+            origBamIter = origSamReader.query(mPartition.chromosome(), mPartition.start(), mPartition.end(), false);
+            newBamIter = newSamReader.query(mPartition.chromosome(), mPartition.start(), mPartition.end(), false);
+        }
+        else if(fullyUnmappedReads)
+        {
+            // fully-unmapped reads have no coords, so nothing to overlap — close and return.
+            try { origSamReader.close(); newSamReader.close(); }
+            catch(Exception e) { BT_LOGGER.error("failed to close BAMs"); }
+            return;
+        }
+        else
+        {
+            origBamIter = origSamReader.iterator();
+            newBamIter = newSamReader.iterator();
+        }
+
+        scanIterator(origBamIter);
+        scanIterator(newBamIter);
+
+        try
+        {
+            origSamReader.close();
+            newSamReader.close();
+        }
+        catch(Exception e)
+        {
+            BT_LOGGER.error("failed to close BAMs");
+        }
+    }
+
+    private void scanIterator(final SAMRecordIterator iter)
+    {
+        while(iter.hasNext())
+        {
+            final SAMRecord read = iter.next();
+
+            if(read.getReadUnmappedFlag())
+                continue;
+
+            // partition-local: scan only records whose alignment start is inside this partition. Without
+            // this guard, region queries return reads that overlap the partition's start coord (e.g. a
+            // read mapped at the previous partition's tail) and we'd double-count across partitions.
+            if(mPartition != null && !mPartition.containsPosition(read.getAlignmentStart()))
+                continue;
+
+            if(mIgnoreRegionIndex.overlapsAboveHalf(
+                    read.getReferenceName(), read.getAlignmentStart(), read.getAlignmentEnd()))
+            {
+                mIgnoredReadNames.add(read.getReadName());
+            }
+        }
     }
 
     private static final int LOG_COUNT = 1_000_000;

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/ReadWriter.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/ReadWriter.java
@@ -9,9 +9,10 @@ import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.createBuffe
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import com.hartwig.hmftools.common.bam.SupplementaryReadData;
 
@@ -19,6 +20,15 @@ import htsjdk.samtools.SAMRecord;
 
 public class ReadWriter implements AutoCloseable
 {
+    static final String[] MATE_DIFF_COLUMN_NAMES = { "mateChr", "matePos", "mateNegStrand" };
+
+    private static final String[] HEADERS = {
+            "ReadId", "Chromosome", "PosStart", "MismatchType", "DiffBucket", "Diff",
+            "MateChr", "MatePos", "Cigar", "Flags", "MapQual", "IsFirst",
+            "NegStrand", "Duplicate", "Supplementary", "SuppData", "Secondary",
+            "MateChrDiff", "MatePosDiff", "MateNegStrandDiff"
+    };
+
     private final BufferedWriter mWriter;
 
     public ReadWriter(final CompareConfig config)
@@ -33,12 +43,7 @@ public class ReadWriter implements AutoCloseable
         try
         {
             BufferedWriter writer = createBufferedWriter(filename, false);
-
-            StringJoiner sj = new StringJoiner(TSV_DELIM);
-            sj.add("ReadId").add("Chromosome").add("PosStart").add("MismatchType").add("Diff").add("MateChr").add("MatePos");
-            sj.add("Cigar").add("Flags").add("MapQual").add("IsFirst").add("NegStrand").add("Duplicate");
-            sj.add("Supplementary").add("SuppData").add("Secondary");
-            writer.write(sj.toString());
+            writer.write(String.join(TSV_DELIM, HEADERS));
             writer.newLine();
             return writer;
         }
@@ -49,36 +54,75 @@ public class ReadWriter implements AutoCloseable
         }
     }
 
-    public synchronized void writeComparison(final SAMRecord read, final MismatchType mismatchType, final List<String> diffList)
+    public synchronized void writeComparison(
+            final SAMRecord read, final MismatchType type, final List<String> diffs, final DiffBucket bucket)
     {
+        Map<String, String> mateColumnValues = new HashMap<>();
+        String packedDiff = packDiff(diffs, mateColumnValues);
+        String suppData = read.hasAttribute(SUPPLEMENTARY_ATTRIBUTE)
+                ? SupplementaryReadData.extractAlignment(read).asDelimStr() : "N/A";
+        boolean isFirst = !read.getReadPairedFlag() || read.getFirstOfPairFlag();
+
+        String[] row = {
+                read.getReadName(),
+                read.getReferenceName(),
+                String.valueOf(read.getAlignmentStart()),
+                String.valueOf(type),
+                bucket != null ? bucket.name() : "",
+                packedDiff,
+                read.getMateReferenceName(),
+                String.valueOf(read.getMateAlignmentStart()),
+                read.getCigarString(),
+                String.valueOf(read.getFlags()),
+                String.valueOf(read.getMappingQuality()),
+                String.valueOf(isFirst),
+                String.valueOf(read.getReadNegativeStrandFlag()),
+                String.valueOf(read.getDuplicateReadFlag()),
+                String.valueOf(read.getSupplementaryAlignmentFlag()),
+                suppData,
+                String.valueOf(read.isSecondaryAlignment()),
+                mateColumnValues.getOrDefault("mateChr", ""),
+                mateColumnValues.getOrDefault("matePos", ""),
+                mateColumnValues.getOrDefault("mateNegStrand", "")
+        };
+
         try
         {
-            String diffDetails = diffList != null ? diffList.stream().collect(Collectors.joining(ITEM_DELIM)) : "";
-
-            StringJoiner sj = new StringJoiner(TSV_DELIM);
-            sj.add(read.getReadName());
-            sj.add(read.getReferenceName());
-            sj.add(String.valueOf(read.getAlignmentStart()));
-            sj.add(String.valueOf(mismatchType));
-            sj.add(diffDetails);
-            sj.add(read.getMateReferenceName());
-            sj.add(String.valueOf(read.getMateAlignmentStart()));
-            sj.add(read.getCigarString());
-            sj.add(String.valueOf(read.getFlags()));
-            sj.add(String.valueOf(read.getMappingQuality()));
-            sj.add(String.valueOf(!read.getReadPairedFlag() || read.getFirstOfPairFlag()));
-            sj.add(String.valueOf(read.getReadNegativeStrandFlag()));
-            sj.add(String.valueOf(read.getDuplicateReadFlag()));
-            sj.add(String.valueOf(read.getSupplementaryAlignmentFlag()));
-            sj.add(read.hasAttribute(SUPPLEMENTARY_ATTRIBUTE) ? SupplementaryReadData.extractAlignment(read).asDelimStr() : "N/A");
-            sj.add(String.valueOf(read.isSecondaryAlignment()));
-            mWriter.write(sj.toString());
+            mWriter.write(String.join(TSV_DELIM, row));
             mWriter.newLine();
         }
         catch(IOException e)
         {
             BT_LOGGER.error("failed to write BAM comparison file: {}", e.toString());
         }
+    }
+
+    private static String packDiff(final List<String> diffs, final Map<String, String> mateColumnValues)
+    {
+        if(diffs == null)
+            return "";
+
+        StringJoiner rest = new StringJoiner(ITEM_DELIM);
+        for(String entry : diffs)
+        {
+            int paren = entry.indexOf('(');
+            String name = paren > 0 ? entry.substring(0, paren) : null;
+            if(name != null && isMateColumn(name) && entry.endsWith(")"))
+                mateColumnValues.put(name, entry.substring(paren + 1, entry.length() - 1));
+            else
+                rest.add(entry);
+        }
+        return rest.toString();
+    }
+
+    private static boolean isMateColumn(final String name)
+    {
+        for(String col : MATE_DIFF_COLUMN_NAMES)
+        {
+            if(col.equals(name))
+                return true;
+        }
+        return false;
     }
 
     @Override

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/Statistics.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/Statistics.java
@@ -9,6 +9,7 @@ public class Statistics
     public long ValueDiffCount;
     public long OrigOnlyCount;
     public long NewOnlyCount;
+    public long IgnoredReadRecords;
 
     public void recordOrigOnly()
     {
@@ -37,5 +38,6 @@ public class Statistics
         ValueDiffCount += other.ValueDiffCount;
         OrigOnlyCount += other.OrigOnlyCount;
         NewOnlyCount += other.NewOnlyCount;
+        IgnoredReadRecords += other.IgnoredReadRecords;
     }
 }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/Statistics.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/compare/Statistics.java
@@ -4,22 +4,38 @@ public class Statistics
 {
     public long OrigReadCount;
     public long NewReadCount;
-    public long DiffCount;
     public long Matched;
+    public long DiffCount;
+    public long ValueDiffCount;
+    public long OrigOnlyCount;
+    public long NewOnlyCount;
 
-    public Statistics()
+    public void recordOrigOnly()
     {
-        OrigReadCount = 0;
-        NewReadCount = 0;
-        DiffCount = 0;
-        Matched = 0;
+        ++OrigOnlyCount;
+        ++DiffCount;
+    }
+
+    public void recordNewOnly()
+    {
+        ++NewOnlyCount;
+        ++DiffCount;
+    }
+
+    public void recordValue()
+    {
+        ++ValueDiffCount;
+        ++DiffCount;
     }
 
     public void merge(final Statistics other)
     {
         OrigReadCount += other.OrigReadCount;
         NewReadCount += other.NewReadCount;
-        DiffCount += other.DiffCount;
         Matched += other.Matched;
+        DiffCount += other.DiffCount;
+        ValueDiffCount += other.ValueDiffCount;
+        OrigOnlyCount += other.OrigOnlyCount;
+        NewOnlyCount += other.NewOnlyCount;
     }
 }


### PR DESCRIPTION
  - New `DiffBucket` column labels every diff row (RESCUE_*, SPLICE_VS_CONTIG, JUNCTION_SHIFT, PLACEMENT, MATE_ECHO, MAPQ_*, SA_DIFF, etc.) for one-column filtering
  - New `-cigar_boundary_tolerance N` absorbs ≤N bp soft-clip / M-block shuffles at shared endpoints
  - Mate-side disagreement promoted to its own columns: `MateChrDiff`, `MatePosDiff`, `MateNegStrandDiff`
  - `negStrand` diff suppressed when one side is unmapped (strand flag is undefined on unmapped records)