### PR TITLE
Lilac: ensure gene cache is initialised before tests that need it

### DIFF
--- a/lilac/src/main/java/com/hartwig/hmftools/lilac/coverage/ComplexCoverage.java
+++ b/lilac/src/main/java/com/hartwig/hmftools/lilac/coverage/ComplexCoverage.java
@@ -73,10 +73,6 @@ public final class ComplexCoverage implements Comparable<ComplexCoverage>
 
     private int calcHomozygousCount()
     {
-        // for unit tests
-        if(GENE_CACHE == null)
-            return 0;
-
         return GENE_CACHE.ExpectAlleleCount - getAlleles().size();
     }
 

--- a/lilac/src/test/java/com/hartwig/hmftools/lilac/app/LilacAppTest.java
+++ b/lilac/src/test/java/com/hartwig/hmftools/lilac/app/LilacAppTest.java
@@ -1,16 +1,10 @@
 package com.hartwig.hmftools.lilac.app;
 
-import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.V37;
 import static com.hartwig.hmftools.lilac.LilacConstants.FAIL_LOW_COVERAGE_THRESHOLD;
 import static com.hartwig.hmftools.lilac.LilacConstants.STOP_LOSS_ON_C_ALLELE;
 import static com.hartwig.hmftools.lilac.LilacConstants.WARN_LOW_COVERAGE_THRESHOLD;
 import static com.hartwig.hmftools.lilac.ReferenceData.GENE_CACHE;
-import static com.hartwig.hmftools.lilac.ReferenceData.GENE_EXON_BOUNDARIES;
 import static com.hartwig.hmftools.lilac.ReferenceData.STOP_LOSS_ON_C_INDEL;
-import static com.hartwig.hmftools.lilac.ReferenceData.loadHlaTranscripts;
-import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_A;
-import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_B;
-import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_C;
 import static com.hartwig.hmftools.lilac.misc.LilacTestUtils.createFragment;
 import static com.hartwig.hmftools.lilac.misc.LilacTestUtils.disableLogging;
 import static com.hartwig.hmftools.lilac.qc.LilacQCStatus.PASS;
@@ -23,14 +17,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
-import com.hartwig.hmftools.lilac.GeneCache;
-import com.hartwig.hmftools.lilac.GeneSelector;
 import com.hartwig.hmftools.lilac.LilacApplication;
 import com.hartwig.hmftools.lilac.LilacConfig;
 import com.hartwig.hmftools.lilac.ReferenceData;
@@ -66,21 +57,6 @@ public class LilacAppTest
         LilacApplication app = new LilacApplication(new LilacConfig(SAMPLE_TEST), configBuilder);
         app.reset();
         return app;
-    }
-
-    public static void buildGeneCache()
-    {
-        if(GENE_CACHE != null)
-            return;
-
-        GENE_CACHE = new GeneCache(loadHlaTranscripts(V37, GeneSelector.MHC_CLASS_1));
-
-        if(GENE_EXON_BOUNDARIES == null)
-            GENE_EXON_BOUNDARIES = new HashMap<>();
-
-        GENE_EXON_BOUNDARIES.put(HLA_A, GENE_CACHE.AminoAcidExonBoundaries.get(HLA_A));
-        GENE_EXON_BOUNDARIES.put(HLA_B, GENE_CACHE.AminoAcidExonBoundaries.get(HLA_B));
-        GENE_EXON_BOUNDARIES.put(HLA_C, GENE_CACHE.AminoAcidExonBoundaries.get(HLA_C));
     }
 
     @Test

--- a/lilac/src/test/java/com/hartwig/hmftools/lilac/coverage/ComplexCoverageRankingTest.java
+++ b/lilac/src/test/java/com/hartwig/hmftools/lilac/coverage/ComplexCoverageRankingTest.java
@@ -2,6 +2,7 @@ package com.hartwig.hmftools.lilac.coverage;
 
 import static com.hartwig.hmftools.lilac.coverage.ComplexCoverageRanking.solutionComplexity;
 import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_A;
+import static com.hartwig.hmftools.lilac.util.GeneCacheSetup.buildGeneCache;
 
 import static org.junit.Assert.assertEquals;
 
