### PR TITLE
PanelBuilder: only write gene stats and sample variant info files when configured (AUS-471)

### DIFF
--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/OutputWriter.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/OutputWriter.java
@@ -1,5 +1,7 @@
 package com.hartwig.hmftools.panelbuilder;
 
+import static java.util.Objects.requireNonNull;
+
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.CANDIDATE_PROBES_FILE_NAME;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.CANDIDATE_TARGET_REGIONS_FILE_NAME;
 import static com.hartwig.hmftools.panelbuilder.PanelBuilderConstants.COVERED_REGIONS_FILE_NAME;
@@ -31,6 +33,8 @@ public class OutputWriter implements AutoCloseable
     // Null when RNA probes are not requested.
     @Nullable
     private final ProbeOutputWriter mRnaOutput;
+    // Null when sample variants are not requested.
+    @Nullable
     private final DelimFileWriter<SampleVariants.VariantInfo> mSampleVariantInfoTsvWriter;
 
     private enum SampleVariantInfoColumns
@@ -42,8 +46,8 @@ public class OutputWriter implements AutoCloseable
 
     private static final Logger LOGGER = LogManager.getLogger(OutputWriter.class);
 
-    public OutputWriter(final String outputDir, @Nullable final String outputId, boolean verboseOutput, boolean rnaOutput)
-            throws IOException
+    public OutputWriter(final String outputDir, @Nullable final String outputId, boolean verboseOutput, boolean geneStats,
+            boolean rnaOutput, boolean sampleVariants) throws IOException
     {
         Function<String, String> outputFilePath = fileName ->
         {
@@ -61,18 +65,20 @@ public class OutputWriter implements AutoCloseable
         mDnaOutput = new ProbeOutputWriter(
                 dnaFilePath, PANEL_PROBES_FILE_STEM, COVERED_TARGET_REGIONS_FILE_NAME, COVERED_REGIONS_FILE_NAME,
                 REJECTED_FEATURES_FILE_STEM, CANDIDATE_TARGET_REGIONS_FILE_NAME, CANDIDATE_PROBES_FILE_NAME, GENE_STATS_FILE_NAME,
-                verboseOutput, false);
+                geneStats, verboseOutput, false);
 
         mRnaOutput = rnaOutput
                 ? new ProbeOutputWriter(
                 rnaFilePath, PANEL_PROBES_FILE_STEM, COVERED_TARGET_REGIONS_FILE_NAME, COVERED_REGIONS_FILE_NAME,
                 REJECTED_FEATURES_FILE_STEM, CANDIDATE_TARGET_REGIONS_FILE_NAME, CANDIDATE_PROBES_FILE_NAME, GENE_STATS_FILE_NAME,
-                verboseOutput, true)
+                true, verboseOutput, true)
                 : null;
 
-        mSampleVariantInfoTsvWriter = new DelimFileWriter<>(
+        mSampleVariantInfoTsvWriter = sampleVariants
+                ? new DelimFileWriter<>(
                 outputFilePath.apply(SAMPLE_VARIANT_INFO_FILE_NAME), SampleVariantInfoColumns.values(),
-                OutputWriter::writeSampleVariantInfoRow);
+                OutputWriter::writeSampleVariantInfoRow)
+                : null;
     }
 
     public ProbeOutputWriter dnaPanelOutput()
@@ -102,7 +108,7 @@ public class OutputWriter implements AutoCloseable
 
     public void writeSampleVariantInfos(final List<SampleVariants.VariantInfo> variantInfos)
     {
-        variantInfos.forEach(mSampleVariantInfoTsvWriter::writeRow);
+        variantInfos.forEach(requireNonNull(mSampleVariantInfoTsvWriter)::writeRow);
     }
 
     private static void writeSampleVariantInfoRow(final SampleVariants.VariantInfo variantInfo, DelimFileWriter.Row row)
@@ -122,6 +128,9 @@ public class OutputWriter implements AutoCloseable
         {
             mRnaOutput.close();
         }
-        mSampleVariantInfoTsvWriter.close();
+        if(mSampleVariantInfoTsvWriter != null)
+        {
+            mSampleVariantInfoTsvWriter.close();
+        }
     }
 }

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/PanelBuilderApplication.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/PanelBuilderApplication.java
@@ -82,7 +82,8 @@ public class PanelBuilderApplication
 
         checkCreateOutputDir(mConfig.outputDir());
         mOutputWriter = new OutputWriter(
-                mConfig.outputDir(), mConfig.outputId(), mConfig.verboseOutput(), mConfig.rnaGenesFile() != null);
+                mConfig.outputDir(), mConfig.outputId(), mConfig.verboseOutput(), mConfig.genesFile() != null,
+                mConfig.rnaGenesFile() != null, mConfig.sampleVariants() != null);
 
         LOGGER.info("Generating probes");
         mPanelData = new PanelData();

