### PR TITLE
Skip Java build and test CI for PRs which only modify documentation (AUS-434)

### DIFF
--- a/.github/workflows/java-build-test-skip.yml
+++ b/.github/workflows/java-build-test-skip.yml
@@ -1,0 +1,22 @@
+# Quick no-op action to run in place of the real build and test workflow, for commits which only touch documentation.
+
+name: Java build and unit test
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: ["opened", "reopened", "synchronize"]
+    paths:
+      # These must match the ignored paths in the real build workflow.
+      - "**/*.md"
+      - "**/*.png"
+      - "**/*.jpg"
+      - "*/docs/*.html"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: "echo 'No code changes - nothing to do'"

--- a/.github/workflows/java-build-test.yml
+++ b/.github/workflows/java-build-test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ "master" ]
     types: ["opened", "reopened", "synchronize"]
+    paths-ignore:
+      # Don't run on documentation changes, since the code is not affected.
+      - "**/*.md"
+      - "**/*.png"
+      - "**/*.jpg"
+      - "*/docs/*.html"
 
 jobs:
   build:


### PR DESCRIPTION
So PRs for docs only can be faster.