### PR TITLE
Infra 2908 - add bamchecker option to filter out reads+contigs not in the ref genome

### DIFF
--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/BamChecker.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/BamChecker.java
@@ -61,9 +61,17 @@ public class BamChecker
                 .referenceSequence(new File(mConfig.RefGenomeFile))
                 .open(new File(mConfig.BamFile)).getFileHeader();
 
-        FragmentCache fragmentCache = new FragmentCache(fileHeader);
+        RefGenomeCompatibility refGenomeCompatibility = null;
+        if(mConfig.FilterNonRefContigs)
+        {
+            refGenomeCompatibility = new RefGenomeCompatibility(mConfig.RefGenomeContigs, fileHeader, mConfig.RefGenomeDictionary);
+            BT_LOGGER.info("filtering BAM output to {} reference contigs", mConfig.RefGenomeContigs.size());
+        }
 
-        List<PartitionThread> partitionThreads = createPartitionThreads(fragmentCache);
+        FragmentCache fragmentCache = new FragmentCache(
+                refGenomeCompatibility != null ? refGenomeCompatibility.outputHeader() : fileHeader);
+
+        List<PartitionThread> partitionThreads = createPartitionThreads(fragmentCache, refGenomeCompatibility);
         List<Thread> allThreads = Lists.newArrayList(partitionThreads);
 
         if(!runThreadTasks(allThreads))
@@ -113,7 +121,7 @@ public class BamChecker
         BT_LOGGER.info("BamChecker complete, mins({})", runTimeMinsStr(startTimeMs));
     }
 
