### PR TITLE
Document PEACH resource file location

### DIFF
--- a/peach/README.md
+++ b/peach/README.md
@@ -38,7 +38,7 @@ To install, download the latest compiled jar file from the [download links](#ver
 
 PEACH requires Java 17+.
 
-TODO: Add link to config files
+PEACH resource file names are documented in the [pipeline resource overview](../pipeline/README_RESOURCES.md#peach).
 
 ## Arguments
 ### Example Usage


### PR DESCRIPTION
## Summary
- Replace the PEACH README config-file TODO with a link to the existing pipeline resource overview.
- Point users to the documented PEACH resource filenames instead of leaving the installation section incomplete.

## Testing
- Not run; documentation-only change.