### PR TITLE
Compar: bug fixes for v1.6.0

### DIFF
--- a/compar/src/main/java/com/hartwig/hmftools/compar/driver/DriverComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/driver/DriverComparer.java
@@ -87,7 +87,9 @@ public class DriverComparer implements ItemComparer
             }
             else
             {
-                loadData(sourceSampleId, sourceData.Files, sourceData.Type);
+                String sourceReferenceId = mConfig.sourceReferenceId(sourceData.Type, sampleId);
+                FileSources sampleFileSources = FileSources.sampleInstance(sourceData.Files, sourceSampleId, sourceReferenceId);
+                loadData(sourceSampleId, sampleFileSources, sourceData.Type);
             }
         }
 

--- a/compar/src/main/java/com/hartwig/hmftools/compar/metrics/BamMetricsComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/metrics/BamMetricsComparer.java
@@ -92,14 +92,18 @@ public class BamMetricsComparer implements ItemComparer
         final List<ComparableItem> comparableItems = Lists.newArrayList();
         try
         {
-            BamMetricSummary metrics = loadBamMetricsSummary(sampleId, fileSources.TumorBamMetrics);
+            String sourceFile = isTumor() ? fileSources.TumorBamMetrics : fileSources.GermlineBamMetrics;
+            String sourceSampleId = isTumor() ? sampleId : germlineSampleId;
+            BamMetricSummary metrics = loadBamMetricsSummary(sourceSampleId, sourceFile);
             comparableItems.add(new BamMetricsData(mCategory, metrics, mComparisonPercentages));
         }
         catch(IOException e)
         {
-            CMP_LOGGER.warn("sample({}) failed to load tumor BAM metrics data: {}", sampleId, e.toString());
+            CMP_LOGGER.warn("sample({}) failed to load {} BAM metrics data: {}", sampleId, isTumor() ? "tumor" : "germline", e.toString());
             return null;
         }
         return comparableItems;
     }
+
+    private boolean isTumor() { return mCategory == CategoryType.TUMOR_BAM_METRICS; }
 }

--- a/compar/src/main/java/com/hartwig/hmftools/compar/metrics/FlagstatComparer.java
+++ b/compar/src/main/java/com/hartwig/hmftools/compar/metrics/FlagstatComparer.java
@@ -67,17 +67,21 @@ public class FlagstatComparer implements ItemComparer
     @Override
     public List<ComparableItem> loadFromFile(final String sampleId, final String germlineSampleId, final FileSources fileSources)
     {
-        final List<ComparableItem> comparableItems = Lists.newArrayList();
+        List<ComparableItem> comparableItems = Lists.newArrayList();
         try
         {
-            BamFlagStats flagstat = BamFlagStats.read(determineFlagStatsFilePath(sampleId, fileSources.TumorFlagstat));
+            String sourceFile = isTumor() ? fileSources.TumorFlagstat : fileSources.GermlineFlagstat;
+            String sourceSampleId = isTumor() ? sampleId : germlineSampleId;
+            BamFlagStats flagstat = BamFlagStats.read(determineFlagStatsFilePath(sourceSampleId, sourceFile));
             comparableItems.add(new FlagstatData(mCategory, flagstat));
         }
         catch(IOException e)
         {
-            CMP_LOGGER.warn("sample({}) failed to load tumor flagstat data: {}", sampleId, e.toString());
+            CMP_LOGGER.warn("sample({}) failed to load {} flagstat data: {}", sampleId, isTumor() ? "tumor" : "germline", e.toString());
             return null;
         }
         return comparableItems;
     }
+
+    private boolean isTumor() { return mCategory == CategoryType.TUMOR_FLAGSTAT; }
 }

--- a/hmf-common/src/main/java/com/hartwig/hmftools/common/pipeline/PipelineToolDirectories.java
+++ b/hmf-common/src/main/java/com/hartwig/hmftools/common/pipeline/PipelineToolDirectories.java
@@ -110,7 +110,35 @@ public record PipelineToolDirectories(
             "virusinterpreter",
             "qsee");
 
-    public static final PipelineToolDirectories OA_V2_3_FORMAT = OA_V2_2_FORMAT;
+    public static final PipelineToolDirectories OA_V2_3_FORMAT = new PipelineToolDirectories(
+            "amber",
+            "chord",
+            "cider",
+            "cobalt",
+            "cuppa",
+            "esvee",
+            "bamtools/$",
+            "bamtools/$",
+            "isofox",
+            "lilac",
+            "linx/germline_annotations",
+            "linx/somatic_annotations",
+            "orange",
+            "pave",
+            "pave",
+            "peach",
+            "purple",
+            "sage/germline",
+            "sage/somatic",
+            "sigs",
+            "",
+            "teal",
+            "bamtools/*",
+            "bamtools/*",
+            "vchord",  // not yet implemented in this version
+            "virusbreakend",
+            "virusinterpreter",
+            "qsee");
 
     public static final PipelineToolDirectories OA_V3_0_FORMAT = new PipelineToolDirectories(
             "amber",


### PR DESCRIPTION
Fixes:
- Replace wildcards in paths for driver loading.
- Fix germline flagstat and Bam metrics loading tumor data.
- Fix OA v2.3 bamtools paths.