### PR TITLE
Add GitHub codeowners (AUS-434)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@hartwig-aus-dev
+*	@hartwigmedical/hartwig-aus-dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@hartwig-aus-dev


### PR DESCRIPTION
Owned by the Aus dev team: https://github.com/orgs/hartwigmedical/teams/hartwig-aus-dev/members

Once merged, we will require PRs to be approved by codeowners.