### PR TITLE
Redux: skip invalid reads without truncating regions (AUS418)

### DIFF
--- a/redux/src/main/java/com/hartwig/hmftools/redux/BamReader.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/BamReader.java
@@ -15,11 +15,14 @@ import com.hartwig.hmftools.common.genome.refgenome.RefGenomeVersion;
 import com.hartwig.hmftools.common.region.ChrBaseRegion;
 import com.hartwig.hmftools.common.bam.BamSlicer;
 
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.QueryInterval;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
 
 public class BamReader
 {
@@ -122,6 +125,27 @@ public class BamReader
         mActiveBamReaders.add(index, bamReader);
     }
 
+    // reads htsjdk cannot BAM-encode: a zero-length CIGAR element or a SEQ length that disagrees with the CIGAR
+    static boolean isMalformed(final SAMRecord record)
+    {
+        if(record.getReadUnmappedFlag())
+            return false;
+
+        Cigar cigar = record.getCigar();
+
+        if(cigar.isEmpty())
+            return false;
+
+        for(CigarElement element : cigar.getCigarElements())
+        {
+            if(element.getLength() == 0)
+                return true;
+        }
+
+        byte[] bases = record.getReadBases();
+        return bases != null && bases.length > 0 && bases.length != cigar.getReadLength();
+    }
+
     private class BamFileReader
     {
         private final SamReader mSamReader;
@@ -134,7 +158,9 @@ public class BamReader
         {
             File file = new File(bamFile);
             mFilename = file.getName();
-            mSamReader = SamReaderFactory.makeDefault().referenceSequence(new File(mRefGenomeFile)).open(file);
+            mSamReader = SamReaderFactory.makeDefault()
+                    .validationStringency(ValidationStringency.SILENT)
+                    .referenceSequence(new File(mRefGenomeFile)).open(file);
 
             mSamIterator = null;
             mCurrentRecord = null;
@@ -161,7 +187,7 @@ public class BamReader
             }
             catch(Exception e)
             {
-                mCurrentRecord = null;
+                handleReadError(region.toString(), e);
             }
         }
 
@@ -169,21 +195,40 @@ public class BamReader
         {
             try
             {
-                if(mSamIterator.hasNext())
+                while(mSamIterator.hasNext())
                 {
-                    mCurrentRecord = mSamIterator.next();
+                    SAMRecord record = mSamIterator.next();
+
+                    if(isMalformed(record))
+                    {
+                        logMalformed(record);
+                        continue;
+                    }
+
+                    mCurrentRecord = record;
+                    return;
                 }
-                else
-                {
-                    mCurrentRecord = null;
-                    mSamIterator.close();
-                }
+
+                mCurrentRecord = null;
+                mSamIterator.close();
             }
             catch(Exception e)
             {
-                mCurrentRecord = null;
-                mSamIterator = null;
+                handleReadError("position " + currentPosition(), e);
             }
+        }
+
+        private void logMalformed(final SAMRecord record)
+        {
+            RD_LOGGER.warn("BAM({}) skipping malformed read({}) cigar({}) seqLength({})",
+                    mFilename, record.getReadName(), record.getCigarString(), record.getReadLength());
+        }
+
+        private void handleReadError(final String context, final Exception e)
+        {
+            mCurrentRecord = null;
+            mSamIterator = null;
+            RD_LOGGER.warn("BAM({}) skipping unreadable read at {}: {}", mFilename, context, e.toString());
         }
 
         public String filename() { return mFilename; }

--- a/redux/src/test/java/com/hartwig/hmftools/redux/BamReaderTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/BamReaderTest.java
@@ -1,0 +1,68 @@
+package com.hartwig.hmftools.redux;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+public class BamReaderTest
+{
+    private static SAMRecord mappedRead(final Cigar cigar, final int seqLength)
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadName("read1");
+        record.setReadUnmappedFlag(false);
+        record.setCigar(cigar);
+
+        byte[] bases = new byte[seqLength];
+        Arrays.fill(bases, (byte) 'A');
+        record.setReadBases(bases);
+        return record;
+    }
+
+    private static Cigar cigar(final CigarElement... elements)
+    {
+        return new Cigar(Arrays.asList(elements));
+    }
+
+    @Test
+    public void testValidReadNotMalformed()
+    {
+        assertFalse(BamReader.isMalformed(mappedRead(cigar(new CigarElement(10, CigarOperator.M)), 10)));
+    }
+
+    @Test
+    public void testSeqShorterThanCigarIsMalformed()
+    {
+        assertTrue(BamReader.isMalformed(mappedRead(cigar(new CigarElement(10, CigarOperator.M)), 5)));
+    }
+
+    @Test
+    public void testZeroLengthCigarElementIsMalformed()
+    {
+        assertTrue(BamReader.isMalformed(mappedRead(
+                cigar(new CigarElement(0, CigarOperator.M), new CigarElement(10, CigarOperator.M)), 10)));
+    }
+
+    @Test
+    public void testEmptyCigarNotMalformed()
+    {
+        assertFalse(BamReader.isMalformed(mappedRead(new Cigar(), 10)));
+    }
+
+    @Test
+    public void testUnmappedReadNotMalformed()
+    {
+        SAMRecord record = new SAMRecord(new SAMFileHeader());
+        record.setReadUnmappedFlag(true);
+        assertFalse(BamReader.isMalformed(record));
+    }
+}


### PR DESCRIPTION
Stops a single upstream-invalid read from silently truncating a REDUX region or aborting the run.

1. SILENT stringency - htsjdk returns odd records instead of throwing.
2. Skip and log malformed reads (zero-length CIGAR element or SEQ/CIGAR length mismatch), which otherwise abort BAM encode.
3. Log and continue on a read error rather than dropping the rest of the region.