### PR TITLE
ESVEE: use SAGA breakends for unchained phased assemblies

### DIFF
--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignData.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignData.java
@@ -136,10 +136,12 @@ public class AlignData
     public String cigar() { return mCigar; }
     public String xaTag() { return mXaTag; }
     public String mdTag() { return mMdTag; }
+
     public Orientation orientation() { return mOrientation; }
     public boolean isForward() { return mOrientation.isForward(); }
     public boolean isReverse() { return mOrientation.isReverse(); }
     public boolean isSupplementary() { return SamRecordUtils.isFlagSet(mFlags, SUPPLEMENTARY_ALIGNMENT); }
+
     public int leftSoftClipLength() { return mSoftClipLeft; }
     public int rightSoftClipLength() { return mSoftClipRight; }
     public int alignedBases() { return mAlignedBases; }
@@ -175,9 +177,7 @@ public class AlignData
     }
 
     public void markDroppedOnRequery() { mDroppedOnRequery = true; }
-
     public boolean droppedOnRequery() { return mDroppedOnRequery; }
-
     public boolean isRequery() { return mIsRequery; }
 
     public void setRequeriedSequenceCoords(int sequenceStart, int sequenceEnd)
@@ -189,17 +189,14 @@ public class AlignData
     }
 
     public int sequenceStart() { return mSequenceStart; }
-
     public int sequenceEnd() { return mSequenceEnd; }
 
     public int rawSequenceStart() { return mRawSequenceStart; }
-
     public int rawSequenceEnd() { return mRawSequenceEnd; }
 
     public List<CigarElement> cigarElements() { return mCigarElements; }
 
     public int adjustedAlignment() { return mAdjustedAlignment; }
-
     public double modifiedMapQual() { return mModifiedMapQual; }
 
     private int calcAdjustedIndelScore()
@@ -324,11 +321,8 @@ public class AlignData
     }
 
     public boolean hasLowMapQualAlignment() { return mSelectedAltAlignment != null || mUnselectedAltAlignments != null; }
-
     public boolean hasSelectedAltAlignment() { return mSelectedAltAlignment != null; }
-
     public boolean hasLowMapQualShortSvLink() { return mHasLowMapQualShortSvLink; }
-
     public AlternativeAlignment selectedAltAlignment() { return mSelectedAltAlignment; }
 
     public void setSelectedAltAlignments(

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignData.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignData.java
@@ -19,7 +19,6 @@ import static com.hartwig.hmftools.esvee.assembly.AssemblyConstants.BWA_GAP_OPEN
 import static com.hartwig.hmftools.esvee.assembly.AssemblyConstants.MULTI_MAPPED_ALT_ALIGNMENT_REGIONS_V37;
 import static com.hartwig.hmftools.esvee.assembly.AssemblyConstants.MULTI_MAPPED_ALT_ALIGNMENT_REGIONS_V38;
 import static com.hartwig.hmftools.esvee.assembly.types.RepeatInfo.calcTrimmedBaseLength;
-import static com.hartwig.hmftools.esvee.common.FilterType.MIN_LENGTH;
 import static com.hartwig.hmftools.esvee.common.SvConstants.MIN_VARIANT_LENGTH;
 
 import static htsjdk.samtools.CigarOperator.D;
@@ -39,6 +38,7 @@ import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.genome.region.Orientation;
 import com.hartwig.hmftools.common.region.ChrBaseRegion;
 import com.hartwig.hmftools.esvee.assembly.types.RepeatInfo;
+import com.hartwig.hmftools.esvee.common.saga.SagaAlignment;
 
 import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignment;
 
@@ -46,7 +46,7 @@ import htsjdk.samtools.CigarElement;
 
 public class AlignData
 {
-    private ChrBaseRegion mRefLocation;
+    private final ChrBaseRegion mRefLocation;
     private final int mMapQual;
     private final int mNMatches;
     private final int mScore;
@@ -59,11 +59,11 @@ public class AlignData
     private int mSoftClipLeft;
     private int mSoftClipRight;
 
-    private Orientation mOrientation;
+    private final Orientation mOrientation;
     private final int mAlignedBases;
 
-    private int mRawSequenceStart;
-    private int mRawSequenceEnd;
+    private final int mRawSequenceStart;
+    private final int mRawSequenceEnd;
     private int mSequenceStart;
     private int mSequenceEnd;
     private boolean mDroppedOnRequery;
@@ -109,7 +109,7 @@ public class AlignData
         }
 
         mOrientation = SamRecordUtils.isFlagSet(mFlags, READ_REVERSE_STRAND) ? REVERSE : FORWARD;
-        mAlignedBases = mCigarElements.stream().filter(x -> x.getOperator() == M).mapToInt(x -> x.getLength()).sum();
+        mAlignedBases = mCigarElements.stream().filter(x -> x.getOperator() == M).mapToInt(CigarElement::getLength).sum();
 
         mSequenceStart = sequenceStart;
         mSequenceEnd = max(sequenceEnd - 1, 0);
@@ -126,25 +126,41 @@ public class AlignData
     }
 
     public ChrBaseRegion refLocation() { return mRefLocation; }
+
     public String chromosome() { return mRefLocation.Chromosome; }
+
     public int positionStart() { return mRefLocation.start(); }
+
     public int positionEnd() { return mRefLocation.end(); }
+
     public int mapQual() { return mMapQual; }
+
     public int nMatches() { return mNMatches; }
+
     public int score() { return mScore; }
+
     public int flags() { return mFlags; }
+
     public String cigar() { return mCigar; }
+
     public String xaTag() { return mXaTag; }
+
     public String mdTag() { return mMdTag; }
 
     public Orientation orientation() { return mOrientation; }
+
     public boolean isForward() { return mOrientation.isForward(); }
+
     public boolean isReverse() { return mOrientation.isReverse(); }
+
     public boolean isSupplementary() { return SamRecordUtils.isFlagSet(mFlags, SUPPLEMENTARY_ALIGNMENT); }
 
     public int leftSoftClipLength() { return mSoftClipLeft; }
+
     public int rightSoftClipLength() { return mSoftClipRight; }
+
     public int alignedBases() { return mAlignedBases; }
+
     public int segmentLength() { return mSequenceEnd - mSequenceStart + 1; }
 
     public void setSoftClipLengths(int left, int right)
@@ -177,7 +193,9 @@ public class AlignData
     }
 
     public void markDroppedOnRequery() { mDroppedOnRequery = true; }
+
     public boolean droppedOnRequery() { return mDroppedOnRequery; }
+
     public boolean isRequery() { return mIsRequery; }
 
     public void setRequeriedSequenceCoords(int sequenceStart, int sequenceEnd)
@@ -189,14 +207,17 @@ public class AlignData
     }
 
     public int sequenceStart() { return mSequenceStart; }
+
     public int sequenceEnd() { return mSequenceEnd; }
 
     public int rawSequenceStart() { return mRawSequenceStart; }
+
     public int rawSequenceEnd() { return mRawSequenceEnd; }
 
     public List<CigarElement> cigarElements() { return mCigarElements; }
 
     public int adjustedAlignment() { return mAdjustedAlignment; }
+
     public double modifiedMapQual() { return mModifiedMapQual; }
 
     private int calcAdjustedIndelScore()
@@ -321,8 +342,11 @@ public class AlignData
     }
 
     public boolean hasLowMapQualAlignment() { return mSelectedAltAlignment != null || mUnselectedAltAlignments != null; }
+
     public boolean hasSelectedAltAlignment() { return mSelectedAltAlignment != null; }
+
     public boolean hasLowMapQualShortSvLink() { return mHasLowMapQualShortSvLink; }
+
     public AlternativeAlignment selectedAltAlignment() { return mSelectedAltAlignment; }
 
     public void setSelectedAltAlignments(
@@ -354,7 +378,7 @@ public class AlignData
         return mRefLocation.compareTo(other.mRefLocation) < 0;
     }
 
-    public static AlignData from(final BwaMemAlignment alignment, final RefGenomeVersion refGenomeVersion)
+    public static AlignData fromRef(final BwaMemAlignment alignment, final RefGenomeVersion refGenomeVersion)
     {
         int chrIndex = alignment.getRefId();
 
@@ -368,6 +392,15 @@ public class AlignData
                 new ChrBaseRegion(chromosome, alignment.getRefStart() + 1, alignment.getRefEnd()),
                 alignment.getSeqStart(), alignment.getSeqEnd(), alignment.getMapQual(), alignment.getAlignerScore(),
                 alignment.getSamFlag(), alignment.getCigar(), alignment.getNMismatches(), alignment.getXATag(), alignment.getMDTag());
+    }
+
+    public static AlignData fromSaga(final SagaAlignment alignment)
+    {
+        BwaMemAlignment rawAlignment = alignment.rawAlignment();
+        return new AlignData(
+                new ChrBaseRegion(alignment.sagaVariant().id(), alignment.sagaStart() + 1, alignment.sagaEnd()),
+                alignment.queryStart(), alignment.queryEnd(), rawAlignment.getMapQual(), rawAlignment.getAlignerScore(),
+                rawAlignment.getSamFlag(), rawAlignment.getCigar(), rawAlignment.getNMismatches(), rawAlignment.getXATag(), rawAlignment.getMDTag());
     }
 
     public String toString()

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignData.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignData.java
@@ -126,41 +126,23 @@ public class AlignData
     }
 
     public ChrBaseRegion refLocation() { return mRefLocation; }
-
     public String chromosome() { return mRefLocation.Chromosome; }
-
     public int positionStart() { return mRefLocation.start(); }
-
     public int positionEnd() { return mRefLocation.end(); }
-
     public int mapQual() { return mMapQual; }
-
     public int nMatches() { return mNMatches; }
-
     public int score() { return mScore; }
-
     public int flags() { return mFlags; }
-
     public String cigar() { return mCigar; }
-
     public String xaTag() { return mXaTag; }
-
     public String mdTag() { return mMdTag; }
-
     public Orientation orientation() { return mOrientation; }
-
     public boolean isForward() { return mOrientation.isForward(); }
-
     public boolean isReverse() { return mOrientation.isReverse(); }
-
     public boolean isSupplementary() { return SamRecordUtils.isFlagSet(mFlags, SUPPLEMENTARY_ALIGNMENT); }
-
     public int leftSoftClipLength() { return mSoftClipLeft; }
-
     public int rightSoftClipLength() { return mSoftClipRight; }
-
     public int alignedBases() { return mAlignedBases; }
-
     public int segmentLength() { return mSequenceEnd - mSequenceStart + 1; }
 
     public void setSoftClipLengths(int left, int right)

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignmentFragments.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AlignmentFragments.java
@@ -46,7 +46,7 @@ public class AlignmentFragments
         }
     }
 
-    private class FragmentReads
+    private static class FragmentReads
     {
         public final List<SupportRead> PrimaryReads;
         public final List<SupportRead> DuplicateReads; // identical reads from another assembly
@@ -538,7 +538,7 @@ public class AlignmentFragments
         return -1;
     }
 
-    private class ReadBreakendMatch
+    private static class ReadBreakendMatch
     {
         public final boolean IsSplit;
         public final Breakend Breakend;
@@ -600,7 +600,7 @@ public class AlignmentFragments
 
         // next a misaligned junction read - crossing the segment boundary
         int readSeqIndexStart = read.fullAssemblyIndexStart();
-        int readSeqIndexEnd = read.fullAssemblyIndexEnd();
+        int readSeqIndexEnd = read.fullAssemblyIndexEnd();  // inclusive bound
 
         int fullSequenceEndIndex = mAssemblyAlignment.fullSequenceLength() - 1;
 
@@ -611,10 +611,10 @@ public class AlignmentFragments
             {
                 int[] indelSequenceIndices = segment.indelSeqenceIndices();
 
-                if(readSeqIndexStart < indelSequenceIndices[0] && readSeqIndexEnd > indelSequenceIndices[0])
+                if(readSeqIndexStart < indelSequenceIndices[0] && readSeqIndexEnd >= indelSequenceIndices[0])
                     return true;
 
-                if(readSeqIndexStart < indelSequenceIndices[1] && readSeqIndexEnd > indelSequenceIndices[1])
+                if(readSeqIndexStart < indelSequenceIndices[1] && readSeqIndexEnd >= indelSequenceIndices[1])
                     return true;
             }
 

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
@@ -124,18 +124,12 @@ public class AssemblyAligner extends ThreadTask
             return;
         }
 
-        if(mSagaMatcher != null)
-        {
-            List<SagaJunctionInfo> junctionInfos = assemblyAlignment.linkIndices().stream().map(SagaJunctionInfo::new).toList();
-            // If an assembly is a LINE site, then the extension sequence requirement is lower.
-            // In which case need to lower the requirement for the junction overlap, or else there can be false negative matches.
-            boolean lowerJunctionOverlap = assemblyAlignment.assemblies().stream().anyMatch(JunctionAssembly::hasLineSequence);
-            SagaMatchBySequence sagaMatch = mSagaMatcher.matchBySequence(assemblyAlignment.fullSequence().getBytes(), junctionInfos, lowerJunctionOverlap, false);
-            assemblyAlignment.setSagaMatch(sagaMatch);
-        }
-
+        AlignmentInfo alignmentInfo = null;
         // Try to form breakends from the matched SAGA variant first. Otherwise, create breakends from alignment to ref genome.
