### PR TITLE
FastqTools: fix truncation data loss and match-count race

### DIFF
--- a/fastq-tools/src/main/java/com/hartwig/hmftools/fastqtools/umi/FastqUmiExtracter.java
+++ b/fastq-tools/src/main/java/com/hartwig/hmftools/fastqtools/umi/FastqUmiExtracter.java
@@ -276,23 +276,20 @@ public class FastqUmiExtracter
 
     private static void compressTextLines(final String[] lines, final Path outputPath) throws IOException
     {
-        OutputStream fos = Files.newOutputStream(outputPath);
-        BufferedOutputStream bos = new BufferedOutputStream(fos);
-        GZIPOutputStream gzos = new GZIPOutputStream(bos);
-
-        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(gzos, StandardCharsets.UTF_8));
-
-        for(String line : lines)
+        try(OutputStream fos = Files.newOutputStream(outputPath);
+            BufferedOutputStream bos = new BufferedOutputStream(fos);
+            GZIPOutputStream gzos = new GZIPOutputStream(bos);
+            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(gzos, StandardCharsets.UTF_8)))
         {
-            if(line == null)
-                break;
+            for(String line : lines)
+            {
+                if(line == null)
+                    break;
 
-            writer.write(line);
-            writer.newLine();
+                writer.write(line);
+                writer.newLine();
+            }
         }
-
-        writer.flush();
-        gzos.finish();
     }
 
     private static final String ZIPPED_EXTENSION = ".gz";

--- a/fastq-tools/src/main/java/com/hartwig/hmftools/fastqtools/umi/KnownUmis.java
+++ b/fastq-tools/src/main/java/com/hartwig/hmftools/fastqtools/umi/KnownUmis.java
@@ -16,6 +16,7 @@ import static com.hartwig.hmftools.fastqtools.FastqCommon.READ_ITEM_QUALS;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.common.codon.Nucleotides;
@@ -28,7 +29,7 @@ public class KnownUmis
 
     private final List<String> mKnownUmis;
     private final List<String> mKnownUmisReversed;
-    private long mKnownUmiMatchCount;
+    private final AtomicLong mKnownUmiMatchCount;
 
     private final String UNMATCHED_UMI = "X";
 
@@ -45,7 +46,7 @@ public class KnownUmis
 
         mKnownUmis = Lists.newArrayList();
         mKnownUmisReversed = Lists.newArrayList();
-        mKnownUmiMatchCount = 0;
+        mKnownUmiMatchCount = new AtomicLong();
 
         if(knownUmiFile != null)
         {
@@ -69,7 +70,7 @@ public class KnownUmis
 
         if(umiLength1 > 0 && umiLength2 > 0)
         {
-            ++mKnownUmiMatchCount;
+            mKnownUmiMatchCount.incrementAndGet();
         }
         else
         {
@@ -190,7 +191,8 @@ public class KnownUmis
         if(mKnownUmis.isEmpty() || readCount == 0)
             return;
 
-        double matchedPerc = mKnownUmiMatchCount / (double)readCount;
-        FQ_LOGGER.info("known UMI matched({} {}%)", mKnownUmiMatchCount, format("%.2f", matchedPerc * 100));
+        long matchCount = mKnownUmiMatchCount.get();
+        double matchedPerc = matchCount / (double)readCount;
+        FQ_LOGGER.info("known UMI matched({} {}%)", matchCount, format("%.2f", matchedPerc * 100));
     }
 }


### PR DESCRIPTION
PR for a couple of fixes to merge back into the AUS440-fastq-misc branch.

* There's a missing writer.close(), the last batch of data sits in the buffer and isn't written. Fixed properly using try with resources.
* A count is incremented from threads which is non deterministic, fixed with atomic. Don't think this should introduce much contention.

Both issues reproduced using machine generated test scripts + data, and the fixes verified same way.