### PR TITLE
GeneUtils: fix overlapping regions in BED file (INN-329)

### DIFF
--- a/gene-utils/src/main/java/com/hartwig/hmftools/geneutils/targetregion/RegionData.java
+++ b/gene-utils/src/main/java/com/hartwig/hmftools/geneutils/targetregion/RegionData.java
@@ -124,7 +124,7 @@ public class RegionData extends ChrBaseRegion
             if(region.start() > newRegion.end())
                 break;
 
-            if(newRegion.matches(region))
+            if(region.containsRegion(newRegion))
                 return;
 
             if(newRegion.start() < region.start())


### PR DESCRIPTION
Happened when a new specific region is a strict subset of an existing region.