-        AlignmentInfo alignmentInfo = processSagaMatchedAssembly(assemblyAlignment);
+        if(tryMatchAssemblyAlignmentToSaga(assemblyAlignment))
+        {
+            alignmentInfo = processSagaMatchedAssembly(assemblyAlignment);
+        }
         if(alignmentInfo == null)
         {
             alignmentInfo = alignAssembly(assemblyAlignment);
@@ -145,6 +139,31 @@ public class AssemblyAligner extends ThreadTask
         alignmentFragments.allocateBreakendSupport();
 
         writeAssemblyData(mWriter, mConfig, assemblyAlignment, alignmentInfo.alignments(), alignmentInfo.requeriedAlignments());
+    }
+
+    private boolean tryMatchAssemblyAlignmentToSaga(AssemblyAlignment assemblyAlignment)
+    {
+        if(mSagaMatcher == null)
+        {
+            return false;
+        }
+
+        // Only use SAGA for the simple case of 0 or 1 links. Chained assemblies require more care, not implemented for now.
+        boolean isChained = assemblyAlignment.phaseSet() != null && assemblyAlignment.phaseSet().assemblyLinks().size() > 1;
+        if(isChained)
+        {
+            return false;
+        }
+
+        List<SagaJunctionInfo> junctionInfos = assemblyAlignment.linkIndices().stream().map(SagaJunctionInfo::new).toList();
+        // If an assembly is a LINE site, then the extension sequence requirement is lower.
+        // In which case need to lower the requirement for the junction overlap, or else there can be false negative matches.
+        boolean lowerJunctionOverlap = assemblyAlignment.assemblies().stream().anyMatch(JunctionAssembly::hasLineSequence);
+        SagaMatchBySequence sagaMatch = mSagaMatcher.matchBySequence(assemblyAlignment.fullSequence()
+                .getBytes(), junctionInfos, lowerJunctionOverlap, false);
+        assemblyAlignment.setSagaMatch(sagaMatch);
+
+        return sagaMatch != null;
     }
 
     private record AlignmentInfo(

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
@@ -161,6 +161,8 @@ public class AssemblyAligner extends ThreadTask
             return null;
         }
 
+        // FIXME? validate that the saga match is nearby to the assembly.
+
         SagaAlignment sagaAlignment = sagaMatch.alignment();
         AlignData alignData = AlignData.fromSaga(sagaAlignment);
         alignData.setFullSequenceData(assemblyAlignment.fullSequence(), assemblyAlignment.fullSequenceLength());

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
@@ -127,6 +127,8 @@ public class AssemblyAligner extends ThreadTask
         if(mSagaMatcher != null)
         {
             List<SagaJunctionInfo> junctionInfos = assemblyAlignment.linkIndices().stream().map(SagaJunctionInfo::new).toList();
+            // If an assembly is a LINE site, then the extension sequence requirement is lower.
+            // In which case need to lower the requirement for the junction overlap, or else there can be false negative matches.
             boolean lowerJunctionOverlap = assemblyAlignment.assemblies().stream().anyMatch(JunctionAssembly::hasLineSequence);
             SagaMatchBySequence sagaMatch = mSagaMatcher.matchBySequence(assemblyAlignment.fullSequence().getBytes(), junctionInfos, lowerJunctionOverlap, false);
             assemblyAlignment.setSagaMatch(sagaMatch);

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
@@ -34,6 +34,7 @@ import com.hartwig.hmftools.esvee.assembly.types.JunctionAssembly;
 import com.hartwig.hmftools.esvee.assembly.types.SupportRead;
 import com.hartwig.hmftools.esvee.assembly.types.SupportType;
 import com.hartwig.hmftools.esvee.assembly.types.ThreadTask;
+import com.hartwig.hmftools.esvee.common.saga.SagaAlignment;
 import com.hartwig.hmftools.esvee.common.saga.SagaJunctionInfo;
 import com.hartwig.hmftools.esvee.common.saga.SagaMatchBySequence;
 import com.hartwig.hmftools.esvee.common.saga.SagaSequenceMatcher;
@@ -126,15 +127,60 @@ public class AssemblyAligner extends ThreadTask
         if(mSagaMatcher != null)
         {
             List<SagaJunctionInfo> junctionInfos = assemblyAlignment.linkIndices().stream().map(SagaJunctionInfo::new).toList();
-            boolean lowerJunctionOverlap = assemblyAlignment.assemblies().size() == 1 && assemblyAlignment.assemblies().get(0).hasLineSequence();
+            boolean lowerJunctionOverlap = assemblyAlignment.assemblies().stream().anyMatch(JunctionAssembly::hasLineSequence);
             SagaMatchBySequence sagaMatch = mSagaMatcher.matchBySequence(assemblyAlignment.fullSequence().getBytes(), junctionInfos, lowerJunctionOverlap, false);
             assemblyAlignment.setSagaMatch(sagaMatch);
         }
 
+        // Try to form breakends from the matched SAGA variant first. Otherwise, create breakends from alignment to ref genome.
+        AlignmentInfo alignmentInfo = processSagaMatchedAssembly(assemblyAlignment);
+        if(alignmentInfo == null)
+        {
+            alignmentInfo = alignAssembly(assemblyAlignment);
+        }
+
+        AlignmentFragments alignmentFragments = new AlignmentFragments(assemblyAlignment, mConfig.combinedSampleIds());
+        alignmentFragments.allocateBreakendSupport();
+
+        writeAssemblyData(mWriter, mConfig, assemblyAlignment, alignmentInfo.alignments(), alignmentInfo.requeriedAlignments());
+    }
+
+    private record AlignmentInfo(
+            List<AlignData> alignments,
+            List<AlignData> requeriedAlignments
+    )
+    {
+    }
+
+    @Nullable
+    private AlignmentInfo processSagaMatchedAssembly(final AssemblyAlignment assemblyAlignment)
+    {
+        SagaMatchBySequence sagaMatch = assemblyAlignment.sagaMatch();
+        if(sagaMatch == null)
+        {
+            return null;
+        }
+
+        SagaAlignment sagaAlignment = sagaMatch.alignment();
+        AlignData alignData = AlignData.fromSaga(sagaAlignment);
+        alignData.setFullSequenceData(assemblyAlignment.fullSequence(), assemblyAlignment.fullSequenceLength());
+
+        BreakendBuilder breakendBuilder = new BreakendBuilder(mConfig.RefGenome, assemblyAlignment);
+        boolean success = breakendBuilder.formBreakendsFromSaga(sagaAlignment, alignData);
+        if(!success)
+        {
+            return null;
+        }
+
+        return new AlignmentInfo(List.of(alignData), Collections.emptyList());
+    }
+
+    private AlignmentInfo alignAssembly(final AssemblyAlignment assemblyAlignment)
+    {
         List<BwaMemAlignment> bwaAlignments = mAligner.alignSequence(assemblyAlignment.fullSequence().getBytes());
 
         List<AlignData> alignments = bwaAlignments.stream()
-                .map(x -> AlignData.from(x, mConfig.RefGenVersion))
+                .map(x -> AlignData.fromRef(x, mConfig.RefGenVersion))
                 .filter(x -> x != null).collect(Collectors.toList());
 
         // set the orientation-adjusted sequence coordinates - done here since used in requery logic
@@ -147,12 +193,19 @@ public class AssemblyAligner extends ThreadTask
 
         alignments = requerySupplementaryAlignments(assemblyAlignment, alignments, requeriedAlignments);
 
-        processAlignmentResults(assemblyAlignment, alignments);
+        if(!alignments.isEmpty())
+        {
+            BreakendBuilder breakendBuilder = new BreakendBuilder(mConfig.RefGenome, assemblyAlignment);
+            breakendBuilder.formBreakends(alignments);
 
-        AlignmentFragments alignmentFragments = new AlignmentFragments(assemblyAlignment, mConfig.combinedSampleIds());
-        alignmentFragments.allocateBreakendSupport();
+            // final filters on assembly and alignment results
+            if(isWeakSingleReadExtensionAssembly(assemblyAlignment))
+            {
+                assemblyAlignment.breakends().clear();
+            }
+        }
 
-        writeAssemblyData(mWriter, mConfig, assemblyAlignment, alignments, requeriedAlignments);
+        return new AlignmentInfo(alignments, requeriedAlignments);
     }
 
     private List<AlignData> requerySoftClipAlignments(final AssemblyAlignment assemblyAlignment, final List<AlignData> alignments)
@@ -201,7 +254,7 @@ public class AssemblyAligner extends ThreadTask
         List<BwaMemAlignment> requeryBwaAlignments = mAligner.alignSequence(softClipBases.getBytes());
 
         List<AlignData> newAlignments = requeryBwaAlignments.stream()
-                .map(x -> AlignData.from(x, mConfig.RefGenVersion))
+                .map(x -> AlignData.fromRef(x, mConfig.RefGenVersion))
                 .filter(x -> x != null).collect(Collectors.toList());
 
         if(newAlignments.isEmpty())
@@ -299,7 +352,7 @@ public class AssemblyAligner extends ThreadTask
         List<BwaMemAlignment> requeryBwaAlignments = mAligner.alignSequence(alignmentSequence.getBytes());
 
         List<AlignData> requeryAlignments = requeryBwaAlignments.stream()
-                .map(x -> AlignData.from(x, mConfig.RefGenVersion))
+                .map(x -> AlignData.fromRef(x, mConfig.RefGenVersion))
                 .filter(x -> x != null).collect(Collectors.toList());
 
         List<AlignData> convertedAlignments = Lists.newArrayList();
@@ -336,21 +389,6 @@ public class AssemblyAligner extends ThreadTask
         }
 
         return convertedAlignments;
-    }
-
-    private void processAlignmentResults(final AssemblyAlignment assemblyAlignment, final List<AlignData> alignments)
-    {
-        if(alignments.isEmpty())
-            return;
-
-        BreakendBuilder breakendBuilder = new BreakendBuilder(mConfig.RefGenome, assemblyAlignment);
-        breakendBuilder.formBreakends(alignments);
-
-        // final filters on assembly and alignment results
-        if(isWeakSingleReadExtensionAssembly(assemblyAlignment))
-        {
-            assemblyAlignment.breakends().clear();
-        }
     }
 
     private static boolean isWeakSingleReadExtensionAssembly(final AssemblyAlignment assemblyAlignment)

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/Breakend.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/Breakend.java
@@ -59,6 +59,8 @@ public class Breakend implements Comparable<Breakend>
     private int mThreePrimeRangeEnd;
     private int mMaxLocalRepeat;
 
+    private boolean mSagaInferred;
+
     public Breakend(
             final AssemblyAlignment assembly, final String chromosome, final int position, final Orientation orientation,
             final String insertedBases, final HomologyData homology)
@@ -92,6 +94,8 @@ public class Breakend implements Comparable<Breakend>
         mThreePrimeRangeStart = 0;
         mThreePrimeRangeEnd = 0;
         mMaxLocalRepeat = 0;
+
+        mSagaInferred = false;
     }
 
     public int id() { return mId; }
@@ -291,6 +295,10 @@ public class Breakend implements Comparable<Breakend>
         else
             return Position == position;
     }
+
+    public boolean isSagaInferred() { return mSagaInferred; }
+
+    public void setSagaInferred() { mSagaInferred = true; }
 
     public String toString()
     {

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -112,6 +112,7 @@ public class BreakendBuilder
         List<Integer> assemblyJunctionOffsets = sagaAlignment.queryJunctionOffsets();
 
         String rawInsertSequence;
+        int indelLength;
         boolean lowerBreakendInferred;
         boolean upperBreakendInferred;
         if(sagaVariant.isInsert())
@@ -131,21 +132,27 @@ public class BreakendBuilder
 
             rawInsertSequence = startInferredSeq + assemblySeq.substring(assemblyStart, assemblyEnd) + endInferredSeq;
 
+            indelLength = rawInsertSequence.length();
+
             lowerBreakendInferred = startInferredLength > 0;
             upperBreakendInferred = endInferredLength > 0;
         }
         else
         {
             // Deletion - no insert sequence and the assembly spans the junction (otherwise it couldn't have matched the SAGA variant).
+
+            // FIXME: the assembly can have a few different number of bases deleted and that is lost here, since in the saga alignment small indels are allowed around the junction
+
             rawInsertSequence = "";
+            indelLength = upperSagaBreakend.position() - lowerSagaBreakend.position() - 1;
             lowerBreakendInferred = false;
             upperBreakendInferred = false;
         }
 
         int assemblyIndelStart = assemblyJunctionOffsets.get(0);
-        int assemblyIndelEnd = assemblyJunctionOffsets.size() > 1 ? assemblyJunctionOffsets.get(1) : assemblyJunctionOffsets.get(0) + 1;
+        int assemblyIndelEnd = assemblyIndelStart + rawInsertSequence.length();
 
-        IndelCoords indelCoords = new IndelCoords(lowerSagaBreakend.position(), upperSagaBreakend.position(), rawInsertSequence.length());
+        IndelCoords indelCoords = new IndelCoords(lowerSagaBreakend.position(), upperSagaBreakend.position(), indelLength);
         indelCoords.setInsertedBases(rawInsertSequence);
 
         IndelBreakendData breakendData =
