### PR TITLE
OPR-469: Support cuppa chart plot to findings model

### DIFF
--- a/finding/src/main/java/com/hartwig/hmftools/finding/FindingRecordFactory.java
+++ b/finding/src/main/java/com/hartwig/hmftools/finding/FindingRecordFactory.java
@@ -260,7 +260,7 @@ public class FindingRecordFactory
                             .findingKey("predictedTumorOrigin")
                             .mode(cuppaMode(cuppa.mode()))
                             .predictions(predictedTumorOrigins)
-                            .visualisationFile(VisualisationFileUtil.createNullable(orangePlots.cuppaSummaryPlot()))
+                            .visualisationFile(VisualisationFileUtil.createNullable(orangePlots.cuppaChartPlot()))
                             .build()
                     )
                     .build();

--- a/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangePlots.java
+++ b/orange-datamodel/src/main/java/com/hartwig/hmftools/datamodel/orange/OrangePlots.java
@@ -49,7 +49,6 @@ public interface OrangePlots
     @Nullable
     String cuppaFeaturePlot();
 
-    @Deprecated
     @Nullable
     String cuppaChartPlot();
 }


### PR DESCRIPTION
Support the cuppa chart plot in the output of the findings model to use for OncoAct reporting 