### PR TITLE
Redux: add a distance threshold for reverse strand duplicates (AUS418)

### DIFF
--- a/redux/src/main/java/com/hartwig/hmftools/redux/duplicate/ReadCache.java
+++ b/redux/src/main/java/com/hartwig/hmftools/redux/duplicate/ReadCache.java
@@ -55,6 +55,7 @@ public class ReadCache
     public static final int DEFAULT_POP_DISTANCE_CHECK = 100; // how often in base terms to check for popping read groups
     public static final int DEFAULT_LOG_READ_COUNT_THRESHOLD = 100000; // based on observed cache sizes for deep panels
     public static final int DEFAULT_DYNAMIC_READ_COUNT_THRESHOLD = 100_000; // level at which steps are taken to reduce the cache size
+    public static final int MAX_DISTANCE_FOR_REVERSE_STRAND_DUPLICATES = 1000; // a reverse key can sit far past its own reads
 
     public ReadCache(
             int groupSize, int maxSoftClipLength, boolean useFragmentOrientation, final DuplicatesConfig duplicatesConfig,
@@ -147,6 +148,7 @@ public class ReadCache
         //  - if the fragment coords lower position <= max soft-clip length from current read start position
         // 2. Uses the upper read position (ie unclipped read end position)
         //  - if the fragment coords upper position < current read start position
+        //  - and if its reads start more than the max reverse-strand duplicate distance from the current read start position
         // 3. otherwise for a new chromosome or if evicting all fragments, take them all
         //
         // then remove any read groups which are then empty
@@ -172,9 +174,6 @@ public class ReadCache
         {
             ReadPositionGroup group = mPositionGroups.get(groupIndex);
 
-            if(group.Chromosome.equals(mCurrentChromosome) && mCurrentReadMinPosition < group.PositionStart)
-                break;
-
             boolean takeAllFragments = !group.Chromosome.equals(mCurrentChromosome) || group.PositionEnd < popFragCoordLowerPosition;
 
             Set<FragmentCoords> processedCoords = takeAllFragments ? null : Sets.newHashSet();
@@ -182,6 +181,8 @@ public class ReadCache
             for(Map.Entry<FragmentCoords,List<SAMRecord>> entry : group.FragCoordsMap.entrySet())
             {
                 FragmentCoords fragCoords = entry.getKey();
+
+                List<SAMRecord> reads = entry.getValue();
 
                 if(!takeAllFragments && group.Chromosome.equals(mCurrentChromosome))
                 {
@@ -194,15 +195,16 @@ public class ReadCache
                     }
                     else
                     {
-                        if(readPosition > popFragCoordUpperPosition)
+                        SAMRecord lastRead = reads.get(reads.size() - 1);
+
+                        if(readPosition > popFragCoordUpperPosition
+                        && lastRead.getAlignmentStart() + MAX_DISTANCE_FOR_REVERSE_STRAND_DUPLICATES > mCurrentReadMinPosition)
                             continue;
                     }
                 }
 
                 if(!takeAllFragments)
                     processedCoords.add(fragCoords);
-
-                List<SAMRecord> reads = entry.getValue();
 
                 if(reads.size() > 1)
                 {

--- a/redux/src/test/java/com/hartwig/hmftools/redux/ReadCacheTest.java
+++ b/redux/src/test/java/com/hartwig/hmftools/redux/ReadCacheTest.java
@@ -1,5 +1,6 @@
 package com.hartwig.hmftools.redux;
 
+import static com.hartwig.hmftools.common.bam.SamRecordUtils.getFivePrimeUnclippedPosition;
 import static com.hartwig.hmftools.common.bam.SupplementaryReadData.SUPP_POS_STRAND;
 import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_1;
 import static com.hartwig.hmftools.common.test.GeneTestUtils.CHR_2;
@@ -192,6 +193,84 @@ public class ReadCacheTest
     }
 
     @Test
+    public void testReverseSplicedReadWithinThresholdIsStillMarkedDuplicate()
+    {
+        ReadCache readCache = new ReadCache(ReadCache.DEFAULT_GROUP_SIZE, ReadCache.DEFAULT_MAX_SOFT_CLIP, false);
+
+        SAMRecord splicedRead = createSplicedRecord(100, "50M2000N50M");
+        SAMRecord splicedDuplicate = createSplicedRecord(600, "50M1500N50M");
+
+        assertEquals(FragmentCoords.fromRead(splicedRead, false).Key, FragmentCoords.fromRead(splicedDuplicate, false).Key);
+
+        readCache.processRead(splicedRead);
+        readCache.processRead(splicedDuplicate);
+
+        FragmentCoordReads fragCoordReads = readCache.popReads();
+        assertNull(fragCoordReads);
+
+        processUnsplicedDuplicates(readCache);
+
+        fragCoordReads = readCache.popReads();
+        assertNotNull(fragCoordReads);
+
+        assertEquals(1, fragCoordReads.DuplicateGroups.size());
+        assertEquals(0, fragCoordReads.SingleReads.size());
+
+        // this read takes the read position past the threshold from the second spliced read, releasing both
+        SAMRecord read3 = createRecord(CHR_1, 1700);
+
+        readCache.processRead(read3);
+
+        fragCoordReads = readCache.popReads();
+        assertNotNull(fragCoordReads);
+
+        assertEquals(2, fragCoordReads.DuplicateGroups.size());
+        assertEquals(0, fragCoordReads.SingleReads.size());
+    }
+
+    @Test
+    public void testReverseSplicedReadBeyondThresholdMissesDuplicate()
+    {
+        ReadCache readCache = new ReadCache(ReadCache.DEFAULT_GROUP_SIZE, ReadCache.DEFAULT_MAX_SOFT_CLIP, false);
+
+        SAMRecord splicedRead = createSplicedRecord(100, "50M2000N50M");
+        SAMRecord splicedDuplicate = createSplicedRecord(1200, "50M900N50M");
+
+        assertEquals(FragmentCoords.fromRead(splicedRead, false).Key, FragmentCoords.fromRead(splicedDuplicate, false).Key);
+
+        readCache.processRead(splicedRead);
+
+        FragmentCoordReads fragCoordReads = readCache.popReads();
+        assertNull(fragCoordReads);
+
+        processUnsplicedDuplicates(readCache);
+
+        fragCoordReads = readCache.popReads();
+        assertNotNull(fragCoordReads);
+
+        assertEquals(1, fragCoordReads.DuplicateGroups.size());
+        assertEquals(0, fragCoordReads.SingleReads.size());
+
+        // this read takes the read position past the threshold, so the spliced read is released on its own
+        SAMRecord read3 = createRecord(CHR_1, 1100);
+
+        readCache.processRead(read3);
+
+        fragCoordReads = readCache.popReads();
+        assertNotNull(fragCoordReads);
+
+        assertEquals(1, fragCoordReads.DuplicateGroups.size());
+        assertEquals(1, fragCoordReads.SingleReads.size());
+
+        readCache.processRead(splicedDuplicate);
+
+        fragCoordReads = readCache.evictAll();
+
+        assertEquals(0, fragCoordReads.DuplicateGroups.size());
+        assertEquals(2, fragCoordReads.SingleReads.size());
+    }
+
+    @Test
     public void testReadCacheReadPositionWithinGroupBounds()
     {
         final int readLength = 143;
@@ -218,6 +297,21 @@ public class ReadCacheTest
         assertEquals(
                 Sets.newHashSet("READ_001", "READ_002"),
                 duplicateGroupReads.stream().map(SAMRecord::getReadName).collect(Collectors.toCollection(Sets::newHashSet)));
+    }
+
+    private static void processUnsplicedDuplicates(final ReadCache readCache)
+    {
+        readCache.processRead(createRecord(CHR_1, 700));
+        readCache.processRead(createRecord(CHR_1, 700));
+        readCache.processRead(createRecord(CHR_1, 900));
+        readCache.processRead(createRecord(CHR_1, 900));
+    }
+
+    private static SAMRecord createSplicedRecord(final int readStart, final String cigar)
+    {
+        return createSamRecord(
+                READ_ID_GEN.nextId(), CHR_1, readStart, "A".repeat(100), cigar,
+                CHR_1, 3000, true, false, null, false, TEST_READ_CIGAR);
     }
 
     private static SAMRecord createRecord(final String chromosome, final int readStart)


### PR DESCRIPTION
Redux ran out of memory on RNA samples with a large chrM read share.

1. Reads enter the cache in `alignmentStart` order, where `FragmentCoords` keys a reverse read on alignmentEnd + rightSoftClip, which counts any N gap. So the coord is bucketed far downstream of where its reads actually arrived.
2. `popPassedReads` stopped scanning at the first bucket ahead of the current read position. That is safe while the key sits within a read length of the alignment start, but a spliced reverse read is bucketed kilobases out, so it stays in the cache when it could be popped.
3. The scan now covers the full bucket list, and a reverse FragmentCoords is held only while its key is ahead of the current read position and its reads started within `MAX_DISTANCE_FOR_REVERSE_STRAND_DUPLICATES` (1000) bases, the furthest apart two reverse reads can start and still be marked duplicates.

Forward branch, fragment coords key and bucketing position all unchanged.