@@ -206,27 +213,29 @@ public class BreakendBuilder
         if(indelCoords == null || indelCoords.Length < MIN_INDEL_LENGTH)
             return false;
 
-        int assemblyIndelStart = alignment.sequenceStart() + getReadIndexFromPosition(
-                alignment.positionStart(), alignment.cigarElements(), indelCoords.PosStart, true, false)
+        int assemblyIndelStart = alignment.sequenceStart()
+                + getReadIndexFromPosition(alignment.positionStart(), alignment.cigarElements(), indelCoords.PosStart, true, false)
+                // Advance from the last ref base to the first indel base.
+                + 1
                 // back out soft-clip since the method above includes that
                 - leftSoftClipLength(alignment.cigarElements());
-        int assemblyIndelEnd = assemblyIndelStart + (indelCoords.isInsert() ? indelCoords.Length : 1);
+        int assemblyIndelEnd = assemblyIndelStart + (indelCoords.isInsert() ? indelCoords.Length : 0);
 
         boolean isChained = mAssemblyAlignment.phaseSet() != null && mAssemblyAlignment.phaseSet().assemblyLinks().size() > 1;
         if(!isChained)
         {
             // the indel must have sufficient bases either side of it to be called
-            int leftAnchorLength = assemblyIndelStart + 1;
-            int rightAnchorLength = alignment.segmentLength() - assemblyIndelEnd - 1;
+            int leftAnchorLength = assemblyIndelStart;
+            int rightAnchorLength = alignment.segmentLength() - assemblyIndelEnd;
 
             if(leftAnchorLength < ALIGNMENT_INDEL_MIN_ANCHOR_LENGTH || rightAnchorLength < ALIGNMENT_INDEL_MIN_ANCHOR_LENGTH)
                 return false;
         }
 
         String assemblySeq = mAssemblyAlignment.fullSequence();
-        if(indelCoords.isInsert() && assemblyIndelStart >= 0 && assemblyIndelEnd < assemblySeq.length())
+        if(indelCoords.isInsert() && assemblyIndelStart >= 0 && assemblyIndelEnd <= assemblySeq.length())
         {
-            indelCoords.setInsertedBases(assemblySeq.substring(assemblyIndelStart + 1, assemblyIndelEnd + 1));
+            indelCoords.setInsertedBases(assemblySeq.substring(assemblyIndelStart, assemblyIndelEnd));
         }
 
         IndelBreakendData breakendData =

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -93,16 +93,14 @@ public class BreakendBuilder
         String phasedAsmSeq = mAssemblyAlignment.fullSequence();
 
         // Calculate the indices of the breakends within the phased assembly sequence.
-        List<Integer> seqJunctionOffsets = sagaAlignment.sagaAssembly().junctionOffsets().stream()
-                .map(o -> getReadIndexFromPosition(sagaAlignment.sagaStart(), sagaAlignment.cigar().getCigarElements(), o, false, true))
-                .toList();
+        List<Integer> seqJunctionOffsets = sagaAlignment.queryJunctionOffsets();
 
         // If it's an insert, the insert sequence is between the two junctions. Otherwise, it's a deletion and there's no insert sequence.
         String insertedBases;
         if(seqJunctionOffsets.size() == 2)
         {
-            int phasedAsmStart = max(seqJunctionOffsets.get(0), 0);
-            int phasedAsmEnd = min(seqJunctionOffsets.get(1), phasedAsmSeq.length());
+            int phasedAsmStart = min(max(0, seqJunctionOffsets.get(0)), phasedAsmSeq.length() - 1);
+            int phasedAsmEnd = min(max(0, seqJunctionOffsets.get(1)), phasedAsmSeq.length());
             int startInferred = phasedAsmStart - seqJunctionOffsets.get(0);
             int endInferred = seqJunctionOffsets.get(1) - phasedAsmEnd;
             // TODO: fill SAGA sequence instead of N

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -98,57 +98,62 @@ public class BreakendBuilder
         SagaVariant sagaVariant = sagaAssembly.variant();
         SagaBreakend lowerSagaBreakend = sagaVariant.breakend1();
         SagaBreakend upperSagaBreakend = sagaVariant.breakend2();
-        List<Integer> sagaJunctionOffsets = sagaAlignment.sagaAssembly().junctionOffsets();
 
-        // Calculate the indices of the breakends within the phased assembly sequence.
-        List<Integer> seqJunctionOffsets = sagaAlignment.queryJunctionOffsets();
-
-        // If it's an insert, the insert sequence is between the two junctions. Otherwise, it's a deletion and there's no insert sequence.
-        String insertedBases;
-        boolean lowerBreakendInferred;
-        boolean upperBreakendInferred;
-        if(sagaJunctionOffsets.size() == 2)
-        {
-            String assemblySeq = mAssemblyAlignment.fullSequence();
-            int assemblyStart = min(max(0, seqJunctionOffsets.get(0)), assemblySeq.length() - 1);
-            int assemblyEnd = min(max(0, seqJunctionOffsets.get(1)), assemblySeq.length());
-
-            // If there wasn't enough phased assembly to cover the whole SAGA insert sequence, get the missing part of the insert from SAGA.
-            int startInferredLength = sagaAlignment.sagaStart() - sagaJunctionOffsets.get(0);
-            String startInferredSeq =
-                    startInferredLength > 0 ? sagaAssembly.sequence().substring(sagaJunctionOffsets.get(0), sagaAlignment.sagaStart()) : "";
-            int endInferredLength = sagaJunctionOffsets.get(1) - sagaAlignment.sagaEnd();
-            String endInferredSeq =
-                    endInferredLength > 0 ? sagaAssembly.sequence().substring(sagaAlignment.sagaEnd(), sagaJunctionOffsets.get(1)) : "";
-
-            insertedBases = startInferredSeq + assemblySeq.substring(assemblyStart, assemblyEnd) + endInferredSeq;
-
-            lowerBreakendInferred = startInferredLength > 0;
-            upperBreakendInferred = endInferredLength > 0;
-        }
-        else if(sagaJunctionOffsets.size() == 1)
-        {
-            insertedBases = "";
-            lowerBreakendInferred = false;
-            upperBreakendInferred = false;
-        }
-        else
+        // SAGA variants should only be indels, but check because other types are not handled here.
+        if(!lowerSagaBreakend.chromosome().equals(upperSagaBreakend.chromosome()))
         {
             return false;
         }
 
-        // TODO: homology
-        HomologyData homology = null;
+        List<Integer> sagaJunctionOffsets = sagaAssembly.junctionOffsets();
 
-        // TODO: use createIndelBreakends
+        // Calculate the indices of the breakends within the phased assembly sequence.
+        // Note these can be out of bounds if the assembly doesn't span the whole SAGA variant.
+        List<Integer> assemblyJunctionOffsets = sagaAlignment.queryJunctionOffsets();
 
-        Breakend lowerBreakend = new Breakend(
-                mAssemblyAlignment, lowerSagaBreakend.chromosome(), lowerSagaBreakend.position(), lowerSagaBreakend.orientation(),
-                insertedBases, homology);
+        String rawInsertSequence;
+        boolean lowerBreakendInferred;
+        boolean upperBreakendInferred;
+        if(sagaVariant.isInsert())
+        {
+            // Insertion - the assembly overlaps the SAGA insert sequence, which is bounded by the junction offsets.
 
-        Breakend upperBreakend = new Breakend(
-                mAssemblyAlignment, upperSagaBreakend.chromosome(), upperSagaBreakend.position(), upperSagaBreakend.orientation(),
-                insertedBases, homology);
+            String assemblySeq = mAssemblyAlignment.fullSequence();
+            int assemblyStart = min(max(0, assemblyJunctionOffsets.get(0)), assemblySeq.length() - 1);
+            int assemblyEnd = min(max(0, assemblyJunctionOffsets.get(1)), assemblySeq.length());
+
+            // If there wasn't enough phased assembly to cover the whole SAGA insert sequence, get the missing part of the insert from SAGA.
+            String sagaInsertSeq = sagaVariant.insertSequence();
+            int startInferredLength = sagaAlignment.sagaStart() - sagaJunctionOffsets.get(0);
+            int endInferredLength = sagaJunctionOffsets.get(1) - sagaAlignment.sagaEnd();
+            String startInferredSeq = startInferredLength > 0 ? sagaInsertSeq.substring(0, startInferredLength) : "";
+            String endInferredSeq = endInferredLength > 0 ? sagaInsertSeq.substring(sagaInsertSeq.length() - endInferredLength) : "";
+
+            rawInsertSequence = startInferredSeq + assemblySeq.substring(assemblyStart, assemblyEnd) + endInferredSeq;
+
+            lowerBreakendInferred = startInferredLength > 0;
+            upperBreakendInferred = endInferredLength > 0;
+        }
+        else
+        {
+            // Deletion - no insert sequence and the assembly spans the junction (otherwise it couldn't have matched the SAGA variant).
+            rawInsertSequence = "";
+            lowerBreakendInferred = false;
+            upperBreakendInferred = false;
+        }
+
+        int assemblyIndelStart = assemblyJunctionOffsets.get(0);
+        int assemblyIndelEnd = assemblyJunctionOffsets.size() > 1 ? assemblyJunctionOffsets.get(1) : assemblyJunctionOffsets.get(0) + 1;
+
+        IndelCoords indelCoords = new IndelCoords(lowerSagaBreakend.position(), upperSagaBreakend.position(), rawInsertSequence.length());
+        indelCoords.setInsertedBases(rawInsertSequence);
+
+        IndelBreakendData breakendData =
+                calcIndelBreakendsWithHomology(lowerSagaBreakend.chromosome(), indelCoords, assemblyIndelStart, assemblyIndelEnd);
+
+        Pair<Breakend, Breakend> breakends = createIndelBreakends(alignData, breakendData);
+        Breakend lowerBreakend = breakends.getLeft();
+        Breakend upperBreakend = breakends.getRight();
 
         if(lowerBreakendInferred)
         {
@@ -158,21 +163,6 @@ public class BreakendBuilder
         {
             upperBreakend.setSagaInferred();
         }
-
-        // There isn't really an indel in the alignment, but these are only used for assigning read support.
-        int[] indelIndices = new int[] {
-                seqJunctionOffsets.get(0),
-                seqJunctionOffsets.size() > 1 ? seqJunctionOffsets.get(1) : seqJunctionOffsets.get(0) + 1 };
-        BreakendSegment segment =
-                new BreakendSegment(mAssemblyAlignment.id(), sagaAlignment.queryStart(), 0, alignData, indelIndices);
-        lowerBreakend.addSegment(segment);
-        upperBreakend.addSegment(segment);
-
-        lowerBreakend.setOtherBreakend(upperBreakend);
-        upperBreakend.setOtherBreakend(lowerBreakend);
-
-        mAssemblyAlignment.addBreakend(lowerBreakend);
-        mAssemblyAlignment.addBreakend(upperBreakend);
 
         return true;
     }
@@ -299,8 +289,8 @@ public class BreakendBuilder
     {
     }
 
-    private IndelBreakendData calcIndelBreakendsWithHomology(final String chromosome, final IndelCoords indelCoords, int indelSeqStart,
-            int indelSeqEnd)
+    private IndelBreakendData calcIndelBreakendsWithHomology(final String chromosome, final IndelCoords indelCoords, int assemblyIndelStart,
+            int assemblyIndelEnd)
     {
         int lowerPosition = indelCoords.PosStart;
         int upperPosition = indelCoords.PosEnd;
@@ -329,7 +319,7 @@ public class BreakendBuilder
                     // convert an INS to a DUP and reassess homology
                     int totalInexactHomology = homology.InexactEnd - homology.InexactStart;
 
-                    indelSeqStart += totalInexactHomology;
+                    assemblyIndelStart += totalInexactHomology;
                     lowerPosition += 1;
                     upperPosition += totalInexactHomology - 1;
                     lowerOrient = REVERSE;
@@ -389,7 +379,7 @@ public class BreakendBuilder
         }
 
         return new IndelBreakendData(
-                chromosome, lowerPosition, lowerOrient, upperPosition, upperOrient, insertedBases, homology, indelSeqStart, indelSeqEnd);
+                chromosome, lowerPosition, lowerOrient, upperPosition, upperOrient, insertedBases, homology, assemblyIndelStart, assemblyIndelEnd);
     }
 
     private Pair<Breakend, Breakend> createIndelBreakends(final AlignData alignData, final IndelBreakendData breakendData)

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -41,6 +41,7 @@ import com.hartwig.hmftools.esvee.assembly.types.JunctionAssembly;
 import com.hartwig.hmftools.esvee.assembly.types.LinkType;
 import com.hartwig.hmftools.esvee.common.IndelCoords;
 import com.hartwig.hmftools.esvee.common.saga.SagaAlignment;
+import com.hartwig.hmftools.esvee.common.saga.SagaAssembly;
 import com.hartwig.hmftools.esvee.common.saga.SagaBreakend;
 import com.hartwig.hmftools.esvee.common.saga.SagaVariant;
 
@@ -86,28 +87,36 @@ public class BreakendBuilder
             return false;
         }
 
-        SagaVariant sagaVariant = sagaAlignment.sagaVariant();
+        SagaAssembly sagaAssembly = sagaAlignment.sagaAssembly();
+        SagaVariant sagaVariant = sagaAssembly.variant();
         SagaBreakend lowerSagaBreakend = sagaVariant.breakend1();
         SagaBreakend upperSagaBreakend = sagaVariant.breakend2();