-    private List<PartitionThread> createPartitionThreads(final FragmentCache fragmentCache)
+    private List<PartitionThread> createPartitionThreads(final FragmentCache fragmentCache, final RefGenomeCompatibility refGenomeCompatibility)
     {
         List<PartitionThread> partitionThreads = Lists.newArrayListWithCapacity(mConfig.Threads);
 
@@ -131,7 +139,7 @@ public class BamChecker
 
         for(int i = 0; i < mConfig.Threads; ++i)
         {
-            PartitionThread partitionThread = new PartitionThread(mConfig, fragmentCache, taskQueue, i);
+            PartitionThread partitionThread = new PartitionThread(mConfig, fragmentCache, taskQueue, i, refGenomeCompatibility);
             partitionThreads.add(partitionThread);
         }
 

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/CheckConfig.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/CheckConfig.java
@@ -29,11 +29,17 @@ import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.parseOutput
 import static com.hartwig.hmftools.common.utils.file.FileWriterUtils.pathFromFile;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.hartwig.hmftools.common.bamops.BamToolName;
+import com.hartwig.hmftools.common.genome.refgenome.RefGenomeSource;
 import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.region.SpecificRegions;
 import com.hartwig.hmftools.common.utils.config.ConfigBuilder;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
 
 public class CheckConfig
 {
@@ -52,7 +58,10 @@ public class CheckConfig
     public final boolean SkipUnmapped;
     public final boolean ReverseBqsr;
     public final boolean DropIncompleteFragments;
+    public final boolean FilterNonRefContigs;
     public final int SortThreadMemory;
+    public final SAMSequenceDictionary RefGenomeDictionary;
+    public final Set<String> RefGenomeContigs;
 
     public static CheckParams Params = new CheckParams(); // global since used per-fragment
 
@@ -69,6 +78,7 @@ public class CheckConfig
     public static final String CONVERT_HARD_CLIPS = "convert_hard_clips";
     public static final String MIN_ALIGNMENT_SCORE = "min_align_score";
     public static final String SORT_THREAD_MEMORY = "sort_thread_mem";
+    public static final String FILTER_NON_REF_CONTIGS = "filter_non_ref_contigs";
 
 
     public static final String WRITE_INCOMPLETE_FRAGS = "write_incompletes";
@@ -122,6 +132,10 @@ public class CheckConfig
         MaxWriteIncompleteFragments = configBuilder.getInteger(MAX_WRITE_INCOMPLETE_FRAGS);
         WriteIncompleteFragments = configBuilder.hasFlag(WRITE_INCOMPLETE_FRAGS) || MaxWriteIncompleteFragments > 0;
         DropIncompleteFragments = configBuilder.hasFlag(DROP_INCOMPLETE_FRAGS);
+        FilterNonRefContigs = configBuilder.hasFlag(FILTER_NON_REF_CONTIGS);
+        RefGenomeDictionary = FilterNonRefContigs ? loadRefGenomeDictionary(RefGenomeFile) : null;
+        RefGenomeContigs = RefGenomeDictionary != null ? RefGenomeDictionary.getSequences().stream()
+                .map(SAMSequenceRecord::getSequenceName).collect(Collectors.toSet()) : null;
 
         LOG_READ_COUNT = configBuilder.getInteger(CFG_LOG_READ_COUNT);
         SortThreadMemory = configBuilder.getInteger(SORT_THREAD_MEMORY);
@@ -144,6 +158,15 @@ public class CheckConfig
 
     public boolean writeBam() { return BamToolPath != null; }
 
+    private static SAMSequenceDictionary loadRefGenomeDictionary(final String refGenomeFile)
+    {
+        RefGenomeSource refGenomeSource = RefGenomeSource.loadRefGenome(refGenomeFile);
+        if(refGenomeSource == null)
+            throw new IllegalStateException("failed to load reference genome: " + refGenomeFile);
+
+        return refGenomeSource.refGenomeFile().getSequenceDictionary();
+    }
+
     public static void registerConfig(final ConfigBuilder configBuilder)
     {
         configBuilder.addPath(BAM_FILE, true, BAM_FILE_DESC);
@@ -164,6 +187,7 @@ public class CheckConfig
 
         configBuilder.addInteger(CFG_LOG_READ_COUNT, "Log partition processed read count frequency", LOG_READ_COUNT);
         configBuilder.addInteger(SORT_THREAD_MEMORY, "Memory per sort thread (value in GB)", DEFAULT_SORT_THREAD_MEMORY);
+        configBuilder.addFlag(FILTER_NON_REF_CONTIGS, "Filter reads and header contigs not present in the reference genome");
         configBuilder.addInteger(MAX_WRITE_INCOMPLETE_FRAGS, "Max incomplete fragments to write (0 means unlimited)", 0);
         configBuilder.addFlag(PERF_DEBUG, PERF_DEBUG_DESC);
         configBuilder.addFlag(SKIP_UNMAPPED, "Skip full unmapped reads");

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/FragmentStats.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/FragmentStats.java
@@ -12,6 +12,7 @@ public class FragmentStats
     public long MateCigarFixed;
     public long SuppsDropped;
     public long PrimariesUnmapped;
+    public long NonRefContigDropped;
 
     public FragmentStats()
     {
@@ -22,6 +23,7 @@ public class FragmentStats
         MateCigarFixed = 0;
         SuppsDropped = 0;
         PrimariesUnmapped = 0;
+        NonRefContigDropped = 0;
     }
 
     public void reset()
@@ -33,6 +35,7 @@ public class FragmentStats
         MateCigarFixed = 0;
         SuppsDropped = 0;
         PrimariesUnmapped = 0;
+        NonRefContigDropped = 0;
     }
 
     public void merge(final FragmentStats other)
@@ -44,12 +47,13 @@ public class FragmentStats
         MateCigarFixed += other.MateCigarFixed;
         PrimariesUnmapped += other.PrimariesUnmapped;
         SuppsDropped += other.SuppsDropped;
+        NonRefContigDropped += other.NonRefContigDropped;
     }
 
     public String toString()
     {
-        return format("fragments(%d) interPartition(%d) withSupp(%d) maxFrags(%d) mateCigarFixed(%d) primaryUnmapped(%d) suppDropped(%d)",
+        return format("fragments(%d) interPartition(%d) withSupp(%d) maxFrags(%d) mateCigarFixed(%d) primaryUnmapped(%d) suppDropped(%d) nonRefContigDropped(%d)",
                 TotalFragments, InterPartitionFragments, FragmentsWithSupplementaries, MaxFragmentCount, MateCigarFixed,
-                PrimariesUnmapped, SuppsDropped);
+                PrimariesUnmapped, SuppsDropped, NonRefContigDropped);
     }
 }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/PartitionChecker.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/PartitionChecker.java
