### PR TITLE
Esvee: set breakend qual for SAGA matched variants (AUS-260)

### DIFF
--- a/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
+++ b/esvee/src/main/java/com/hartwig/hmftools/esvee/assembly/alignment/AssemblyAligner.java
@@ -189,6 +189,10 @@ public class AssemblyAligner extends ThreadTask
         AlignData alignData = AlignData.fromSaga(sagaAlignment);
         alignData.setFullSequenceData(assemblyAlignment.fullSequence(), assemblyAlignment.fullSequenceLength());
 
+        // derive the modified map qual from the SAGA alignment, as done for BWA alignments in AlignmentFilters.
+        // this is a single alignment so there is no neighbouring-alignment overlap (inexact homology) to account for.
+        alignData.setAdjustedAlignment(assemblyAlignment.fullSequence(), 0, 0);
+
         BreakendBuilder breakendBuilder = new BreakendBuilder(mConfig.RefGenome, assemblyAlignment);
         boolean success = breakendBuilder.formBreakendsFromSaga(sagaAlignment, alignData);
         if(!success)


### PR DESCRIPTION
Fixes the qual field always being 0 if SAGA matched. The value is now computed based off the BWA alignment to the SAGA assembly, using the same methodology as for the non-SAGA case.