-
-        String phasedAsmSeq = mAssemblyAlignment.fullSequence();
+        List<Integer> sagaJunctionOffsets = sagaAlignment.sagaAssembly().junctionOffsets();
 
         // Calculate the indices of the breakends within the phased assembly sequence.
         List<Integer> seqJunctionOffsets = sagaAlignment.queryJunctionOffsets();
 
         // If it's an insert, the insert sequence is between the two junctions. Otherwise, it's a deletion and there's no insert sequence.
         String insertedBases;
-        if(seqJunctionOffsets.size() == 2)
+        if(sagaJunctionOffsets.size() == 2)
         {
+            String phasedAsmSeq = mAssemblyAlignment.fullSequence();
             int phasedAsmStart = min(max(0, seqJunctionOffsets.get(0)), phasedAsmSeq.length() - 1);
             int phasedAsmEnd = min(max(0, seqJunctionOffsets.get(1)), phasedAsmSeq.length());
-            int startInferred = phasedAsmStart - seqJunctionOffsets.get(0);
-            int endInferred = seqJunctionOffsets.get(1) - phasedAsmEnd;
-            // TODO: fill SAGA sequence instead of N
-            insertedBases = "N".repeat(startInferred) + phasedAsmSeq.substring(phasedAsmStart, phasedAsmEnd) + "N".repeat(endInferred);
+
+            // If there wasn't enough phased assembly to cover the whole SAGA insert sequence, get the missing part of the insert from SAGA.
+            int startInferredLength = sagaAlignment.sagaStart() - sagaJunctionOffsets.get(0);
+            String startInferredSeq =
+                    startInferredLength > 0 ? sagaAssembly.sequence().substring(sagaJunctionOffsets.get(0), sagaAlignment.sagaStart()) : "";
+            int endInferredLength = sagaJunctionOffsets.get(1) - sagaAlignment.sagaEnd();
+            String endInferredSeq =
+                    endInferredLength > 0 ? sagaAssembly.sequence().substring(sagaAlignment.sagaEnd(), sagaJunctionOffsets.get(1)) : "";
+
+            insertedBases = startInferredSeq + phasedAsmSeq.substring(phasedAsmStart, phasedAsmEnd) + endInferredSeq;
         }
         else
         {
+            assert sagaJunctionOffsets.size() == 1;
             insertedBases = "";
         }
 

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -2,7 +2,6 @@ package com.hartwig.hmftools.esvee.assembly.alignment;
 
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 import static com.hartwig.hmftools.common.bam.CigarUtils.getReadIndexFromPosition;
 import static com.hartwig.hmftools.common.bam.CigarUtils.leftSoftClipLength;
@@ -81,6 +80,10 @@ public class BreakendBuilder
 
     public boolean formBreakendsFromSaga(final SagaAlignment sagaAlignment, final AlignData alignData)
     {
+        // For a SAGA-matched variant, use the breakends stated in the SAGA resource. Why?
+        //   - Some cases where homology causes alignment to be misleading, resulting in wrong breakends.
+        //   - Recover SGLs to full variants given that one half matches a SAGA variant.
+
         // Only use SAGA breakends for the simple case of 0 or 1 links. Chained assemblies require more care, not implemented for now.
         boolean isChained = mAssemblyAlignment.phaseSet() != null && mAssemblyAlignment.phaseSet().assemblyLinks().size() > 1;
         if(isChained)
@@ -105,12 +108,6 @@ public class BreakendBuilder
             return false;
         }
 
-        List<Integer> sagaJunctionOffsets = sagaAssembly.junctionOffsets();
-
-        // Calculate the indices of the breakends within the phased assembly sequence.
-        // Note these can be out of bounds if the assembly doesn't span the whole SAGA variant.
-        List<Integer> assemblyJunctionOffsets = sagaAlignment.queryJunctionOffsets();
-
         String rawInsertSequence;
         int indelLength;
         boolean lowerBreakendInferred;
@@ -119,21 +116,18 @@ public class BreakendBuilder
         {
             // Insertion - the assembly overlaps the SAGA insert sequence, which is bounded by the junction offsets.
 
-            String assemblySeq = mAssemblyAlignment.fullSequence();
-            int assemblyStart = min(max(0, assemblyJunctionOffsets.get(0)), assemblySeq.length() - 1);
-            int assemblyEnd = min(max(0, assemblyJunctionOffsets.get(1)), assemblySeq.length());
-
-            // If there wasn't enough phased assembly to cover the whole SAGA insert sequence, get the missing part of the insert from SAGA.
-            String sagaInsertSeq = sagaVariant.insertSequence();
-            int startInferredLength = sagaAlignment.sagaStart() - sagaJunctionOffsets.get(0);
-            int endInferredLength = sagaJunctionOffsets.get(1) - sagaAlignment.sagaEnd();
-            String startInferredSeq = startInferredLength > 0 ? sagaInsertSeq.substring(0, startInferredLength) : "";
-            String endInferredSeq = endInferredLength > 0 ? sagaInsertSeq.substring(sagaInsertSeq.length() - endInferredLength) : "";
-
-            rawInsertSequence = startInferredSeq + assemblySeq.substring(assemblyStart, assemblyEnd) + endInferredSeq;
+            // Replace the ESVEE-assembled insert sequence with the SAGA insert sequence. This is because:
+            //   - In the case of 2 unlinked SGLs recovered to paired breakends, deduping requires the insert sequence to be the same.
+            //   - The differences between the phased assembly and SAGA sequence are known to be small, otherwise no SAGA match.
+            //   - Allows more advanced resolution of the SAGA breakends (e.g. template insertions) to be precomputed, in the future.
+            rawInsertSequence = sagaVariant.insertSequence();
 
             indelLength = rawInsertSequence.length();
 
+            // If the phased assembly didn't span the whole SAGA variant, take note that the other breakend is inferred from SAGA.
+            List<Integer> sagaJunctionOffsets = sagaAssembly.junctionOffsets();
+            int startInferredLength = sagaAlignment.sagaStart() - sagaJunctionOffsets.get(0);
+            int endInferredLength = sagaJunctionOffsets.get(1) - sagaAlignment.sagaEnd();
             lowerBreakendInferred = startInferredLength > 0;
             upperBreakendInferred = endInferredLength > 0;
         }
@@ -141,16 +135,19 @@ public class BreakendBuilder
         {
             // Deletion - no insert sequence and the assembly spans the junction (otherwise it couldn't have matched the SAGA variant).
 
-            // FIXME: the assembly can have a few different number of bases deleted and that is lost here, since in the saga alignment small indels are allowed around the junction
-
             rawInsertSequence = "";
+            // Using the SAGA breakends can differ in a few bases of deletion, which is ok. Similar explanation to the insert case above.
             indelLength = upperSagaBreakend.position() - lowerSagaBreakend.position() - 1;
             lowerBreakendInferred = false;
             upperBreakendInferred = false;
         }
 
+        // Calculate the indices of the (adjusted) breakends within the phased assembly sequence.
+        // Note these can be out of bounds if the assembly doesn't span the whole SAGA variant.
+        // These are only used for fragment support counting.
+        List<Integer> assemblyJunctionOffsets = sagaAlignment.queryJunctionOffsets();
         int assemblyIndelStart = assemblyJunctionOffsets.get(0);
-        int assemblyIndelEnd = assemblyIndelStart + rawInsertSequence.length();
+        int assemblyIndelEnd = assemblyJunctionOffsets.size() > 1 ? assemblyJunctionOffsets.get(1) : assemblyIndelStart;
 
         IndelCoords indelCoords = new IndelCoords(lowerSagaBreakend.position(), upperSagaBreakend.position(), indelLength);
         indelCoords.setInsertedBases(rawInsertSequence);
@@ -380,8 +377,7 @@ public class BreakendBuilder
             }
             else
             {
-                // in this case the delete does not include the overlapped homology bases, so both breakends need to be shifted forward
-                // by the same amount, being the exact homology at the start
+                // Adjust the breakends to be middle-aligned. Doesn't change the nature of the variant, however.
                 lowerPosition += abs(homology.ExactStart);
                 upperPosition += abs(homology.ExactStart);
             }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -87,6 +87,12 @@ public class BreakendBuilder
             return false;
         }
 
+        // Reverse strand match shouldn't occur and isn't handled here.
+        if(!sagaAlignment.isForward())
+        {
+            return false;
+        }
+
         SagaAssembly sagaAssembly = sagaAlignment.sagaAssembly();
         SagaVariant sagaVariant = sagaAssembly.variant();
         SagaBreakend lowerSagaBreakend = sagaVariant.breakend1();
@@ -119,12 +125,15 @@ public class BreakendBuilder
             lowerBreakendInferred = startInferredLength > 0;
             upperBreakendInferred = endInferredLength > 0;
         }
-        else
+        else if(sagaJunctionOffsets.size() == 1)
         {
-            assert sagaJunctionOffsets.size() == 1;
             insertedBases = "";
             lowerBreakendInferred = false;
             upperBreakendInferred = false;
+        }
+        else
+        {
+            return false;
         }
 
         // TODO: homology

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -45,6 +45,7 @@ import com.hartwig.hmftools.esvee.common.saga.SagaAssembly;
 import com.hartwig.hmftools.esvee.common.saga.SagaBreakend;
 import com.hartwig.hmftools.esvee.common.saga.SagaVariant;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import htsjdk.samtools.CigarElement;