@@ -19,10 +20,17 @@ import com.hartwig.hmftools.lilac.seq.HlaExonSequences;
 import com.hartwig.hmftools.lilac.seq.HlaSequenceLoci;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ComplexCoverageRankingTest
 {
+    @Before
+    public void setUp()
+    {
+        buildGeneCache();
+    }
+
     @Test
     public void testHomozygousCounts()
     {

--- a/lilac/src/test/java/com/hartwig/hmftools/lilac/coverage/CoverageTest.java
+++ b/lilac/src/test/java/com/hartwig/hmftools/lilac/coverage/CoverageTest.java
@@ -1,6 +1,7 @@
 package com.hartwig.hmftools.lilac.coverage;
 
 import static com.hartwig.hmftools.lilac.ReferenceData.GENE_CACHE;
+import static com.hartwig.hmftools.lilac.util.GeneCacheSetup.buildGeneCache;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -10,10 +11,17 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.hartwig.hmftools.lilac.hla.HlaAllele;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class CoverageTest
 {
+    @Before
+    public void setUp()
+    {
+        buildGeneCache();
+    }
+
     @Test
     public void testAlleleCoverageExpansion()
     {

--- a/lilac/src/test/java/com/hartwig/hmftools/lilac/fragment/NucleotideTest.java
+++ b/lilac/src/test/java/com/hartwig/hmftools/lilac/fragment/NucleotideTest.java
@@ -3,12 +3,12 @@ package com.hartwig.hmftools.lilac.fragment;
 import static com.hartwig.hmftools.lilac.LilacConstants.DEFAULT_MIN_DEPTH_FILTER;
 import static com.hartwig.hmftools.lilac.LilacUtils.namesMatch;
 import static com.hartwig.hmftools.lilac.ReferenceData.GENE_EXON_BOUNDARIES;
-import static com.hartwig.hmftools.lilac.app.LilacAppTest.buildGeneCache;
 import static com.hartwig.hmftools.lilac.fragment.FragmentUtils.expandIndices;
 import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_A;
 import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_B;
 import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_C;
 import static com.hartwig.hmftools.lilac.misc.LilacTestUtils.createReadRecord;
+import static com.hartwig.hmftools.lilac.util.GeneCacheSetup.buildGeneCache;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -32,12 +32,19 @@ import com.hartwig.hmftools.lilac.read.Read;
 import com.hartwig.hmftools.lilac.seq.SequenceCount;
 import com.hartwig.hmftools.lilac.util.ThrowOnUnstubbed;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import htsjdk.samtools.SAMRecord;
 
 public class NucleotideTest
 {
+    @Before
+    public void setUp()
+    {
+        buildGeneCache();
+    }
+
     @Test
     public void testCreateNucleotidesFromAminoAcid()
     {
@@ -49,8 +56,6 @@ public class NucleotideTest
     @Test
     public void testGeneEnrichment()
     {
-        buildGeneCache();
-
         NucleotideGeneEnrichment enricher = NucleotideGeneEnrichment.create(GENE_EXON_BOUNDARIES);
 
         List<Integer> indices = Lists.newArrayList();

--- a/lilac/src/test/java/com/hartwig/hmftools/lilac/util/GeneCacheSetup.java
+++ b/lilac/src/test/java/com/hartwig/hmftools/lilac/util/GeneCacheSetup.java
@@ -1,0 +1,32 @@
+package com.hartwig.hmftools.lilac.util;
+
+import static com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion.V37;
+import static com.hartwig.hmftools.lilac.ReferenceData.GENE_CACHE;
+import static com.hartwig.hmftools.lilac.ReferenceData.GENE_EXON_BOUNDARIES;
+import static com.hartwig.hmftools.lilac.ReferenceData.loadHlaTranscripts;
+import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_A;
+import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_B;
+import static com.hartwig.hmftools.lilac.hla.HlaGene.HLA_C;
+
+import java.util.HashMap;
+
+import com.hartwig.hmftools.lilac.GeneCache;
+import com.hartwig.hmftools.lilac.GeneSelector;
+
+public class GeneCacheSetup
+{
+    public static void buildGeneCache()
+    {
+        if(GENE_CACHE != null)
+            return;
+
+        GENE_CACHE = new GeneCache(loadHlaTranscripts(V37, GeneSelector.MHC_CLASS_1));
+
+        if(GENE_EXON_BOUNDARIES == null)
+            GENE_EXON_BOUNDARIES = new HashMap<>();
+
+        GENE_EXON_BOUNDARIES.put(HLA_A, GENE_CACHE.AminoAcidExonBoundaries.get(HLA_A));
+        GENE_EXON_BOUNDARIES.put(HLA_B, GENE_CACHE.AminoAcidExonBoundaries.get(HLA_B));
+        GENE_EXON_BOUNDARIES.put(HLA_C, GENE_CACHE.AminoAcidExonBoundaries.get(HLA_C));
+    }
+}


### PR DESCRIPTION
Initialisation that wasn't done before all tests that needed it, meaning that tests would pass or fail depending on if you ran them all together or individually.

E.g. failure here: https://github.com/hartwigmedical/hmftools/actions/runs/27931902664/job/82645298976

Fixed by moving the initialisation to a shared test utility and running it before the broken tests.