### PR TITLE
Esvee: fix SAGA sequence matching when aligning on reverse strand (AUS-260)

### DIFF
--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignment.java
@@ -52,12 +52,12 @@ public record SagaAlignment(
 
     public int queryStart()
     {
-        return leftClipLength(cigar);
+        return isForward() ? leftClipLength(cigar) : rightClipLength(cigar);
     }
 
     public int queryEnd()
     {
-        return queryLength - rightClipLength(cigar);
+        return queryLength - (isForward() ? rightClipLength(cigar) : leftClipLength(cigar));
     }
 
     public int queryAlignLength()
@@ -90,14 +90,14 @@ public record SagaAlignment(
         return rawAlignment.getAlignerScore();
     }
 
-    // How many more bases could've been aligned on the left?
-    public int leftUnaligned()
+    // How many more bases could've been aligned at the start of the sequences?
+    public int startUnaligned()
     {
         return min(queryStart(), sagaStart());
     }
 
-    // How many more bases could've been aligned on the right?
-    public int rightUnaligned()
+    // How many more bases could've been aligned at the end of the sequences?
+    public int endUnaligned()
     {
         return min(queryLength - queryEnd(), sagaLength() - sagaEnd());
     }

--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/common/saga/SagaSequenceMatcher.java
@@ -172,7 +172,7 @@ public class SagaSequenceMatcher
         // Checking this way instead of just looking at the alignment lengths, because for a single-sided assembly there may not be enough
         // bases to align through to 80% of the other side, even though this is a legit match.
         // It's better to look at how many bases could've been aligned on either side of the aligned subsequence and see if this is too many.
-        int unaligned = alignment.leftUnaligned() + alignment.rightUnaligned();
+        int unaligned = alignment.startUnaligned() + alignment.endUnaligned();
         int maxUnaligned = calcMaxUnalignedBases(alignment.queryLength(), alignment.sagaLength());
         return unaligned <= maxUnaligned;
     }
@@ -224,8 +224,9 @@ public class SagaSequenceMatcher
 
     private record CigarElemWithPos(
             CigarElement element,
-            int readStart,
-            int readEnd,    // Exclusive
+            // Query positions are in the original query sequence (significant for reverse strand matches).
+            int queryStart,
+            int queryEnd,    // Exclusive
             int refStart,
             int refEnd      // Exclusive
     )
@@ -236,27 +237,29 @@ public class SagaSequenceMatcher
         }
     }
 
-    private static List<CigarElemWithPos> getCigarElementPositions(final Cigar cigar, int refStart)
+    private static List<CigarElemWithPos> getCigarElementPositions(final Cigar cigar, int refStart, boolean isForward, int queryLength)
     {
         List<CigarElemWithPos> result = new ArrayList<>();
-        int readIndex = 0;
+        int queryIndex = 0;
         int refIndex = refStart;
         for(CigarElement element : cigar.getCigarElements())
         {
             CigarOperator operator = element.getOperator();
-            int nextReadIndex = readIndex;
+            int nextQueryIndex = queryIndex;
             if(operator.consumesReadBases() || operator.isClipping())
             {
-                nextReadIndex += element.getLength();
+                nextQueryIndex += element.getLength();
             }
             int nextRefIndex = refIndex;
             if(operator.consumesReferenceBases())
             {
                 nextRefIndex += element.getLength();
             }
-            result.add(new CigarElemWithPos(element, readIndex, nextReadIndex, refIndex, nextRefIndex));
+            int queryStart = isForward ? queryIndex : queryLength - nextQueryIndex;
+            int queryEnd = isForward ? nextQueryIndex : queryLength - queryIndex;
+            result.add(new CigarElemWithPos(element, queryStart, queryEnd, refIndex, nextRefIndex));
 
-            readIndex = nextReadIndex;
+            queryIndex = nextQueryIndex;
             refIndex = nextRefIndex;
         }
         return result;
@@ -267,7 +270,7 @@ public class SagaSequenceMatcher
         return cigarElements.stream()
                 .filter(e -> e.operator().isIndel() && !ignoreIndel(e.element()))
                 .anyMatch(e -> isJunctionNearIndel(
-                        junctionInfo.assemblyOffset(), isQuery ? e.readStart() : e.refStart(), isQuery ? e.readEnd() : e.refEnd()));
+                        junctionInfo.assemblyOffset(), isQuery ? e.queryStart() : e.refStart(), isQuery ? e.queryEnd() : e.refEnd()));
     }
 
     private boolean ignoreIndel(final CigarElement element)