--- a/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/ProbeOutputWriter.java
+++ b/panel-builder/src/main/java/com/hartwig/hmftools/panelbuilder/ProbeOutputWriter.java
@@ -43,6 +43,8 @@ public class ProbeOutputWriter implements AutoCloseable
     private final DelimFileWriter<RejectedFeature> mRejectedFeaturesTsvWriter;
     private final BufferedWriter mRejectedFeaturesBedWriter;
     private final BufferedWriter mCandidateTargetRegionsBedWriter;
+    // Null when gene features are not requested for this panel.
+    @Nullable
     private final DelimFileWriter<GeneStats> mGeneStatsTsvWriter;
     // Verbose output only; null otherwise.
     @Nullable
@@ -129,7 +131,8 @@ public class ProbeOutputWriter implements AutoCloseable
 
     public ProbeOutputWriter(final Function<String, String> outputFilePath, final String probesStem, final String coveredTargetRegionsFile,
             final String coveredRegionsFile, final String rejectedFeaturesStem, final String candidateTargetRegionsFile,
-            final String candidateProbesFile, final String geneStatsFile, boolean verboseOutput, boolean rna) throws IOException
+            final String candidateProbesFile, final String geneStatsFile, boolean geneStats, boolean verboseOutput, boolean rna)
+            throws IOException
     {
         mRna = rna;
 
@@ -149,8 +152,10 @@ public class ProbeOutputWriter implements AutoCloseable
 
         mCandidateTargetRegionsBedWriter = createBufferedWriter(outputFilePath.apply(candidateTargetRegionsFile));
 
-        mGeneStatsTsvWriter =
-                new DelimFileWriter<>(outputFilePath.apply(geneStatsFile), GeneStatsColumns.values(), ProbeOutputWriter::writeGeneStatsRow);
+        mGeneStatsTsvWriter = geneStats
+                ? new DelimFileWriter<>(
+                outputFilePath.apply(geneStatsFile), GeneStatsColumns.values(), ProbeOutputWriter::writeGeneStatsRow)
+                : null;
 
         if(verboseOutput)
         {
@@ -356,7 +361,7 @@ public class ProbeOutputWriter implements AutoCloseable
 
     public void writeGeneStats(final List<GeneStats> geneStats)
     {
-        geneStats.forEach(mGeneStatsTsvWriter::writeRow);
+        geneStats.forEach(requireNonNull(mGeneStatsTsvWriter)::writeRow);
     }
 
     private static void writeGeneStatsRow(final GeneStats stats, DelimFileWriter.Row row)
@@ -475,7 +480,10 @@ public class ProbeOutputWriter implements AutoCloseable
         mRejectedFeaturesTsvWriter.close();
         mRejectedFeaturesBedWriter.close();
         mCandidateTargetRegionsBedWriter.close();
-        mGeneStatsTsvWriter.close();
+        if(mGeneStatsTsvWriter != null)
+        {
+            mGeneStatsTsvWriter.close();
+        }
         if(mCandidateProbesTsvWriter != null)
         {
             checkFlushCandidateProbes(true);

--- a/panel-builder/src/test/java/com/hartwig/hmftools/panelbuilder/OutputWriterRnaTest.java
+++ b/panel-builder/src/test/java/com/hartwig/hmftools/panelbuilder/OutputWriterRnaTest.java
@@ -35,7 +35,7 @@ public class OutputWriterRnaTest
                 .withGcContent(0.5);
 
         Path outputDir = Files.createTempDirectory("panelbuilder-rna-output");
-        try(OutputWriter writer = new OutputWriter(outputDir.toString(), null, false, true))
+        try(OutputWriter writer = new OutputWriter(outputDir.toString(), null, false, false, true, false))
         {
             writer.rnaPanelOutput().writeProbes(List.of(probe));
         }


### PR DESCRIPTION
Previously the gene stats and sample variant info files were always written, producing empty header-only files when the corresponding feature was not requested.

- `dna_gene_stats.tsv` is now written only when gene features are requested.
- `sample_variant_info.tsv` is now written only when sample variants are requested.

This matches the behaviour already documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)