### PR TITLE
Fix for SBX YC tag parsing when encountering empty duplex region

### DIFF
--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/sequencing/SbxBamUtils.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/sequencing/SbxBamUtils.java
@@ -77,7 +77,7 @@ public class SbxBamUtils
 
         if(!ycTagStr.startsWith(SBX_YC_TAG_DELIM_LIT))
         {
-            String[] ycTagComponents = ycTagStr.split(SBX_YC_TAG_DELIM);
+            String[] ycTagComponents = ycTagStr.split(SBX_YC_TAG_DELIM, -1);
 
             if(ycTagComponents.length < 2)
                 return null;

--- a/hmf-common/src/test/java/com/hartwig/hmftools/common/sequencing/SbxBamUtilsTest.java
+++ b/hmf-common/src/test/java/com/hartwig/hmftools/common/sequencing/SbxBamUtilsTest.java
@@ -16,18 +16,18 @@ public class SbxBamUtilsTest
     public void
     testGetDuplexIndelsNoDuplexIndels()
     {
-        String ycTagStr = "0+100+0";
+        String ycTagStr = "+100+"; // no leading simplex count or trailing tail, both meaning zero
         List<Integer> duplexIndelIndices = getDuplexIndelIndices(ycTagStr);
 
         assertTrue(duplexIndelIndices.isEmpty());
 
-        ycTagStr = "10+100I100+0";
+        ycTagStr = "10+100I100+"; // no trailing tail, meaning zero
         duplexIndelIndices = getDuplexIndelIndices(ycTagStr);
 
         assertEquals(1, duplexIndelIndices.size());
         assertTrue(duplexIndelIndices.contains(110));
 
-        ycTagStr = "+100I100+0"; // no leading simplex count, meaning zero
+        ycTagStr = "+100I100+"; // no leading simplex count or trailing tail, both meaning zero
         duplexIndelIndices = getDuplexIndelIndices(ycTagStr);
 
         assertEquals(1, duplexIndelIndices.size());
@@ -41,6 +41,12 @@ public class SbxBamUtilsTest
         assertTrue(duplexIndelIndices.contains(41));
 
         ycTagStr = "390++"; // empty duplex region and omitted tail, not invalid
+
+        duplexIndelIndices = getDuplexIndelIndices(ycTagStr);
+
+        assertTrue(duplexIndelIndices.isEmpty());
+
+        ycTagStr = "++"; // no leading simplex count, empty duplex region, and omitted tail
 
         duplexIndelIndices = getDuplexIndelIndices(ycTagStr);
 

--- a/hmf-common/src/test/java/com/hartwig/hmftools/common/sequencing/SbxBamUtilsTest.java
+++ b/hmf-common/src/test/java/com/hartwig/hmftools/common/sequencing/SbxBamUtilsTest.java
@@ -39,5 +39,11 @@ public class SbxBamUtilsTest
 
         assertEquals(1, duplexIndelIndices.size());
         assertTrue(duplexIndelIndices.contains(41));
+
+        ycTagStr = "390++"; // empty duplex region and omitted tail, not invalid
+
+        duplexIndelIndices = getDuplexIndelIndices(ycTagStr);
+
+        assertTrue(duplexIndelIndices.isEmpty());
     }
 }


### PR DESCRIPTION
Fixes a crash in `getDuplexIndelIndices` when the YC tag's duplex segment is empty (e.g. a fully-simplex read with no duplex coverage). `String`.split() without a limit silently drops trailing empty tokens, so "390+".split("\+") returns ["390"] instead of ["390", ""], failing the length check and returning null, which is now fatal. 

**Fix**: pass -1 as the limit to preserve the empty trailing token.
This tag shape is valid per the SBX-D YC tag spec, so 390++ should parse successfully rather than crash.

**Tested**: patched jar run against a real SBX CRAM containing this exact case and REDUX completes cleanly (379,999 reads processed, no invalid SBX ycTag error), vs. the unpatched jar which failed with invalid SBX ycTag(390++).