@@ -34,6 +34,7 @@ public class PartitionChecker
     private final SamReader mSamReader;
     private final SAMFileWriter mBamWriter;
     private final FragmentCache mFragmentCache;
+    private final RefGenomeCompatibility mRefGenomeCompatibility;
 
     private final BamSlicer mBamSlicer;
     private ChrBaseRegion mRegion;
@@ -48,12 +49,14 @@ public class PartitionChecker
     private final boolean mLogReadIds;
 
     public PartitionChecker(
-            final CheckConfig config, final FragmentCache fragmentCache, final SamReader samReader, final SAMFileWriter bamWriter)
+            final CheckConfig config, final FragmentCache fragmentCache, final SamReader samReader, final SAMFileWriter bamWriter,
+            final RefGenomeCompatibility refGenomeCompatibility)
     {
         mConfig = config;
         mSamReader = samReader;
         mBamWriter = bamWriter;
         mFragmentCache = fragmentCache;
+        mRefGenomeCompatibility = refGenomeCompatibility;
 
         mRegion = null;
 
@@ -140,6 +143,12 @@ public class PartitionChecker
         if(mLogReadIds && mConfig.LogReadIds.contains(read.getReadName()))
         {
             BT_LOGGER.debug("specific read({})", readToString(read));
+        }
+
+        if(mRefGenomeCompatibility != null && !mRefGenomeCompatibility.recordIsCompatible(read))
+        {
+            ++mCurrentStats.NonRefContigDropped;
+            return;
         }
 
         if(!mRegion.containsPosition(read.getAlignmentStart()))
@@ -264,6 +273,15 @@ public class PartitionChecker
 
     private void writeRecord(final SAMRecord read)
     {
+        if(mBamWriter == null)
+            return;
+
+        if(mRefGenomeCompatibility != null && !mRefGenomeCompatibility.prepareForWrite(read))
+        {
+            ++mCurrentStats.NonRefContigDropped;
+            return;
+        }
+
         if(mBamWriter != null)
             mBamWriter.addAlignment(read);
     }

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/PartitionChecker.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/PartitionChecker.java
@@ -145,7 +145,7 @@ public class PartitionChecker
             BT_LOGGER.debug("specific read({})", readToString(read));
         }
 
-        if(mRefGenomeCompatibility != null && !mRefGenomeCompatibility.recordIsCompatible(read))
+        if(mRefGenomeCompatibility != null && !mRefGenomeCompatibility.prepareForWrite(read))
         {
             ++mCurrentStats.NonRefContigDropped;
             return;

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/PartitionThread.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/PartitionThread.java
@@ -28,6 +28,7 @@ public class PartitionThread extends Thread
     private final SAMFileWriter mBamWriter;
     private final SamReader mSamReader;
     private final TaskQueue mPartitions;
+    private final RefGenomeCompatibility mRefGenomeCompatibility;
 
     private final PartitionChecker mPartitionChecker;
     private final String mBamFilename;
@@ -36,9 +37,11 @@ public class PartitionThread extends Thread
     protected static final String SORTED_BAM_ID = "sorted";
 
     public PartitionThread(
-            final CheckConfig config, final FragmentCache fragmentCache, final TaskQueue partitions, final int threadId)
+            final CheckConfig config, final FragmentCache fragmentCache, final TaskQueue partitions, final int threadId,
+            final RefGenomeCompatibility refGenomeCompatibility)
     {
         mPartitions = partitions;
+        mRefGenomeCompatibility = refGenomeCompatibility;
 
         mSamReader = SamReaderFactory.makeDefault()
                 .referenceSequence(new File(config.RefGenomeFile))
@@ -50,7 +53,7 @@ public class PartitionThread extends Thread
             // create a BAM writer per thread
             mBamFilename = config.formFilename(format("%s_%02d", UNSORTED_BAM_ID, threadId), BAM_EXTENSION);
 
-            SAMFileHeader fileHeader = mSamReader.getFileHeader().clone();
+            SAMFileHeader fileHeader = mRefGenomeCompatibility != null ? mRefGenomeCompatibility.outputHeader() : mSamReader.getFileHeader().clone();
             fileHeader.setSortOrder(SAMFileHeader.SortOrder.unsorted);
 
             mBamWriter = new SAMFileWriterFactory().makeBAMWriter(fileHeader, false, new File(mBamFilename));
@@ -61,13 +64,14 @@ public class PartitionThread extends Thread
             mBamFilename = "";
         }
 