@@ -108,9 +109,9 @@ public class BreakendBuilder
         boolean upperBreakendInferred;
         if(sagaJunctionOffsets.size() == 2)
         {
-            String phasedAsmSeq = mAssemblyAlignment.fullSequence();
-            int phasedAsmStart = min(max(0, seqJunctionOffsets.get(0)), phasedAsmSeq.length() - 1);
-            int phasedAsmEnd = min(max(0, seqJunctionOffsets.get(1)), phasedAsmSeq.length());
+            String assemblySeq = mAssemblyAlignment.fullSequence();
+            int assemblyStart = min(max(0, seqJunctionOffsets.get(0)), assemblySeq.length() - 1);
+            int assemblyEnd = min(max(0, seqJunctionOffsets.get(1)), assemblySeq.length());
 
             // If there wasn't enough phased assembly to cover the whole SAGA insert sequence, get the missing part of the insert from SAGA.
             int startInferredLength = sagaAlignment.sagaStart() - sagaJunctionOffsets.get(0);
@@ -120,7 +121,7 @@ public class BreakendBuilder
             String endInferredSeq =
                     endInferredLength > 0 ? sagaAssembly.sequence().substring(sagaAlignment.sagaEnd(), sagaJunctionOffsets.get(1)) : "";
 
-            insertedBases = startInferredSeq + phasedAsmSeq.substring(phasedAsmStart, phasedAsmEnd) + endInferredSeq;
+            insertedBases = startInferredSeq + assemblySeq.substring(assemblyStart, assemblyEnd) + endInferredSeq;
 
             lowerBreakendInferred = startInferredLength > 0;
             upperBreakendInferred = endInferredLength > 0;
@@ -138,6 +139,8 @@ public class BreakendBuilder
 
         // TODO: homology
         HomologyData homology = null;
+
+        // TODO: use createIndelBreakends
 
         Breakend lowerBreakend = new Breakend(
                 mAssemblyAlignment, lowerSagaBreakend.chromosome(), lowerSagaBreakend.position(), lowerSagaBreakend.orientation(),
@@ -162,7 +165,6 @@ public class BreakendBuilder
                 seqJunctionOffsets.size() > 1 ? seqJunctionOffsets.get(1) : seqJunctionOffsets.get(0) + 1 };
         BreakendSegment segment =
                 new BreakendSegment(mAssemblyAlignment.id(), sagaAlignment.queryStart(), 0, alignData, indelIndices);
-
         lowerBreakend.addSegment(segment);
         upperBreakend.addSegment(segment);
 
@@ -214,128 +216,33 @@ public class BreakendBuilder
         if(indelCoords == null || indelCoords.Length < MIN_INDEL_LENGTH)
             return false;
 
-        int indelSeqStart = alignment.sequenceStart() + getReadIndexFromPosition(
+        int assemblyIndelStart = alignment.sequenceStart() + getReadIndexFromPosition(
                 alignment.positionStart(), alignment.cigarElements(), indelCoords.PosStart, true, false)
                 // back out soft-clip since the method above includes that
                 - leftSoftClipLength(alignment.cigarElements());
-
-        int indelSeqEnd = indelSeqStart + (indelCoords.isInsert() ? indelCoords.Length : 1);
+        int assemblyIndelEnd = assemblyIndelStart + (indelCoords.isInsert() ? indelCoords.Length : 1);
 
         boolean isChained = mAssemblyAlignment.phaseSet() != null && mAssemblyAlignment.phaseSet().assemblyLinks().size() > 1;
         if(!isChained)
         {
             // the indel must have sufficient bases either side of it to be called
-            int leftAnchorLength = indelSeqStart + 1;
-            int rightAnchorLength = alignment.segmentLength() - indelSeqEnd - 1;
+            int leftAnchorLength = assemblyIndelStart + 1;
+            int rightAnchorLength = alignment.segmentLength() - assemblyIndelEnd - 1;
 
             if(leftAnchorLength < ALIGNMENT_INDEL_MIN_ANCHOR_LENGTH || rightAnchorLength < ALIGNMENT_INDEL_MIN_ANCHOR_LENGTH)
                 return false;
         }
 
-        String insertedBases = "";
-        HomologyData homology = null;
-
-        int indelPosStart = indelCoords.PosStart;
-        int indelPosEnd = indelCoords.PosEnd;
-
-        Orientation lowerOrient = FORWARD;
-        Orientation upperOrient = REVERSE;
-
-        if(indelCoords.isInsert())
+        String assemblySeq = mAssemblyAlignment.fullSequence();
+        if(indelCoords.isInsert() && assemblyIndelStart >= 0 && assemblyIndelEnd < assemblySeq.length())
         {
-            if(indelSeqStart >= 0 && indelSeqEnd < mAssemblyAlignment.fullSequenceLength())
-            {
-                insertedBases = mAssemblyAlignment.fullSequence().substring(indelSeqStart + 1, indelSeqEnd + 1);
-                String basesStart = insertedBases;
-
-                int homPosEnd = indelPosEnd;
-                String basesEnd = mRefGenome.getBaseString(alignment.chromosome(), homPosEnd, homPosEnd + insertedBases.length() - 1);
-
-                homology = HomologyData.determineIndelHomology(basesStart, basesEnd, insertedBases.length());
-
-                if(!homology.Homology.isEmpty())
-                {
-                    // convert an INS to a DUP and reassess homology
-                    int totalInexactHomology = homology.InexactEnd - homology.InexactStart;
-
-                    indelSeqStart += totalInexactHomology;
-                    indelPosStart += 1;
-                    indelPosEnd += totalInexactHomology - 1;
-                    lowerOrient = REVERSE;
-                    upperOrient = FORWARD;
-                    int newHomologyLength = 0;
-                    if(totalInexactHomology == insertedBases.length())
-                    {
-                        String postIndelBases = mRefGenome.getBaseString(
-                                alignment.chromosome(), indelPosEnd + 1, indelPosEnd + insertedBases.length());
-
-                        while(newHomologyLength < insertedBases.length() && newHomologyLength < postIndelBases.length()
-                                && insertedBases.charAt(newHomologyLength) == postIndelBases.charAt(newHomologyLength))
-                        {
-                            ++newHomologyLength;
-                        }
-                    }
-
-                    if(newHomologyLength > 0)
-                    {
-                        String newHomologyBases = insertedBases.substring(0, newHomologyLength);
-
-                        homology = new HomologyData(newHomologyBases, 0, newHomologyLength, 0, newHomologyLength);
-                    }
-                    else
-                    {
-                        homology = null;
-                    }
-
-                    insertedBases = insertedBases.substring(totalInexactHomology);
-                }
-            }
-        }
-        else
-        {
-            // check for exact homology at the bases either side of the delete
-            int maxLength = indelCoords.Length - 1;
-            int homPosStart = indelPosStart + 1;
-            String basesStart = mRefGenome.getBaseString(alignment.chromosome(), homPosStart, homPosStart + maxLength);
-
-            int homPosEnd = indelPosEnd;
-            String basesEnd = mRefGenome.getBaseString(alignment.chromosome(), homPosEnd, homPosEnd + maxLength);
-
-            homology = HomologyData.determineIndelHomology(basesStart, basesEnd, maxLength);
-
-            if(homology.Homology.isEmpty())
-            {
-                homology = null;
-            }
-            else
-            {
-                // in this case the delete does not include the overlapped homology bases, so both breakends need to be shifted forward
-                // by the same amount, being the exact homology at the start
-                indelPosStart += abs(homology.ExactStart);
-                indelPosEnd += abs(homology.ExactStart);
-            }
+            indelCoords.setInsertedBases(assemblySeq.substring(assemblyIndelStart + 1, assemblyIndelEnd + 1));
         }
 
-        Breakend lowerBreakend = new Breakend(
-                mAssemblyAlignment, alignment.chromosome(), indelPosStart, lowerOrient, insertedBases, homology);
+        IndelBreakendData breakendData =
+                calcIndelBreakendsWithHomology(alignment.chromosome(), indelCoords, assemblyIndelStart, assemblyIndelEnd);
 
-        mAssemblyAlignment.addBreakend(lowerBreakend);
-
-        int[] indelSequenceIndices = new int[] { indelSeqStart, indelSeqEnd };
-        BreakendSegment segment =
-                new BreakendSegment(mAssemblyAlignment.id(), alignment.sequenceStart(), 0, alignment, indelSequenceIndices);
-
-        lowerBreakend.addSegment(segment);
-
-        Breakend upperBreakend =
-                new Breakend(mAssemblyAlignment, alignment.chromosome(), indelPosEnd, upperOrient, insertedBases, homology);
-
-        mAssemblyAlignment.addBreakend(upperBreakend);
-
-        upperBreakend.addSegment(segment);
-
-        lowerBreakend.setOtherBreakend(upperBreakend);
-        upperBreakend.setOtherBreakend(lowerBreakend);
+        createIndelBreakends(alignment, breakendData);
 
         return true;
     }
@@ -375,6 +282,139 @@ public class BreakendBuilder
         }
 
         return indelCoords;
+    }
+
+    private record IndelBreakendData(
+            String chromosome,
+            int lowerPosition,
+            Orientation lowerOrient,
+            int upperPosition,
+            Orientation upperOrient,
+            String insertedBases,
+            @Nullable
+            HomologyData homology,
+            int assemblyIndelStart,
+            int assemblyIndelEnd
+    )
+    {
+    }
+
+    private IndelBreakendData calcIndelBreakendsWithHomology(final String chromosome, final IndelCoords indelCoords, int indelSeqStart,
+            int indelSeqEnd)
+    {
+        int lowerPosition = indelCoords.PosStart;
+        int upperPosition = indelCoords.PosEnd;
+
+        Orientation lowerOrient = FORWARD;
+        Orientation upperOrient = REVERSE;
+
+        String insertedBases = indelCoords.insertedBases();
+
+        HomologyData homology = null;
+
+        if(indelCoords.isInsert())
+        {
+            if(!insertedBases.isEmpty())
+            {
+                String basesStart = insertedBases;
+
+                int homPosEnd = upperPosition;
+                String basesEnd = mRefGenome.getBaseString(chromosome, homPosEnd, homPosEnd + insertedBases.length() - 1);
+
+                homology = HomologyData.determineIndelHomology(basesStart, basesEnd, insertedBases.length());
+                assert homology != null;
+
+                if(!homology.Homology.isEmpty())
+                {
+                    // convert an INS to a DUP and reassess homology
+                    int totalInexactHomology = homology.InexactEnd - homology.InexactStart;
+
+                    indelSeqStart += totalInexactHomology;
+                    lowerPosition += 1;
+                    upperPosition += totalInexactHomology - 1;
+                    lowerOrient = REVERSE;
+                    upperOrient = FORWARD;
+                    int newHomologyLength = 0;
+                    if(totalInexactHomology == insertedBases.length())
+                    {
+                        String postIndelBases =
+                                mRefGenome.getBaseString(chromosome, upperPosition + 1, upperPosition + insertedBases.length());
+
+                        while(newHomologyLength < insertedBases.length() && newHomologyLength < postIndelBases.length()
+                                && insertedBases.charAt(newHomologyLength) == postIndelBases.charAt(newHomologyLength))
+                        {
+                            ++newHomologyLength;
+                        }
+                    }
+
+                    if(newHomologyLength > 0)
+                    {
+                        String newHomologyBases = insertedBases.substring(0, newHomologyLength);
+
+                        homology = new HomologyData(newHomologyBases, 0, newHomologyLength, 0, newHomologyLength);
+                    }
+                    else
+                    {
+                        homology = null;
+                    }
+
+                    insertedBases = insertedBases.substring(totalInexactHomology);
+                }
+            }
+        }
+        else
+        {
+            // check for exact homology at the bases either side of the delete
+            int maxLength = indelCoords.Length - 1;
+            int homPosStart = lowerPosition + 1;
+            String basesStart = mRefGenome.getBaseString(chromosome, homPosStart, homPosStart + maxLength);
+
+            int homPosEnd = upperPosition;
+            String basesEnd = mRefGenome.getBaseString(chromosome, homPosEnd, homPosEnd + maxLength);
+
+            homology = HomologyData.determineIndelHomology(basesStart, basesEnd, maxLength);
+            assert homology != null;
+
+            if(homology.Homology.isEmpty())
+            {
+                homology = null;
+            }
+            else
+            {
+                // in this case the delete does not include the overlapped homology bases, so both breakends need to be shifted forward
+                // by the same amount, being the exact homology at the start
+                lowerPosition += abs(homology.ExactStart);
+                upperPosition += abs(homology.ExactStart);
+            }
+        }
+
+        return new IndelBreakendData(
+                chromosome, lowerPosition, lowerOrient, upperPosition, upperOrient, insertedBases, homology, indelSeqStart, indelSeqEnd);
+    }
+
+    private Pair<Breakend, Breakend> createIndelBreakends(final AlignData alignData, final IndelBreakendData breakendData)
+    {
+        Breakend lowerBreakend = new Breakend(
+                mAssemblyAlignment, breakendData.chromosome(), breakendData.lowerPosition(), breakendData.lowerOrient(),
+                breakendData.insertedBases(), breakendData.homology());
+
+        Breakend upperBreakend = new Breakend(
+                mAssemblyAlignment, breakendData.chromosome(), breakendData.upperPosition(), breakendData.upperOrient(),
+                breakendData.insertedBases(), breakendData.homology());
+
+        int[] indelSequenceIndices = new int[] { breakendData.assemblyIndelStart(), breakendData.assemblyIndelEnd() };
+        BreakendSegment segment =
+                new BreakendSegment(mAssemblyAlignment.id(), alignData.sequenceStart(), 0, alignData, indelSequenceIndices);
+        lowerBreakend.addSegment(segment);
+        upperBreakend.addSegment(segment);
+
+        lowerBreakend.setOtherBreakend(upperBreakend);
+        upperBreakend.setOtherBreakend(lowerBreakend);
+
+        mAssemblyAlignment.addBreakend(lowerBreakend);
+        mAssemblyAlignment.addBreakend(upperBreakend);
+
+        return Pair.of(lowerBreakend, upperBreakend);
     }
 
     private void formSingleBreakend(final AlignData alignment, final List<AlignData> zeroQualAlignments)

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -98,6 +98,8 @@ public class BreakendBuilder
 
         // If it's an insert, the insert sequence is between the two junctions. Otherwise, it's a deletion and there's no insert sequence.
         String insertedBases;
+        boolean lowerBreakendInferred;
+        boolean upperBreakendInferred;
         if(sagaJunctionOffsets.size() == 2)
         {
             String phasedAsmSeq = mAssemblyAlignment.fullSequence();
@@ -113,11 +115,16 @@ public class BreakendBuilder
                     endInferredLength > 0 ? sagaAssembly.sequence().substring(sagaAlignment.sagaEnd(), sagaJunctionOffsets.get(1)) : "";
 
             insertedBases = startInferredSeq + phasedAsmSeq.substring(phasedAsmStart, phasedAsmEnd) + endInferredSeq;
+
+            lowerBreakendInferred = startInferredLength > 0;
+            upperBreakendInferred = endInferredLength > 0;
         }
         else
         {
             assert sagaJunctionOffsets.size() == 1;
             insertedBases = "";
+            lowerBreakendInferred = false;
+            upperBreakendInferred = false;
         }
 
         // TODO: homology
@@ -130,6 +137,15 @@ public class BreakendBuilder
         Breakend upperBreakend = new Breakend(
                 mAssemblyAlignment, upperSagaBreakend.chromosome(), upperSagaBreakend.position(), upperSagaBreakend.orientation(),
                 insertedBases, homology);
+
+        if(lowerBreakendInferred)
+        {
+            lowerBreakend.setSagaInferred();
+        }
+        if(upperBreakendInferred)
+        {
+            upperBreakend.setSagaInferred();
+        }
 
         // There isn't really an indel in the alignment, but these are only used for assigning read support.
         int[] indelIndices = new int[] {

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -84,13 +84,6 @@ public class BreakendBuilder
         //   - Some cases where homology causes alignment to be misleading, resulting in wrong breakends.
         //   - Recover SGLs to full variants given that one half matches a SAGA variant.
 
-        // Only use SAGA breakends for the simple case of 0 or 1 links. Chained assemblies require more care, not implemented for now.
-        boolean isChained = mAssemblyAlignment.phaseSet() != null && mAssemblyAlignment.phaseSet().assemblyLinks().size() > 1;
-        if(isChained)
-        {
-            return false;
-        }
-
         // Reverse strand match shouldn't occur and isn't handled here.
         if(!sagaAlignment.isForward())
         {

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/BreakendBuilder.java
@@ -2,8 +2,10 @@ package com.hartwig.hmftools.esvee.assembly.alignment;
 
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 import static com.hartwig.hmftools.common.bam.CigarUtils.getReadIndexFromPosition;
+import static com.hartwig.hmftools.common.bam.CigarUtils.leftSoftClipLength;
 import static com.hartwig.hmftools.common.codon.Nucleotides.reverseComplementBases;
 import static com.hartwig.hmftools.common.genome.region.Orientation.FORWARD;
 import static com.hartwig.hmftools.common.genome.region.Orientation.REVERSE;
@@ -25,7 +27,6 @@ import static com.hartwig.hmftools.esvee.common.SvConstants.MIN_INDEL_LENGTH;
 
 import static htsjdk.samtools.CigarOperator.D;
 import static htsjdk.samtools.CigarOperator.I;
-import static htsjdk.samtools.CigarOperator.S;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,6 +40,11 @@ import com.hartwig.hmftools.esvee.assembly.types.Junction;
 import com.hartwig.hmftools.esvee.assembly.types.JunctionAssembly;
 import com.hartwig.hmftools.esvee.assembly.types.LinkType;
 import com.hartwig.hmftools.esvee.common.IndelCoords;
+import com.hartwig.hmftools.esvee.common.saga.SagaAlignment;
+import com.hartwig.hmftools.esvee.common.saga.SagaBreakend;
+import com.hartwig.hmftools.esvee.common.saga.SagaVariant;
+
+import org.jetbrains.annotations.Nullable;
 
 import htsjdk.samtools.CigarElement;
 
@@ -69,6 +75,72 @@ public class BreakendBuilder
                 SV_LOGGER.debug("alignment({})", alignData);
             }
         }
