### PR TITLE
PanelBuilder: support per-chromosome copy number backbone resolution (AUS-486)

### DIFF
--- a/panel-builder/README.md
+++ b/panel-builder/README.md
@@ -39,6 +39,7 @@ Resource files specific to PanelBuilder are [available here](https://console.clo
 | genes_rna             | Path                         | (none)                      | Path to TSV file containing desired RNA gene features. If not specified, RNA gene probes are not produced.                               |
 | cn_backbone           | Flag                         | (none)                      | If specified, include copy number backbone probes in the panel.                                                                          |
 | cn_backbone_res_kb    | Integer                      | 1000                        | Approximate spacing between copy number backbone probes, in kb.                                                                          |
+| cn_backbone_res_kb_chromosomes | Comma-separated list of `chr:kb` | (none)          | Per-chromosome overrides of the copy number backbone spacing, e.g. `7:500,Y:2000`. Chromosomes not listed use `cn_backbone_res_kb`.      |
 | het_sites             | Path                         | (none)                      | Path to heterozygous SNP sites TSV file for copy number backbone. May be GZIP'd.                                                         |
 | cdr3                  | Flag                         | (none)                      | If specified, include CDR3 regions in the panel.                                                                                         |
 | sample                | String                       | (none)                      | ID of sample for sample variant probes. If not specified, sample variant probes are not produced.                                        |
@@ -191,6 +192,9 @@ The methodology for the Y chromosome is similar, except:
 - QS criteria: `QS=1`.
 
 The strict QS and GC criteria aim to eliminate bias from amplification and hybridisation efficiency, yielding more accurate copy number determination.
+
+The partition spacing defaults to `cn_backbone_res_kb` for all chromosomes. It can be overridden per chromosome with `cn_backbone_res_kb_chromosomes` (minimum 1kb).
+Note that non-uniform probe density across the genome may bias downstream copy number and purity estimation, which assume roughly even genome-wide sampling.
 
 ### CDR3 Regions
 

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/CnBackboneResolution.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/CnBackboneResolution.java
@@ -23,7 +23,7 @@ public record CnBackboneResolution(
         return overrides.getOrDefault(chromosome, defaultResolution);
     }
 
-    // defaultKb: global spacing in kb. overridesStr: comma-separated chr:kb pairs, or null for none.
+    // Overrides are comma-separated chr:kb pairs, or null/blank for none.
     public static CnBackboneResolution parse(int defaultKb, @Nullable final String overridesStr)
     {
         Map<HumanChromosome, Integer> overrides = (overridesStr == null || overridesStr.isBlank())

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/CnBackboneResolution.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/CnBackboneResolution.java
@@ -1,0 +1,83 @@
+package com.hartwig.hmftools.panelbuilder;
+
+import static java.lang.String.format;
+
+import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.CN_BACKBONE_RESOLUTION_MIN;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.hartwig.hmftools.common.genome.chromosome.HumanChromosome;
+
+import org.jetbrains.annotations.Nullable;
+
+// Copy number backbone partition spacing in bases, with optional per-chromosome overrides of the default.
+public record CnBackboneResolution(
+        int defaultResolution,
+        Map<HumanChromosome, Integer> overrides
+)
+{
+    public int forChromosome(final HumanChromosome chromosome)
+    {
+        return overrides.getOrDefault(chromosome, defaultResolution);
+    }
+
+    // defaultKb: global spacing in kb. overridesStr: comma-separated chr:kb pairs, or null for none.
+    public static CnBackboneResolution parse(int defaultKb, @Nullable final String overridesStr)
+    {
+        Map<HumanChromosome, Integer> overrides = (overridesStr == null || overridesStr.isBlank())
+                ? Map.of()
+                : Arrays.stream(overridesStr.split(","))
+                        .map(CnBackboneResolution::parseOverride)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, CnBackboneResolution::rejectDuplicate));
+        return new CnBackboneResolution(kbToBases(defaultKb), overrides);
+    }
+
+    private static Map.Entry<HumanChromosome, Integer> parseOverride(final String item)
+    {
+        String[] parts = item.split(":");
+        if(parts.length != 2)
+        {
+            throw new UserInputError("Malformed copy number backbone resolution override: " + item);
+        }
+        return Map.entry(parseChromosome(parts[0].trim()), kbToBases(parseKb(parts[1].trim())));
+    }
+
+    private static HumanChromosome parseChromosome(final String chromosome)
+    {
+        if(!HumanChromosome.contains(chromosome))
+        {
+            throw new UserInputError("Invalid chromosome in copy number backbone resolution override: " + chromosome);
+        }
+        return HumanChromosome.fromString(chromosome);
+    }
+
+    private static int parseKb(final String kb)
+    {
+        try
+        {
+            return Integer.parseInt(kb);
+        }
+        catch(NumberFormatException e)
+        {
+            throw new UserInputError("Invalid resolution in copy number backbone resolution override: " + kb);
+        }
+    }
+
+    private static int kbToBases(int kb)
+    {
+        int bases = kb * 1000;
+        if(bases < CN_BACKBONE_RESOLUTION_MIN)
+        {
+            throw new UserInputError(format("Copy number backbone resolution too small: %db (minimum %db)",
+                    bases, CN_BACKBONE_RESOLUTION_MIN));
+        }
+        return bases;
+    }
+
+    private static int rejectDuplicate(int a, int b)
+    {
+        throw new UserInputError("Duplicate chromosome in copy number backbone resolution override");
+    }
+}

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/CopyNumberBackbone.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/CopyNumberBackbone.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.Logger;
 public class CopyNumberBackbone
 {
     private final String mHetSitesFile;
-    private final int mResolution;
+    private final CnBackboneResolution mResolution;
     private final RefGenomeVersion mRefGenomeVersion;
     private final ProbeGenerator mProbeGenerator;
     private final PanelData mPanelData;
@@ -61,7 +61,7 @@ public class CopyNumberBackbone
 
     private static final Logger LOGGER = LogManager.getLogger(CopyNumberBackbone.class);
 
-    public CopyNumberBackbone(final String hetSitesFile, int resolution, final RefGenomeVersion refGenomeVersion,
+    public CopyNumberBackbone(final String hetSitesFile, final CnBackboneResolution resolution, final RefGenomeVersion refGenomeVersion,
             final ProbeGenerator probeGenerator, PanelData panelData)
     {
         mHetSitesFile = hetSitesFile;
@@ -128,17 +128,14 @@ public class CopyNumberBackbone
 
     private Map<String, List<Partition>> createPartitions()
     {
-        LOGGER.debug("Creating copy number backbone partitions with resolution: {}b", mResolution);
-        if(mResolution < 1000)
-        {
-            throw new IllegalArgumentException("Copy number backbone resolution too small");
-        }
-
         RefGenomeCoordinates refGenomeCoordinates = refGenomeCoordinates(mRefGenomeVersion);
 
         return Arrays.stream(HumanChromosome.values()).map(chromosome ->
         {
             // Partitions spaced across the chromosome, avoiding the centromeres.
+
+            int resolution = mResolution.forChromosome(chromosome);
+            LOGGER.debug("Creating {} copy number backbone partitions with resolution: {}b", chromosome, resolution);
 
             String chrStr = mRefGenomeVersion.versionedChromosome(chromosome);
             int centromere = refGenomeCoordinates.centromeres().get(chromosome);
@@ -146,7 +143,7 @@ public class CopyNumberBackbone
             int centromereMax = centromere + CN_BACKBONE_CENTROMERE_MARGIN;
             LOGGER.debug("Excluded centromere region {}:{}-{}", chromosome, centromereMin, centromereMax);
 
-            List<Partition> chrPartitions = partitionChromosome(chrStr, mRefGenomeVersion, mResolution).stream()
+            List<Partition> chrPartitions = partitionChromosome(chrStr, mRefGenomeVersion, resolution).stream()
                     .filter(region -> !region.overlaps(chrStr, centromereMin, centromereMax))
                     .map(Partition::new)
                     .toList();

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/PanelBuilderConfig.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/PanelBuilderConfig.java
@@ -39,7 +39,7 @@ public record PanelBuilderConfig(
         @Nullable String rnaGenesFile,
         boolean includeCnBackbone,
         @Nullable String hetSitesFile,
-        int cnBackboneResolution,
+        CnBackboneResolution cnBackboneResolution,
         boolean includeCdr3,
         List<String> customRegionsFiles,
         @Nullable String customSmallVariantsFile,
@@ -59,6 +59,9 @@ public record PanelBuilderConfig(
     private static final String DESC_HET_SITES_FILE = "Heterozygous SNP sites TSV file";
     private static final String CFG_CN_BACKBONE_RESOLUTION = "cn_backbone_res_kb";
     private static final String DESC_CN_BACKBONE_RESOLUTION = "Approximate spacing between copy number backbone probes, in kb";
+    private static final String CFG_CN_BACKBONE_RESOLUTION_CHROMOSOMES = "cn_backbone_res_kb_chromosomes";
+    private static final String DESC_CN_BACKBONE_RESOLUTION_CHROMOSOMES =
+            "Per-chromosome copy number backbone spacing overrides, as comma-separated chr:kb pairs";
     private static final String CFG_TARGET_GENES_FILE = "genes";
     private static final String DESC_TARGET_GENES_FILE = "Gene options and transcript TSV file";
     private static final String CFG_RNA_GENES_FILE = "genes_rna";
@@ -90,7 +93,9 @@ public record PanelBuilderConfig(
                 configBuilder.getValue(CFG_RNA_GENES_FILE),
                 configBuilder.hasFlag(CFG_INCLUDE_CN_BACKBONE),
                 configBuilder.getValue(CFG_HET_SITES_FILE),
-                configBuilder.getInteger(CFG_CN_BACKBONE_RESOLUTION) * 1000,
+                CnBackboneResolution.parse(
+                        configBuilder.getInteger(CFG_CN_BACKBONE_RESOLUTION),
+                        configBuilder.getValue(CFG_CN_BACKBONE_RESOLUTION_CHROMOSOMES)),
                 configBuilder.hasFlag(CFG_INCLUDE_CDR3),
                 customRegionsFiles,
                 configBuilder.getValue(CFG_CUSTOM_SMALL_VARIANTS_FILE),
@@ -114,6 +119,7 @@ public record PanelBuilderConfig(
         configBuilder.addFlag(CFG_INCLUDE_CN_BACKBONE, DESC_INCLUDE_CN_BACKBONE);
         configBuilder.addPath(CFG_HET_SITES_FILE, false, DESC_HET_SITES_FILE);
         configBuilder.addInteger(CFG_CN_BACKBONE_RESOLUTION, DESC_CN_BACKBONE_RESOLUTION, CN_BACKBONE_RESOLUTION_KB_DEFAULT);
+        configBuilder.addConfigItem(CFG_CN_BACKBONE_RESOLUTION_CHROMOSOMES, false, DESC_CN_BACKBONE_RESOLUTION_CHROMOSOMES);
         configBuilder.addPath(CFG_TARGET_GENES_FILE, false, DESC_TARGET_GENES_FILE);
         configBuilder.addPath(CFG_RNA_GENES_FILE, false, DESC_RNA_GENES_FILE);
         configBuilder.addFlag(CFG_INCLUDE_CDR3, DESC_INCLUDE_CDR3);

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/PanelBuilderConstants.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/PanelBuilderConstants.java
@@ -56,6 +56,8 @@ public class PanelBuilderConstants
 
     // Copy number backbone constants.
     public static final int CN_BACKBONE_RESOLUTION_KB_DEFAULT = 1_000;
+    // Smallest allowed partition spacing. Below this a partition can't fit a probe with edge margin.
+    public static final int CN_BACKBONE_RESOLUTION_MIN = 1_000;
     // Region excluded, per side of the centromere.
     public static final int CN_BACKBONE_CENTROMERE_MARGIN = 3_000_000;
     // Aiming to pick heterozygous sites which are common in the population.

--- a/panel-builder/src/test/java/com/hartwig/hmftools/panelbuilder/CnBackboneResolutionTest.java
+++ b/panel-builder/src/test/java/com/hartwig/hmftools/panelbuilder/CnBackboneResolutionTest.java
@@ -1,0 +1,75 @@
+package com.hartwig.hmftools.panelbuilder;
+
+import static com.hartwig.hmftools.common.genome.chromosome.HumanChromosome._7;
+import static com.hartwig.hmftools.common.genome.chromosome.HumanChromosome._Y;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.hartwig.hmftools.common.genome.chromosome.HumanChromosome;
+
+import org.junit.Test;
+
+public class CnBackboneResolutionTest
+{
+    @Test
+    public void testNoOverrides()
+    {
+        CnBackboneResolution resolution = CnBackboneResolution.parse(1000, null);
+        assertEquals(1_000_000, resolution.forChromosome(_7));
+        assertEquals(1_000_000, resolution.forChromosome(_Y));
+    }
+
+    // Overridden chromosomes use their own spacing; others fall through to the default.
+    @Test
+    public void testOverrides()
+    {
+        CnBackboneResolution resolution = CnBackboneResolution.parse(1000, "7:500,Y:2000");
+        assertEquals(500_000, resolution.forChromosome(_7));
+        assertEquals(2_000_000, resolution.forChromosome(_Y));
+        assertEquals(1_000_000, resolution.forChromosome(HumanChromosome._1));
+    }
+
+    @Test
+    public void testChrPrefixAccepted()
+    {
+        CnBackboneResolution resolution = CnBackboneResolution.parse(1000, "chr7:500");
+        assertEquals(500_000, resolution.forChromosome(_7));
+    }
+
+    @Test
+    public void testDefaultBelowMinimumRejected()
+    {
+        assertThrows(UserInputError.class, () -> CnBackboneResolution.parse(0, null));
+    }
+
+    @Test
+    public void testOverrideBelowMinimumRejected()
+    {
+        assertThrows(UserInputError.class, () -> CnBackboneResolution.parse(1000, "7:0"));
+    }
+
+    @Test
+    public void testUnknownChromosomeRejected()
+    {
+        assertThrows(UserInputError.class, () -> CnBackboneResolution.parse(1000, "25:500"));
+    }
+
+    @Test
+    public void testDuplicateChromosomeRejected()
+    {
+        assertThrows(UserInputError.class, () -> CnBackboneResolution.parse(1000, "7:500,7:600"));
+    }
+
+    @Test
+    public void testMalformedPairRejected()
+    {
+        assertThrows(UserInputError.class, () -> CnBackboneResolution.parse(1000, "7-500"));
+    }
+
+    @Test
+    public void testNonNumericResolutionRejected()
+    {
+        assertThrows(UserInputError.class, () -> CnBackboneResolution.parse(1000, "7:abc"));
+    }
+}


### PR DESCRIPTION
Adds the ability to set different copy number backbone probe spacing per chromosome.

- New optional argument `cn_backbone_res_kb_chromosomes`: comma-separated `chr:kb` pairs (e.g. `7:500,Y:2000`).
- Chromosomes not listed use the existing `cn_backbone_res_kb` default.
- Minimum spacing of 1kb enforced; invalid chromosomes, malformed pairs, and duplicates are rejected with a clear error.
- README notes that non-uniform probe density may bias downstream copy number and purity estimation.

A/B validation on the fake dataset (default vs overrides on chr8 and chr18) confirmed all probes are identical except the copy number backbone probes on the overridden chromosomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)