-        mPartitionChecker = new PartitionChecker(config, fragmentCache, mSamReader, mBamWriter);
+        mPartitionChecker = new PartitionChecker(config, fragmentCache, mSamReader, mBamWriter, mRefGenomeCompatibility);
     }
 
     public static List<ChrBaseRegion> splitRegionsIntoPartitions(final CheckConfig config)
     {
         return PartitionTask.splitRegionsIntoPartitions(
-                config.BamFile, config.RefGenomeFile, config.Threads, config.SpecificChrRegions, config.PartitionSize);
+                config.BamFile, config.RefGenomeFile, config.Threads, config.SpecificChrRegions, config.PartitionSize,
+                config.FilterNonRefContigs ? config.RefGenomeDictionary : null);
     }
 
     public FragmentStats stats() { return mPartitionChecker.stats(); }
@@ -103,13 +107,18 @@ public class PartitionThread extends Thread
         while(iterator.hasNext())
         {
             SAMRecord record = iterator.next();
+            if(mRefGenomeCompatibility != null && !mRefGenomeCompatibility.prepareForWrite(record))
+                continue;
+
             mBamWriter.addAlignment(record);
         }
     }
 
     public void writeIncompleteReads(final List<SAMRecord> reads)
     {
-        reads.forEach(x -> mBamWriter.addAlignment(x));
+        reads.stream()
+                .filter(x -> mRefGenomeCompatibility == null || mRefGenomeCompatibility.prepareForWrite(x))
+                .forEach(x -> mBamWriter.addAlignment(x));
     }
 
     public void close()

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/RefGenomeCompatibility.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/checker/RefGenomeCompatibility.java
@@ -1,0 +1,73 @@
+package com.hartwig.hmftools.bamtools.checker;
+
+import static com.hartwig.hmftools.common.bam.SamRecordUtils.NO_CHROMOSOME_NAME;
+import static com.hartwig.hmftools.common.bam.SamRecordUtils.SUPPLEMENTARY_ATTRIBUTE;
+
+import java.util.Set;
+
+import com.hartwig.hmftools.common.bam.SupplementaryReadData;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+
+public class RefGenomeCompatibility
+{
+    private static final String SAME_AS_REFERENCE_NAME = "=";
+
+    private final Set<String> mAllowedContigs;
+    private final SAMFileHeader mOutputHeader;
+
+    public RefGenomeCompatibility(final Set<String> allowedContigs, final SAMFileHeader inputHeader, final SAMSequenceDictionary refDictionary)
+    {
+        mAllowedContigs = allowedContigs;
+        mOutputHeader = inputHeader.clone();
+        mOutputHeader.setSequenceDictionary(refDictionary);
+    }
+
+    public SAMFileHeader outputHeader()
+    {
+        return mOutputHeader.clone();
+    }
+
+    public boolean recordIsCompatible(final SAMRecord record)
+    {
+        if(!contigIsCompatible(record.getReferenceName()))
+            return false;
+
+        if(!contigIsCompatible(resolvedMateReferenceName(record)))
+            return false;
+
+        String suppData = record.getStringAttribute(SUPPLEMENTARY_ATTRIBUTE);
+        if(suppData == null)
+            return true;
+
+        return SupplementaryReadData.extractAlignments(suppData).stream().allMatch(x -> contigIsCompatible(x.Chromosome));
+    }
+
+    public boolean prepareForWrite(final SAMRecord record)
+    {
+        if(!recordIsCompatible(record))
+            return false;
+
+        String referenceName = record.getReferenceName();
+        String mateReferenceName = resolvedMateReferenceName(record);
+
+        record.setHeader(mOutputHeader);
+        record.setReferenceName(referenceName);
+        record.setMateReferenceName(mateReferenceName);
+
+        return true;
+    }
+
+    private boolean contigIsCompatible(final String contig)
+    {
+        return contig == null || contig.equals(NO_CHROMOSOME_NAME) || mAllowedContigs.contains(contig);
+    }
+
+    private static String resolvedMateReferenceName(final SAMRecord record)
+    {
+        String mateReferenceName = record.getMateReferenceName();
+        return SAME_AS_REFERENCE_NAME.equals(mateReferenceName) ? record.getReferenceName() : mateReferenceName;
+    }
+}

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/common/PartitionTask.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/common/PartitionTask.java
@@ -14,6 +14,7 @@ import com.hartwig.hmftools.common.region.ChrBaseRegion;
 import com.hartwig.hmftools.common.region.SpecificRegions;
 
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
@@ -32,6 +33,13 @@ public class PartitionTask
     public static List<ChrBaseRegion> splitRegionsIntoPartitions(
             final String bamFile, final String refGenomeFile, final int threads, final SpecificRegions specificRegions, final int partitionSize)
     {
+        return splitRegionsIntoPartitions(bamFile, refGenomeFile, threads, specificRegions, partitionSize, null);
+    }
+
+    public static List<ChrBaseRegion> splitRegionsIntoPartitions(
+            final String bamFile, final String refGenomeFile, final int threads, final SpecificRegions specificRegions, final int partitionSize,
+            final SAMSequenceDictionary partitionDictionary)
+    {
         List<ChrBaseRegion> partitionRegions = Lists.newArrayList();
 
         if(!specificRegions.Regions.isEmpty())
@@ -39,10 +47,12 @@ public class PartitionTask
             // only split by thread count if can be done simply
             if(specificRegions.Regions.size() == 1)
             {
+                ChrBaseRegion specificRegion = specificRegions.Regions.get(0);
+                if(partitionDictionary != null && partitionDictionary.getSequence(specificRegion.Chromosome) == null)
+                    return partitionRegions;
+
                 if(threads > 1)
                 {
-                    ChrBaseRegion specificRegion = specificRegions.Regions.get(0);
-
                     int regionCount = (int)ceil(specificRegion.baseLength() / (double)partitionSize);
 
                     // int intervalLength = (int)ceil(specificRegion.baseLength() / (double)threads);
@@ -64,6 +74,9 @@ public class PartitionTask
             {
                 for(ChrBaseRegion region : specificRegions.Regions)
                 {
+                    if(partitionDictionary != null && partitionDictionary.getSequence(region.Chromosome) == null)
+                        continue;
+
                     int regionCount = (int)ceil(region.baseLength() / (double)partitionSize);
 
                     // int intervalLength = (int)ceil(specificRegion.baseLength() / (double)threads);
@@ -86,8 +99,10 @@ public class PartitionTask
                 .open(new File(bamFile));
 
         SAMFileHeader fileHeader = samReader.getFileHeader().clone();
+        List<SAMSequenceRecord> sequenceRecords = partitionDictionary != null ? partitionDictionary.getSequences()
+                : fileHeader.getSequenceDictionary().getSequences();
 
-        for(final SAMSequenceRecord sequenceRecord : fileHeader.getSequenceDictionary().getSequences())
+        for(final SAMSequenceRecord sequenceRecord : sequenceRecords)
         {
             String chromosome = sequenceRecord.getSequenceName();
 

--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/common/PartitionTask.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/common/PartitionTask.java
@@ -7,6 +7,8 @@ import static com.hartwig.hmftools.common.region.PartitionUtils.buildPartitions;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.hartwig.hmftools.bamtools.checker.CheckConfig;
@@ -99,12 +101,16 @@ public class PartitionTask
                 .open(new File(bamFile));
 
         SAMFileHeader fileHeader = samReader.getFileHeader().clone();
-        List<SAMSequenceRecord> sequenceRecords = partitionDictionary != null ? partitionDictionary.getSequences()
-                : fileHeader.getSequenceDictionary().getSequences();
+        List<SAMSequenceRecord> sequenceRecords = fileHeader.getSequenceDictionary().getSequences();
+        Set<String> partitionContigs = partitionDictionary != null ? partitionDictionary.getSequences().stream()
+                .map(SAMSequenceRecord::getSequenceName).collect(Collectors.toSet()) : null;
 
         for(final SAMSequenceRecord sequenceRecord : sequenceRecords)
         {
             String chromosome = sequenceRecord.getSequenceName();
+
+            if(partitionContigs != null && !partitionContigs.contains(chromosome))
+                continue;
 
             if(specificRegions != null && specificRegions.excludeChromosome(chromosome))
                 continue;

--- a/bam-tools/src/test/java/com/hartwig/hmftools/bamtools/checker/BamCheckerTest.java
+++ b/bam-tools/src/test/java/com/hartwig/hmftools/bamtools/checker/BamCheckerTest.java
@@ -512,8 +512,8 @@ public class BamCheckerTest
         refDictionary.addSequence(new SAMSequenceRecord(CHR_1, 1_000));
 
         SAMFileHeader inputHeader = new SAMFileHeader();
-        inputHeader.getSequenceDictionary().addSequence(new SAMSequenceRecord(CHR_1, 1_000));
         inputHeader.getSequenceDictionary().addSequence(new SAMSequenceRecord(VIRAL_CONTIG, 10_000));
+        inputHeader.getSequenceDictionary().addSequence(new SAMSequenceRecord(CHR_1, 1_000));
 
         RefGenomeCompatibility compatibility = new RefGenomeCompatibility(Set.of(CHR_1), inputHeader, refDictionary);
 
@@ -521,6 +521,9 @@ public class BamCheckerTest
         assertNotNull(inputHeader.getSequenceDictionary().getSequence(VIRAL_CONTIG));
 
         SAMRecord compatibleRead = createRecord(inputHeader, CHR_1, CHR_1, null);
+        assertEquals(1, compatibleRead.getReferenceIndex().intValue());
+        assertEquals(1, compatibleRead.getMateReferenceIndex().intValue());
+
         assertTrue(compatibility.recordIsCompatible(compatibleRead));
         assertTrue(compatibility.prepareForWrite(compatibleRead));
         assertEquals(0, compatibleRead.getReferenceIndex().intValue());

--- a/bam-tools/src/test/java/com/hartwig/hmftools/bamtools/checker/BamCheckerTest.java
+++ b/bam-tools/src/test/java/com/hartwig/hmftools/bamtools/checker/BamCheckerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static htsjdk.samtools.CigarOperator.S;
 
 import java.util.List;
+import java.util.Set;
 
 import com.hartwig.hmftools.common.bam.BamReadLite;
 import com.hartwig.hmftools.common.bam.SupplementaryReadData;
@@ -29,13 +30,17 @@ import com.hartwig.hmftools.common.test.SamRecordTestUtils;
 
 import org.junit.Test;
 
+import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
 
 public class BamCheckerTest
 {
     private static final ReadIdGenerator READ_ID_GENERATOR = new ReadIdGenerator();
     private static final String TEST_READ_BASES = "ACGTACGTACGTACGTACGT";
     private static final String TEST_CIGAR = "20M";
+    private static final String VIRAL_CONTIG = "CMV";
 
     public BamCheckerTest()
     {
@@ -498,5 +503,55 @@ public class BamCheckerTest
         assertTrue(read.getCigar().getCigarElements().get(2).getOperator() == S);
 
         assertEquals(primaryReadBases.getBytes().length, read.getReadBases().length);
+    }
+
+    @Test
+    public void testRefGenomeCompatibility()
+    {
+        SAMSequenceDictionary refDictionary = new SAMSequenceDictionary();
+        refDictionary.addSequence(new SAMSequenceRecord(CHR_1, 1_000));
+
+        SAMFileHeader inputHeader = new SAMFileHeader();
+        inputHeader.getSequenceDictionary().addSequence(new SAMSequenceRecord(CHR_1, 1_000));
+        inputHeader.getSequenceDictionary().addSequence(new SAMSequenceRecord(VIRAL_CONTIG, 10_000));
+
+        RefGenomeCompatibility compatibility = new RefGenomeCompatibility(Set.of(CHR_1), inputHeader, refDictionary);
+
+        assertEquals(1, compatibility.outputHeader().getSequenceDictionary().size());
+        assertNotNull(inputHeader.getSequenceDictionary().getSequence(VIRAL_CONTIG));
+
+        SAMRecord compatibleRead = createRecord(inputHeader, CHR_1, CHR_1, null);
+        assertTrue(compatibility.recordIsCompatible(compatibleRead));
+        assertTrue(compatibility.prepareForWrite(compatibleRead));
+        assertEquals(0, compatibleRead.getReferenceIndex().intValue());
+        assertEquals(0, compatibleRead.getMateReferenceIndex().intValue());
+        assertNull(compatibleRead.getHeader().getSequenceDictionary().getSequence(VIRAL_CONTIG));
+
+        assertFalse(compatibility.recordIsCompatible(createRecord(inputHeader, VIRAL_CONTIG, CHR_1, null)));
+        assertFalse(compatibility.recordIsCompatible(createRecord(inputHeader, CHR_1, VIRAL_CONTIG, null)));
+        assertFalse(compatibility.recordIsCompatible(
+                createRecord(inputHeader, CHR_1, CHR_1, new SupplementaryReadData(VIRAL_CONTIG, 100, SUPP_POS_STRAND, TEST_CIGAR, 60))));
+    }
+
+    private static SAMRecord createRecord(
+            final SAMFileHeader header, final String chromosome, final String mateChromosome, final SupplementaryReadData suppAlignment)
+    {
+        SAMRecord record = new SAMRecord(header);
+        record.setReadName(READ_ID_GENERATOR.nextId());
+        record.setReadBases(TEST_READ_BASES.getBytes());
+        record.setBaseQualities(buildBaseQuals(TEST_READ_BASES.length(), 30));
+        record.setReferenceName(chromosome);
+        record.setAlignmentStart(100);
+        record.setCigarString(TEST_CIGAR);
+        record.setMappingQuality(60);
+        record.setReadPairedFlag(true);
+        record.setFirstOfPairFlag(true);
+        record.setMateReferenceName(mateChromosome);
+        record.setMateAlignmentStart(200);
+
+        if(suppAlignment != null)
+            record.setAttribute(SUPPLEMENTARY_ATTRIBUTE, suppAlignment.asSamTag());
+
+        return record;
     }
 }


### PR DESCRIPTION
Bamchecker uses the provided reference enough to read/process the BAM and repair pipeline-relevant issues, but it does not normalize the BAM to that reference’s sequence dictionary. It preserves the original BAM header contigs and can preserve reads aligned to contigs that are absent from the supplied HMF FASTA.
Most of the normal pipeline tolerates that because it mostly queries/works on the human contigs it cares about. So the BAM can be “good enough” for OA/pipeline processing even if its header still says “this BAM also contains CMV/HBV/HCV/HPV/etc.”
CRAM conversion is stricter. When samtools writes CRAM with -T Homo_sapiens_assembly38.alt.masked.fasta, it needs the reference sequence for every contig it is asked to encode in the CRAM header/records. If the BAM says https://github.com/sq SN:CMV or contains reads on HCV-1, but the FASTA has no CMV or HCV-1, samtools cannot build a normal externally referenced CRAM.

Note that I'm not completely sure whether this approach is the right one. I'm also not sure whether the implementation makes sense, because I'm not too familiar with bam-tools.