+    }
+
+    public boolean formBreakendsFromSaga(final SagaAlignment sagaAlignment, final AlignData alignData)
+    {
+        // Only use SAGA breakends for the simple case of 0 or 1 links. Chained assemblies require more care, not implemented for now.
+        boolean isChained = mAssemblyAlignment.phaseSet() != null && mAssemblyAlignment.phaseSet().assemblyLinks().size() > 1;
+        if(isChained)
+        {
+            return false;
+        }
+
+        SagaVariant sagaVariant = sagaAlignment.sagaVariant();
+        SagaBreakend lowerSagaBreakend = sagaVariant.breakend1();
+        SagaBreakend upperSagaBreakend = sagaVariant.breakend2();
+
+        String phasedAsmSeq = mAssemblyAlignment.fullSequence();
+
+        // Calculate the indices of the breakends within the phased assembly sequence.
+        List<Integer> seqJunctionOffsets = sagaAlignment.sagaAssembly().junctionOffsets().stream()
+                .map(o -> getReadIndexFromPosition(sagaAlignment.sagaStart(), sagaAlignment.cigar().getCigarElements(), o, false, true))
+                .toList();
+
+        // If it's an insert, the insert sequence is between the two junctions. Otherwise, it's a deletion and there's no insert sequence.
+        String insertedBases;
+        if(seqJunctionOffsets.size() == 2)
+        {
+            int phasedAsmStart = max(seqJunctionOffsets.get(0), 0);
+            int phasedAsmEnd = min(seqJunctionOffsets.get(1), phasedAsmSeq.length());
+            int startInferred = phasedAsmStart - seqJunctionOffsets.get(0);
+            int endInferred = seqJunctionOffsets.get(1) - phasedAsmEnd;
+            // TODO: fill SAGA sequence instead of N
+            insertedBases = "N".repeat(startInferred) + phasedAsmSeq.substring(phasedAsmStart, phasedAsmEnd) + "N".repeat(endInferred);
+        }
+        else
+        {
+            insertedBases = "";
+        }
+
+        // TODO: homology
+        HomologyData homology = null;
+
+        Breakend lowerBreakend = new Breakend(
+                mAssemblyAlignment, lowerSagaBreakend.chromosome(), lowerSagaBreakend.position(), lowerSagaBreakend.orientation(),
+                insertedBases, homology);
+
+        Breakend upperBreakend = new Breakend(
+                mAssemblyAlignment, upperSagaBreakend.chromosome(), upperSagaBreakend.position(), upperSagaBreakend.orientation(),
+                insertedBases, homology);
+
+        // There isn't really an indel in the alignment, but these are only used for assigning read support.
+        int[] indelIndices = new int[] {
+                seqJunctionOffsets.get(0),
+                seqJunctionOffsets.size() > 1 ? seqJunctionOffsets.get(1) : seqJunctionOffsets.get(0) + 1 };
+        BreakendSegment segment =
+                new BreakendSegment(mAssemblyAlignment.id(), sagaAlignment.queryStart(), 0, alignData, indelIndices);
+
+        lowerBreakend.addSegment(segment);
+        upperBreakend.addSegment(segment);
+
+        lowerBreakend.setOtherBreakend(upperBreakend);
+        upperBreakend.setOtherBreakend(lowerBreakend);
+
+        mAssemblyAlignment.addBreakend(lowerBreakend);
+        mAssemblyAlignment.addBreakend(upperBreakend);
+
+        return true;
     }
 
     private void doFormBreakends(final List<AlignData> alignments)
@@ -105,53 +177,19 @@ public class BreakendBuilder
 
     private boolean formIndelBreakends(final AlignData alignment)
     {
-        // parse the CIGAR to get the indel coords, first looking for a close match to what was expected
-        IndelCoords indelCoords = null;
-
-        boolean isChained = false;
-
-        if(mAssemblyAlignment.phaseSet() != null)
-        {
-            if(mAssemblyAlignment.phaseSet().assemblyLinks().size() == 1)
-            {
-                AssemblyLink assemblyLink = mAssemblyAlignment.phaseSet().assemblyLinks().get(0);
-                StructuralVariantType svType = assemblyLink.svType();
-
-                if(svType == DEL || svType == DUP || svType == INS)
-                {
-                    int svLength = assemblyLink.length();
-
-                    if(svLength == 0 && assemblyLink.insertedBases().length() > 0) // same-base DUP/INS, change implied Cigar insert length
-                    {
-                        svLength = assemblyLink.insertedBases().length();
-                        svType = INS;
-                    }
-
-                    CigarElement specificIndel = new CigarElement(svLength, svType == DEL ? D : I);
-                    indelCoords = IndelCoords.findMatchingIndelCoords(alignment.positionStart(), alignment.cigarElements(), specificIndel);
-                }
-            }
-            else
-            {
-                isChained = true;
-            }
-        }
-
-        // if no match was found, just take the longest
-        if(indelCoords == null)
-            indelCoords = findIndelCoords(alignment.positionStart(), alignment.cigarElements(), MIN_INDEL_LENGTH);
+        IndelCoords indelCoords = getIndelAlignmentIndelCoords(alignment);
 
         if(indelCoords == null || indelCoords.Length < MIN_INDEL_LENGTH)
             return false;
 
         int indelSeqStart = alignment.sequenceStart() + getReadIndexFromPosition(
-                alignment.positionStart(), alignment.cigarElements(),  indelCoords.PosStart, true, false);
-
-        if(alignment.cigarElements().get(0).getOperator() == S) // back out soft-clip since the method above includes that
-            indelSeqStart -= alignment.cigarElements().get(0).getLength();
+                alignment.positionStart(), alignment.cigarElements(), indelCoords.PosStart, true, false)
+                // back out soft-clip since the method above includes that
+                - leftSoftClipLength(alignment.cigarElements());
 
         int indelSeqEnd = indelSeqStart + (indelCoords.isInsert() ? indelCoords.Length : 1);
 
+        boolean isChained = mAssemblyAlignment.phaseSet() != null && mAssemblyAlignment.phaseSet().assemblyLinks().size() > 1;
         if(!isChained)
         {
             // the indel must have sufficient bases either side of it to be called
@@ -200,7 +238,7 @@ public class BreakendBuilder
                                 alignment.chromosome(), indelPosEnd + 1, indelPosEnd + insertedBases.length());
 
                         while(newHomologyLength < insertedBases.length() && newHomologyLength < postIndelBases.length()
-                        && insertedBases.charAt(newHomologyLength) == postIndelBases.charAt(newHomologyLength))
+                                && insertedBases.charAt(newHomologyLength) == postIndelBases.charAt(newHomologyLength))
                         {
                             ++newHomologyLength;
                         }
@@ -226,7 +264,7 @@ public class BreakendBuilder
             // check for exact homology at the bases either side of the delete
             int maxLength = indelCoords.Length - 1;
             int homPosStart = indelPosStart + 1;
-            String basesStart = mRefGenome.getBaseString( alignment.chromosome(), homPosStart, homPosStart + maxLength);
+            String basesStart = mRefGenome.getBaseString(alignment.chromosome(), homPosStart, homPosStart + maxLength);
 
             int homPosEnd = indelPosEnd;
             String basesEnd = mRefGenome.getBaseString(alignment.chromosome(), homPosEnd, homPosEnd + maxLength);
@@ -252,11 +290,13 @@ public class BreakendBuilder
         mAssemblyAlignment.addBreakend(lowerBreakend);
 
         int[] indelSequenceIndices = new int[] { indelSeqStart, indelSeqEnd };
-        BreakendSegment segment = new BreakendSegment(mAssemblyAlignment.id(), alignment.sequenceStart(), 0, alignment, indelSequenceIndices);
+        BreakendSegment segment =
+                new BreakendSegment(mAssemblyAlignment.id(), alignment.sequenceStart(), 0, alignment, indelSequenceIndices);
 
         lowerBreakend.addSegment(segment);
 
-        Breakend upperBreakend = new Breakend(mAssemblyAlignment, alignment.chromosome(), indelPosEnd, upperOrient, insertedBases, homology);
+        Breakend upperBreakend =
+                new Breakend(mAssemblyAlignment, alignment.chromosome(), indelPosEnd, upperOrient, insertedBases, homology);
 
         mAssemblyAlignment.addBreakend(upperBreakend);
 
@@ -266,6 +306,43 @@ public class BreakendBuilder
         upperBreakend.setOtherBreakend(lowerBreakend);
 
         return true;
+    }
+
+    @Nullable
+    private IndelCoords getIndelAlignmentIndelCoords(final AlignData alignment)
+    {
+        // parse the CIGAR to get the indel coords, first looking for a close match to what was expected
+        IndelCoords indelCoords = null;
+        if(mAssemblyAlignment.phaseSet() != null)
+        {
+            if(mAssemblyAlignment.phaseSet().assemblyLinks().size() == 1)
+            {
+                AssemblyLink assemblyLink = mAssemblyAlignment.phaseSet().assemblyLinks().get(0);
+                StructuralVariantType svType = assemblyLink.svType();
+
+                if(svType == DEL || svType == DUP || svType == INS)
+                {
+                    int svLength = assemblyLink.length();
+
+                    if(svLength == 0 && !assemblyLink.insertedBases().isEmpty()) // same-base DUP/INS, change implied Cigar insert length
+                    {
+                        svLength = assemblyLink.insertedBases().length();
+                        svType = INS;
+                    }
+
+                    CigarElement specificIndel = new CigarElement(svLength, svType == DEL ? D : I);
+                    indelCoords = IndelCoords.findMatchingIndelCoords(alignment.positionStart(), alignment.cigarElements(), specificIndel);
+                }
+            }
+        }
+
+        // if no match was found, just take the longest
+        if(indelCoords == null)
+        {
+            indelCoords = findIndelCoords(alignment.positionStart(), alignment.cigarElements(), MIN_INDEL_LENGTH);
+        }
+
+        return indelCoords;
     }
 
     private void formSingleBreakend(final AlignData alignment, final List<AlignData> zeroQualAlignments)
@@ -510,7 +587,8 @@ public class BreakendBuilder
 
             mAssemblyAlignment.addBreakend(breakend);
 
-            BreakendSegment segment = new BreakendSegment(mAssemblyAlignment.id(), alignment.sequenceStart(), nextSegmentIndex++, alignment);
+            BreakendSegment segment =
+                    new BreakendSegment(mAssemblyAlignment.id(), alignment.sequenceStart(), nextSegmentIndex++, alignment);
 
             breakend.addSegment(segment);
 

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/HomologyData.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/HomologyData.java
@@ -4,10 +4,7 @@ import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.lang.String.format;
 
-import static com.hartwig.hmftools.esvee.assembly.alignment.BreakendBuilder.segmentOrientation;
-
 import com.hartwig.hmftools.common.codon.Nucleotides;
-import com.hartwig.hmftools.common.genome.refgenome.RefGenomeInterface;
 import com.hartwig.hmftools.common.genome.region.Orientation;
 
 public class HomologyData
@@ -183,12 +180,6 @@ public class HomologyData
         return new HomologyData(exactHomology, -exactStart, exactEnd, -inexactStart, inexactEnd);
     }
 
-    public boolean matches(final HomologyData other)
-    {
-        return other.Homology.equals(Homology) && ExactStart == other.ExactStart && ExactEnd == other.ExactEnd
-                && InexactStart == other.InexactStart && InexactEnd == other.InexactEnd;
-    }
-
     public static HomologyData determineIndelHomology(final String refBasesStart, final String refBasesEnd, final int overlap)
     {
         if(refBasesStart.length() != refBasesEnd.length())
@@ -227,20 +218,5 @@ public class HomologyData
         int exactEnd = exactMatch - exactStart;
 
         return new HomologyData(sb.toString(), -exactStart, exactEnd, -exactStart, exactEnd);
-    }
-
-    private static String getOverlapBases(
-            final AlignData alignment, final Orientation orientation, final int overlap, final RefGenomeInterface refGenome)
-    {
-        if(orientation.isForward())
-        {
-            return refGenome.getBaseString(
-                    alignment.refLocation().Chromosome, alignment.refLocation().end() - overlap + 1, alignment.refLocation().end());
-        }
-        else
-        {
-            return refGenome.getBaseString(
-                    alignment.refLocation().Chromosome, alignment.refLocation().start(), alignment.refLocation().start() + overlap - 1);
-        }
     }
 }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/output/BreakendWriter.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/output/BreakendWriter.java