@@ -320,7 +323,8 @@ public class SagaSequenceMatcher
             List<SagaJunctionMatchInfo> queryJunctionMatches, List<SagaJunctionMatchInfo> sagaJunctionMatches,
             Set<SagaSequenceMatchCandidateFilter> filters)
     {
-        List<CigarElemWithPos> cigarElements = getCigarElementPositions(alignment.cigar(), alignment.sagaStart());
+        List<CigarElemWithPos> cigarElements = getCigarElementPositions(
+                alignment.cigar(), alignment.sagaStart(), alignment.isForward(), alignment.queryLength());
 
         List<SagaJunctionMatchInfo> queryJunctionMatchInfos = args.junctions().stream()
                 .map(j -> evaluateJunctionAlignment(alignment, cigarElements, j, true)).toList();

--- a/esvee/src/test/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignmentTest.java
+++ b/esvee/src/test/java/com/hartwig/hmftools/esvee/common/saga/SagaAlignmentTest.java
@@ -44,67 +44,67 @@ public class SagaAlignmentTest
     }
 
     @Test
-    public void testLeftUnalignedQueryStartLimits()
+    public void testStartUnalignedQueryStartLimits()
     {
         // queryStart=5 (5S clip), sagaStart=10 → min(5, 10) = 5
         SagaAlignment a = alignment(25, 10, 25, "5S15M5S", 60);
-        assertEquals(5, a.leftUnaligned());
+        assertEquals(5, a.startUnaligned());
     }
 
     @Test
-    public void testLeftUnalignedSagaStartLimits()
+    public void testStartUnalignedSagaStartLimits()
     {
         // queryStart=10 (10S clip), sagaStart=3 → min(10, 3) = 3
         SagaAlignment a = alignment(25, 3, 15, "10S12M3S", 60);
-        assertEquals(3, a.leftUnaligned());
+        assertEquals(3, a.startUnaligned());
     }
 
     @Test
-    public void testLeftUnalignedBothEqual()
+    public void testStartUnalignedBothEqual()
     {
         // queryStart=5, sagaStart=5 → min(5, 5) = 5
         SagaAlignment a = alignment(20, 5, 15, "5S10M5S", 60);
-        assertEquals(5, a.leftUnaligned());
+        assertEquals(5, a.startUnaligned());
     }
 
     @Test
-    public void testLeftUnalignedNoClipNoSagaOffset()
+    public void testStartUnalignedNoClipNoSagaOffset()
     {
         // queryStart=0 (no clip), sagaStart=0 → min(0, 0) = 0
         SagaAlignment a = alignment(10, 0, 10, "10M", 20);
-        assertEquals(0, a.leftUnaligned());
+        assertEquals(0, a.startUnaligned());
     }
 
     @Test
-    public void testRightUnalignedQuerySideLimits()
+    public void testEndUnalignedQuerySideLimits()
     {
         // rightClip=5, sagaLength - sagaEnd = 60-25=35 → min(5, 35) = 5
         SagaAlignment a = alignment(25, 10, 20, "5S10M5S", 60);
-        assertEquals(5, a.rightUnaligned());
+        assertEquals(5, a.endUnaligned());
     }
 
     @Test
-    public void testRightUnalignedSagaSideLimits()
+    public void testEndUnalignedSagaSideLimits()
     {
         // rightClip=10, sagaLength - sagaEnd = 20-15=5 → min(10, 5) = 5
         SagaAlignment a = alignment(25, 5, 15, "5S10M10S", 20);
-        assertEquals(5, a.rightUnaligned());
+        assertEquals(5, a.endUnaligned());
     }
 
     @Test
-    public void testRightUnalignedBothEqual()
+    public void testEndUnalignedBothEqual()
     {
         // rightClip=5, sagaLength - sagaEnd = 25-20=5 → min(5, 5) = 5
         SagaAlignment a = alignment(20, 10, 20, "5S10M5S", 25);
-        assertEquals(5, a.rightUnaligned());
+        assertEquals(5, a.endUnaligned());
     }
 
     @Test
-    public void testRightUnalignedNoClipNoSagaRemaining()
+    public void testEndUnalignedNoClipNoSagaRemaining()
     {
         // rightClip=0, sagaLength - sagaEnd = 10-10=0 → min(0, 0) = 0
         SagaAlignment a = alignment(10, 0, 10, "10M", 10);
-        assertEquals(0, a.rightUnaligned());
+        assertEquals(0, a.endUnaligned());
     }
 
     @Test


### PR DESCRIPTION
The logic which checks junction overlap and indels near junctions used wrong positions when the alignment was reverse strand. This is now fixed. Reverse strand matches don't occur often but may occur e.g. for a single junction part of a larger insert sequence.