### PR TITLE
Bam-tools: flag counts unmapped reads QC fail (WAMS-40)

### DIFF
--- a/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/BamMetrics.java
+++ b/bam-tools/src/main/java/com/hartwig/hmftools/bamtools/metrics/BamMetrics.java
@@ -4,6 +4,7 @@ import static java.lang.Math.min;
 
 import static com.hartwig.hmftools.bamtools.common.CommonUtils.APP_NAME;
 import static com.hartwig.hmftools.bamtools.common.CommonUtils.BT_LOGGER;
+import static com.hartwig.hmftools.common.bam.SamRecordUtils.CONSENSUS_READ_ATTRIBUTE;
 import static com.hartwig.hmftools.common.region.PartitionUtils.partitionChromosome;
 import static com.hartwig.hmftools.common.perf.PerformanceCounter.runTimeMinsStr;
 import static com.hartwig.hmftools.common.perf.TaskExecutor.runThreadTasks;
@@ -137,11 +138,11 @@ public class BamMetrics
 
             SAMRecordIterator iterator = samReader.queryUnmapped();
 
+            boolean expectDuplicates = mConfig.expectDuplicates();
             while(iterator.hasNext())
             {
                 SAMRecord record = iterator.next();
-                boolean passesQC = record.getReadFailsVendorQualityCheckFlag();
-                combinedStats.flagStats().increment(FlagStatType.TOTAL, passesQC);
+                combinedStats.flagStats().processRead(record, record.hasAttribute(CONSENSUS_READ_ATTRIBUTE), expectDuplicates);
             }
         }
 


### PR DESCRIPTION
When determining the flag counts, BamMetrics is currently treating all fully unmapped read pairs as QC Fail. For Roche and Ultima data this means all unmapped reads are counted as QC Fail.

As a consequence, the mapped percentage and primary mapped percentage are somewhat overestimated for Illumina, and forced to be 100% for Roche and Ultima.