@@ -112,6 +112,7 @@ public class BreakendWriter
             if(mConfig.SagaFastaFile != null)
             {
                 sj.add(FLD_SAGA_MATCH);
+                sj.add("SagaInferred");
             }
 
             writer.write(sj.toString());
@@ -254,6 +255,7 @@ public class BreakendWriter
                 {
                     SagaMatchBySequence sagaMatch = assemblyAlignment.sagaMatch();
                     sj.add(sagaMatch == null ? "" : sagaMatch.variant().toString());
+                    sj.add(String.valueOf(breakend.isSagaInferred()));
                 }
 
                 mWriter.write(sj.toString());

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/output/VcfWriter.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/output/VcfWriter.java
@@ -42,6 +42,8 @@ import static com.hartwig.hmftools.common.sv.SvVcfTags.MATE_ID;
 import static com.hartwig.hmftools.common.sv.SvVcfTags.MATE_ID_DESC;
 import static com.hartwig.hmftools.common.sv.SvVcfTags.MAX_LOCAL_REPEAT;
 import static com.hartwig.hmftools.common.sv.SvVcfTags.MAX_LOCAL_REPEAT_DESC;
+import static com.hartwig.hmftools.common.sv.SvVcfTags.SAGA_INFERRED_BREAKEND;
+import static com.hartwig.hmftools.common.sv.SvVcfTags.SAGA_INFERRED_BREAKEND_DESC;
 import static com.hartwig.hmftools.common.sv.SvVcfTags.SAGA_VARIANT;
 import static com.hartwig.hmftools.common.sv.SvVcfTags.SAGA_VARIANT_DESC;
 import static com.hartwig.hmftools.common.sv.SvVcfTags.SV_ID;
@@ -216,6 +218,7 @@ public class VcfWriter implements AutoCloseable
         metaData.add(new VCFInfoHeaderLine(THREE_PRIME_RANGE, 2, VCFHeaderLineType.Integer, THREE_PRIME_RANGE_DESC));
         metaData.add(new VCFInfoHeaderLine(MAX_LOCAL_REPEAT, 1, VCFHeaderLineType.Integer, MAX_LOCAL_REPEAT_DESC));
         metaData.add(new VCFInfoHeaderLine(SAGA_VARIANT, 1, VCFHeaderLineType.String, SAGA_VARIANT_DESC));
+        metaData.add(new VCFInfoHeaderLine(SAGA_INFERRED_BREAKEND, 1, VCFHeaderLineType.Flag, SAGA_INFERRED_BREAKEND_DESC));
 
         for(FilterType filter : FilterType.values())
         {
@@ -371,6 +374,10 @@ public class VcfWriter implements AutoCloseable
         if(sagaMatch != null)
         {
             builder.attribute(SAGA_VARIANT, sagaMatch.variant().noSpaceString());
+        }
+        if(breakend.isSagaInferred())
+        {
+            builder.attribute(SAGA_INFERRED_BREAKEND, true);
         }
 
         VariantContext variantContext = builder.make();

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/types/JunctionAssembly.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/types/JunctionAssembly.java
@@ -860,6 +860,8 @@ public class JunctionAssembly
     {
         int junctionOffset = mJunction.isForward() ? refBaseLength() : baseLength() - refBaseLength();
         List<SagaJunctionInfo> junctionInfos = List.of(new SagaJunctionInfo(junctionOffset));
+        // If the assembly is a LINE site, then the extension sequence requirement is lower.
+        // In which case need to lower the requirement for the junction overlap, or else there can be false negative matches.
         boolean lowerJunctionOverlap = hasLineSequence();
         SagaMatchBySequence match = sagaMatcher.matchBySequence(bases(), junctionInfos, lowerJunctionOverlap, true);
         setSagaMatch(match);

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
@@ -14,7 +14,7 @@ import htsjdk.samtools.Cigar;
 import htsjdk.samtools.SAMFlag;
 
 public record SagaAlignment(
-        BwaMemAlignment alignment,
+        BwaMemAlignment rawAlignment,
         Cigar cigar,
         int queryLength,
         SagaAssembly sagaAssembly
@@ -22,7 +22,7 @@ public record SagaAlignment(
 {
     public boolean isForward()
     {
-        return !SamRecordUtils.isFlagSet(alignment.getSamFlag(), SAMFlag.READ_REVERSE_STRAND);
+        return !SamRecordUtils.isFlagSet(rawAlignment.getSamFlag(), SAMFlag.READ_REVERSE_STRAND);
     }
 
     public int queryStart()
@@ -42,12 +42,12 @@ public record SagaAlignment(
 
     public int sagaStart()
     {
-        return alignment.getRefStart();
+        return rawAlignment.getRefStart();
     }
 
     public int sagaEnd()
     {
-        return alignment.getRefEnd();
+        return rawAlignment.getRefEnd();
     }
 
     public int sagaAlignLength()
@@ -62,7 +62,7 @@ public record SagaAlignment(
 
     public int alignScore()
     {
-        return alignment.getAlignerScore();
+        return rawAlignment.getAlignerScore();
     }
 
     // How many more bases could've been aligned on the left?
@@ -75,6 +75,11 @@ public record SagaAlignment(
     public int rightUnaligned()
     {
         return min(queryLength - queryEnd(), sagaLength() - sagaEnd());
+    }
+
+    public SagaVariant sagaVariant()
+    {
+        return sagaAssembly.variant();
     }
 
     @NotNull

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
@@ -2,8 +2,11 @@ package com.hartwig.hmftools.esvee.common.saga;
 
 import static java.lang.Math.min;
 
+import static com.hartwig.hmftools.common.bam.CigarUtils.getReadIndexFromPosition;
 import static com.hartwig.hmftools.common.bam.CigarUtils.leftClipLength;
 import static com.hartwig.hmftools.common.bam.CigarUtils.rightClipLength;
+
+import java.util.List;
 
 import com.hartwig.hmftools.common.bam.SamRecordUtils;
 
@@ -80,6 +83,35 @@ public record SagaAlignment(
     public SagaVariant sagaVariant()
     {
         return sagaAssembly.variant();
+    }
+
+    public List<Integer> queryJunctionOffsets()
+    {
+        // The indices of the SAGA junctions, mapped into the query sequence range, with extrapolation if required.
+        return sagaAssembly().junctionOffsets().stream()
+                .map(this::sagaIndexToQueryIndex)
+                .toList();
+    }
+
+    private int sagaIndexToQueryIndex(int sagaIndex)
+    {
+        // Extrapolate outside of the aligned range.
+        if(sagaIndex <= sagaStart())
+        {
+            return queryStart() - (sagaStart() - sagaIndex);
+        }
+        if(sagaIndex >= sagaEnd())
+        {
+            return queryEnd() + (sagaIndex - sagaEnd());
+        }
+        // On a D element, use the next index.
+        int result = getReadIndexFromPosition(sagaStart(), cigar.getCigarElements(), sagaIndex, 1, false);
+        if(!(result >= 0 && result <= queryLength))
+        {
+            // Should be impossible because the out of bounds cases were already handled.
+            throw new RuntimeException();
+        }
+        return result;
     }
 
     @NotNull

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
@@ -57,7 +57,7 @@ public record SagaAlignment(
 
     public int sagaLength()
     {
-        return sagaAssembly.assemblyLength();
+        return sagaAssembly.length();
     }
 
     public int alignScore()

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAssembly.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAssembly.java
@@ -9,6 +9,10 @@ public record SagaAssembly(
         SagaVariant variant,
         // Junctions occur just before each of these indices in the assembly sequence.
         // Usually length 2. Can be length 1 for DELs where the junction is a single position.
+        // E.g.
+        // sequence = RRRJJJRRR
+        // junctionOffsets[0] = 3
+        // junctionOffsets[1] = 6
         List<Integer> junctionOffsets,
         String sequence
 )
@@ -17,16 +21,19 @@ public record SagaAssembly(
     {
         if(junctionOffsets.size() != 1 && junctionOffsets.size() != 2)
         {
-            throw new IllegalArgumentException("Invalid number of junction offsets");
+            throw new IllegalArgumentException("Expected 1 or 2 junction offsets");
         }
-        // E.g.
-        // sequence = RRRJJJRRR
-        // junctionOffset[0] = 3
-        // junctionOffset[1] = 6
+
+        if(variant.isInsert() && junctionOffsets.size() != 2)
+        {
+            throw new IllegalArgumentException("Insert should have 2 junction offsets");
+        }
+
         if(!junctionOffsets.stream().allMatch(offset -> offset >= 1 && offset < sequence.length()))
         {
             throw new IllegalArgumentException("Junction offsets out of bounds");
         }
+
         for(int i = 0; i < junctionOffsets.size() - 1; i++)
         {
             if(junctionOffsets.get(i) >= junctionOffsets.get(i + 1))
@@ -67,7 +74,8 @@ public record SagaAssembly(
         {
             throw new IllegalArgumentException("Invalid junction offsets");
         }
-        SagaVariant variant = new SagaVariant(id, breakend1, breakend2);
+        String insertSequence = sequence.substring(junctionOffset1, junctionOffset2 == null ? junctionOffset1 : junctionOffset2);
+        SagaVariant variant = new SagaVariant(id, breakend1, breakend2, insertSequence);
         List<Integer> junctionOffsets = junctionOffset2 == null ? List.of(junctionOffset1) : List.of(junctionOffset1, junctionOffset2);
         return new SagaAssembly(label, variant, junctionOffsets, sequence);
     }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAssembly.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAssembly.java
@@ -10,7 +10,7 @@ public record SagaAssembly(
         // Junctions occur just before each of these indices in the assembly sequence.
         // Usually length 2. Can be length 1 for DELs where the junction is a single position.
         List<Integer> junctionOffsets,
-        int assemblyLength
+        String sequence
 )
 {
     public SagaAssembly
@@ -23,10 +23,22 @@ public record SagaAssembly(
         // sequence = RRRJJJRRR
         // junctionOffset[0] = 3
         // junctionOffset[1] = 6
-        if(!junctionOffsets.stream().allMatch(offset -> offset >= 1 && offset < assemblyLength))
+        if(!junctionOffsets.stream().allMatch(offset -> offset >= 1 && offset < sequence.length()))
         {
             throw new IllegalArgumentException("Junction offsets out of bounds");
         }
+        for(int i = 0; i < junctionOffsets.size() - 1; i++)
+        {
+            if(junctionOffsets.get(i) >= junctionOffsets.get(i + 1))
+            {
+                throw new IllegalArgumentException("Junction offsets not in ascending order");
+            }
+        }
+    }
+
+    public int length()
+    {
+        return sequence.length();
     }
 
     public List<SagaJunctionInfo> junctions()
@@ -34,17 +46,17 @@ public record SagaAssembly(
         return junctionOffsets.stream().map(SagaJunctionInfo::new).toList();
     }
 
-    public static SagaAssembly fromFastaLabel(final String fastaLabel, int assemblyLength)
+    public static SagaAssembly fromFastaRecord(final String label, final String sequence)
     {
         // E.g.:
         // SvimAsm00000237|chr1:181626:1|chr1:181627:-1|150|285
         // SvimAsm00000238|chr1:368909:1|chr1:369380:-1|150|
 
-        String[] parts = fastaLabel.split("\\|");
+        String[] parts = label.split("\\|");
         if(!(parts.length == 4 || parts.length == 5))
         {
             SV_LOGGER.error("Expected 4 or 5 parts but got {}", parts.length);
-            throw new IllegalArgumentException("Invalid fasta label: " + fastaLabel);
+            throw new IllegalArgumentException("Invalid fasta label: " + label);
         }
         String id = parts[0];
         SagaBreakend breakend1 = SagaBreakend.fromString(parts[1]);
@@ -57,6 +69,6 @@ public record SagaAssembly(
         }
         SagaVariant variant = new SagaVariant(id, breakend1, breakend2);
         List<Integer> junctionOffsets = junctionOffset2 == null ? List.of(junctionOffset1) : List.of(junctionOffset1, junctionOffset2);
-        return new SagaAssembly(fastaLabel, variant, junctionOffsets, assemblyLength);
+        return new SagaAssembly(label, variant, junctionOffsets, sequence);
     }
 }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaBreakend.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaBreakend.java
@@ -8,7 +8,7 @@ import com.hartwig.hmftools.common.region.BasePosition;
 import org.jetbrains.annotations.NotNull;
 
 public record SagaBreakend(
-        BasePosition position,
+        BasePosition basePosition,
         Orientation orientation
 )
 {
@@ -25,10 +25,20 @@ public record SagaBreakend(
         return new SagaBreakend(new BasePosition(chromosome, position), orientation);
     }
 
+    public String chromosome()
+    {
+        return basePosition.Chromosome;
+    }
+
+    public int position()
+    {
+        return basePosition.Position;
+    }
+
     @Override
     @NotNull
     public String toString()
     {
-        return format("%s:%s", position, orientation);
+        return format("%s:%s", basePosition, orientation);
     }
 }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaIndexedBreakend.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaIndexedBreakend.java
@@ -15,12 +15,12 @@ public record SagaIndexedBreakend(
 {
     public String chromosome()
     {
-        return breakend.position().Chromosome;
+        return breakend.chromosome();
     }
 
     public int position()
     {
-        return breakend.position().Position;
+        return breakend.position();
     }
 
     public Orientation orientation()

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaJunctionInfo.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaJunctionInfo.java
@@ -1,6 +1,7 @@
 package com.hartwig.hmftools.esvee.common.saga;
 
 public record SagaJunctionInfo(
+        // The index just after the junction in assembly sequence.
         int assemblyOffset
 )
 {

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaMatchBySequence.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaMatchBySequence.java
@@ -3,9 +3,16 @@ package com.hartwig.hmftools.esvee.common.saga;
 import htsjdk.samtools.Cigar;
 
 public record SagaMatchBySequence(
-        SagaVariant variant,
-        Cigar cigar,
-        int alignScore
+        SagaAlignment alignment
 )
 {
+    public SagaVariant variant()
+    {
+        return alignment.sagaAssembly().variant();
+    }
+
+    public Cigar cigar()
+    {
+        return alignment.cigar();
+    }
 }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaResource.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaResource.java
@@ -45,7 +45,8 @@ public class SagaResource
         {
             samDict = fasta.getSequenceDictionary();
             samDict.getSequences().stream()
-                    .map(seq -> SagaAssembly.fromFastaLabel(seq.getSequenceName(), seq.getSequenceLength()))
+                    .map(seq ->
+                            SagaAssembly.fromFastaRecord(seq.getSequenceName(), fasta.getSequence(seq.getSequenceName()).getBaseString()))
                     .forEach(assemblies::add);
         }
         catch(IOException e)

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatchCandidate.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatchCandidate.java
@@ -11,7 +11,7 @@ public record SagaSequenceMatchCandidate(
         SagaAlignment alignment,
         List<SagaJunctionMatchInfo> queryJunctionMatches,
         List<SagaJunctionMatchInfo> sagaJunctionMatches,
-        Set<String> filters)
+        Set<SagaSequenceMatchCandidateFilter> filters)
 {
     public SagaAssembly sagaAssembly()
     {

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatchCandidateFilter.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatchCandidateFilter.java
@@ -1,0 +1,12 @@
+package com.hartwig.hmftools.esvee.common.saga;
+
+public enum SagaSequenceMatchCandidateFilter
+{
+    REVERSE_STRAND,
+    ALIGNED_LENGTH,
+    ALIGN_SCORE,
+    QUERY_JUNCTION_OVERLAP,
+    SAGA_JUNCTION_OVERLAP,
+    QUERY_JUNCTION_INDEL,
+    SAGA_JUNCTION_INDEL,
+}

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
@@ -125,7 +125,7 @@ public class SagaSequenceMatcher
 
     private SagaSequenceMatchCandidate evaluateAlignment(final SagaAlignment alignment, final MatchArguments args)
     {
-        Set<String> filters = new TreeSet<>();
+        Set<SagaSequenceMatchCandidateFilter> filters = new TreeSet<>();
 
         applyAlignmentFilters(alignment, args, filters);
 
@@ -136,26 +136,27 @@ public class SagaSequenceMatcher
         return new SagaSequenceMatchCandidate(alignment, queryJunctionMatches, sagaJunctionMatches, filters);
     }
 
-    private void applyAlignmentFilters(final SagaAlignment alignment, final MatchArguments args, Set<String> filters)
+    private void applyAlignmentFilters(final SagaAlignment alignment, final MatchArguments args,
+            Set<SagaSequenceMatchCandidateFilter> filters)
     {
         // For junction assemblies, the sequence may match to SAGA in reverse if it's part of an INV.
         // For phased assemblies, expect that it matches to the forward strand because ESVEE assemblies are always forward strand.
         if(!args.allowReverseStrand() && !alignment.isForward())
         {
-            filters.add("reverse_strand");
+            filters.add(SagaSequenceMatchCandidateFilter.REVERSE_STRAND);
         }
 
         // Only match if the majority of the sequences align, where possible.
         // I.e. don't allow a small subsequence match where much more sequence was possible to match.
         if(!checkAlignLength(alignment))
         {
-            filters.add("aligned_length");
+            filters.add(SagaSequenceMatchCandidateFilter.ALIGNED_LENGTH);
         }
 
         // Low alignment score means low sequence similarity, so we think this is not a good match.
         if(!checkAlignScore(alignment))
         {
-            filters.add("align_score");
+            filters.add(SagaSequenceMatchCandidateFilter.ALIGN_SCORE);
         }
     }
 
@@ -282,7 +283,7 @@ public class SagaSequenceMatcher
     }
 
     private List<SagaJunctionMatchInfo> filterJunctionMatches(final MatchArguments args,
-            final List<SagaJunctionMatchInfo> junctionMatchInfos, final String prefix, Set<String> filters)
+            final List<SagaJunctionMatchInfo> junctionMatchInfos, boolean isQuery, Set<SagaSequenceMatchCandidateFilter> filters)
     {
         List<SagaJunctionMatchInfo> alignedJunctions = junctionMatchInfos.stream()
                 .filter(j -> checkJunctionOverlap(j, args.lowerJunctionOverlap()))
@@ -292,7 +293,9 @@ public class SagaSequenceMatcher
         // Don't require all the junctions to be covered because we could be matching just one side of the variant (e.g. for junction assembly, or an SGL).
         if(alignedJunctions.isEmpty())
         {
-            filters.add(prefix + "_junction_overlap");
+            filters.add(isQuery
+                    ? SagaSequenceMatchCandidateFilter.QUERY_JUNCTION_OVERLAP
+                    : SagaSequenceMatchCandidateFilter.SAGA_JUNCTION_OVERLAP);
         }
 
         // Ensure there are no large indels near the junctions.
@@ -300,7 +303,9 @@ public class SagaSequenceMatcher
         // Potential FIXME: limit to only the matched junctions.
         if(junctionMatchInfos.stream().anyMatch(SagaJunctionMatchInfo::indelNearby))
         {
-            filters.add(prefix + "_junction_indel");
+            filters.add(isQuery
+                    ? SagaSequenceMatchCandidateFilter.QUERY_JUNCTION_INDEL
+                    : SagaSequenceMatchCandidateFilter.SAGA_JUNCTION_INDEL);
             return emptyList();
         }
         else
@@ -310,7 +315,8 @@ public class SagaSequenceMatcher
     }
 
     private void applyJunctionFilters(final MatchArguments args, final SagaAlignment alignment,
-            List<SagaJunctionMatchInfo> queryJunctionMatches, List<SagaJunctionMatchInfo> sagaJunctionMatches, Set<String> filters)
+            List<SagaJunctionMatchInfo> queryJunctionMatches, List<SagaJunctionMatchInfo> sagaJunctionMatches,
+            Set<SagaSequenceMatchCandidateFilter> filters)
     {
         List<CigarElemWithPos> cigarElements = getCigarElementPositions(alignment.cigar(), alignment.sagaStart());
 
@@ -319,8 +325,8 @@ public class SagaSequenceMatcher
         List<SagaJunctionMatchInfo> sagaJunctionMatchInfos = alignment.sagaAssembly().junctions().stream()
                 .map(j -> evaluateJunctionAlignment(alignment, cigarElements, j, false)).toList();
 
-        queryJunctionMatches.addAll(filterJunctionMatches(args, queryJunctionMatchInfos, "query", filters));
-        sagaJunctionMatches.addAll(filterJunctionMatches(args, sagaJunctionMatchInfos, "saga", filters));
+        queryJunctionMatches.addAll(filterJunctionMatches(args, queryJunctionMatchInfos, true, filters));
+        sagaJunctionMatches.addAll(filterJunctionMatches(args, sagaJunctionMatchInfos, false, filters));
     }
 
     public static BwaMemAligner.Params createAlignerParams(final SagaSequenceMatcherConfig matchConfig)

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
@@ -54,11 +54,6 @@ public class SagaSequenceMatcher
     {
     }
 
-    // junctionOffsets are the indices just after the junction in sequence.
-    // E.g.
-    // sequence = RRRJJJRRR
-    // junctionOffset[0] = 3
-    // junctionOffset[1] = 6
     @Nullable
     public SagaMatchBySequence matchBySequence(final byte[] sequence, final List<SagaJunctionInfo> junctions, boolean lowerJunctionOverlap,
             boolean allowReverseStrand)

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
@@ -86,7 +86,7 @@ public class SagaSequenceMatcher
         return candidates.stream()
                 .filter(SagaSequenceMatchCandidate::isAccepted)
                 .findFirst()
-                .map(candidate -> new SagaMatchBySequence(candidate.variant(), candidate.cigar(), candidate.alignScore()))
+                .map(candidate -> new SagaMatchBySequence(candidate.alignment()))
                 .orElse(null);
     }
 

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
@@ -108,8 +108,8 @@ public class SagaSequenceMatcher
             }
 
             // Then prefer the variant whose length is closer to the ESVEE assembly length (rarely occurs but can help tie-break different alleles).
-            int distance1 = abs(o1.sagaAssembly().assemblyLength() - args.query().length);
-            int distance2 = abs(o2.sagaAssembly().assemblyLength() - args.query().length);
+            int distance1 = abs(o1.sagaAssembly().length() - args.query().length);
+            int distance2 = abs(o2.sagaAssembly().length() - args.query().length);
             return Integer.compare(distance1, distance2);
         }
     }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaVariant.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaVariant.java
@@ -9,12 +9,40 @@ import org.jetbrains.annotations.NotNull;
 public record SagaVariant(
         String id,
         SagaBreakend breakend1,
-        SagaBreakend breakend2
+        SagaBreakend breakend2,
+        String insertSequence
 )
 {
+    public SagaVariant
+    {
+        // Only indels should be in the SAGA resource, and downstream code assumes all SAGA variants are indels.
+        if(!breakend1.chromosome().equals(breakend2.chromosome()))
+        {
+            throw new IllegalArgumentException();
+        }
+        if(!(breakend1.orientation().isForward() && breakend2.orientation().isReverse()))
+        {
+            throw new IllegalArgumentException();
+        }
+        if(!(breakend1.position() < breakend2.position()))
+        {
+            throw new IllegalArgumentException();
+        }
+        boolean isInsert = breakend1.position() + 1 == breakend2.position();
+        if(isInsert && insertSequence.isEmpty())
+        {
+            throw new IllegalArgumentException();
+        }
+    }
+
     public Stream<SagaBreakend> breakends()
     {
         return Stream.of(breakend1, breakend2);
+    }
+
+    public boolean isInsert()
+    {
+        return !insertSequence().isEmpty();
     }
 
     @Override

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/bam/CigarUtils.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/bam/CigarUtils.java
@@ -248,6 +248,12 @@ public final class CigarUtils
     public static int getReadIndexFromPosition(
             final int alignmentStart, final List<CigarElement> cigarElements, int position, boolean lastIfGapped, boolean inferFromSoftClip)
     {
+        return getReadIndexFromPosition(alignmentStart, cigarElements, position, lastIfGapped ? -1 : 0, inferFromSoftClip);
+    }
+
+    public static int getReadIndexFromPosition(
+            final int alignmentStart, final List<CigarElement> cigarElements, int position, int gapMode, boolean inferFromSoftClip)
+    {
         if(position < alignmentStart && !inferFromSoftClip)
             return INVALID_READ_INDEX;
 
@@ -269,9 +275,9 @@ public final class CigarUtils
                 }
                 else
                 {
-                    if(lastIfGapped)
+                    if(gapMode < 0)
                         --index;
-                    else
+                    else if(gapMode == 0)
                         return INVALID_READ_INDEX;
                 }
 

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/bam/CigarUtils.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/bam/CigarUtils.java
@@ -12,7 +12,6 @@ import static htsjdk.samtools.CigarOperator.I;
 import static htsjdk.samtools.CigarOperator.M;
 import static htsjdk.samtools.CigarOperator.S;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/sv/SvVcfTags.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/sv/SvVcfTags.java
@@ -90,6 +90,9 @@ public final class SvVcfTags
     public static final String SAGA_VARIANT = "SAGA";
     public static final String SAGA_VARIANT_DESC = "ID and breakends of the matched SAGA variant";
 
+    public static final String SAGA_INFERRED_BREAKEND = "SAGAINF";
+    public static final String SAGA_INFERRED_BREAKEND_DESC = "Indicates the breakend is inferred from the matched SAGA variant";
+
     // per sample
     public static final String SPLIT_FRAGS = "SF";
     public static final String SPLIT_FRAGS_DESC = "Count of fragments supporting the breakend with a read overlapping the breakend";


### PR DESCRIPTION
- For phased assemblies with 0 or 1 links, and a SAGA match.
- Use the SAGA breakends rather than aligning the assembly.
- This allows resolving SGLs to paired breakends, and addresses cases where the existing alignments/breakends are wrong due to homology or poor mappability.
- Use the insert sequence from SAGA rather than what's implied by the phased assembly. This allows resolving the full insert sequence, and provides a consistent representation.
- Adjust breakends for homology, as the existing indel breakend routine did.
- Add `SAGAINF` VCF info tag to breakends which are inferred to exist based on extending the insert sequence with SAGA.