### PR TITLE
Cider: output IMGT reference unaligned bases for V and J genes (AUS-490)

### DIFF
--- a/cider/README.md
+++ b/cider/README.md
@@ -152,6 +152,7 @@ The full set of fields output are:
 | vPIdentLen, jPIdentLen                                     | The length of sequence used to determine vPIdent/jPIdent                                                                                                     |
 | vPIdentIndelBases, jPIdentIndelBases                       | Number of insertion or deletion bases in the alignment used to calculate vPIdent/jPIdent                                                                     |
 | vPIdentClipBases, jPIdentClipBases                         | Number of clipped bases on the alignment to the IMGT sequence. This indicates the number of bases which strongly diverged from the IMGT sequence.            |
+| vImgtRefUnaligned, jImgtRefUnaligned                       | Number of IMGT reference bases on the extension side that the alignment did not reach. Includes possible unassembled sequence and alignment clip bases.      |
 | SHMStatus                                                  | Somatic hypermutation status as calculated from the V gene annotation. See the section below.                                                                |
 | vAlignStart, dAlignStart, jAlignStart                      | Start of the alignment with the V, D or J gene                                                                                                               | 
 | vAlignEnd, dAlignEnd, jAlignEnd                            | End of the alignment with the V, D or J gene                                                                                                                 |
@@ -214,10 +215,11 @@ Finally, the SHM status is decided on the value of `vPIdent`:
 - Else if >= 97%, **MUTATED_BORDERLINE**
 - Else if < 97%, **MUTATED**
 
-Please note the caveats of the SHM status calculation:
+Please note the caveats of the SHM status calculation, where manual inspection is recommended:
 
-- A low value of `vPIdentLen` or high value of `vPIdentClipBases` (> 5-10b) indicates only a partial match to the IMGT sequence. Manual inspection is recommended.
-- A nonzero value of `vPIdentIndelBases` indicates indels in the sample sequence, which are not accounted for in the SHM status calculation.
+- `vPIdentLen` is low. Indicates only a partial match to the IMGT sequence.
+- `vPIdentClipBases` > 5-10b. Indicates only a partial match to the IMGT sequence.
+- `vImgtRefUnaligned` > 5-10b. Indicates possible failure to assemble the full V/J gene sequence, or a poor match to the IMGT sequence.
 - Discretion is particularly recommended when `vPIdent` is near to 97-98%, where small error could change the SHM status.
 
 The % identity calculation logic is performed similarly for the J side, for completeness.

--- a/cider/src/main/java/com/hartwig/hmftools/cider/SomaticHypermutation.kt
+++ b/cider/src/main/java/com/hartwig/hmftools/cider/SomaticHypermutation.kt
@@ -34,7 +34,10 @@ data class ShmGeneComparison(
     val imgtLength: Int,        // Length of the IMGT sequence used in comparison.
     val pctIdentity: Double,    // Range [0, 100]. Excludes indel bases (for now, at least).
     val indelBases: Int,        // Number of bases in indels in the alignment.
-    val clipBases: Int          // Number of bases in the IMGT sequence which could've been aligned but were clipped.
+    val clipBases: Int,         // Number of bases in the IMGT sequence which could've been aligned but were clipped.
+    // IMGT reference bases on the V/J extension side laying beyond the aligned region (from the IMGT reference edge to the alignment start).
+    // Includes clipBases and potential unassembled sequence.
+    val imgtRefUnaligned: Int
 )
 {
     init
@@ -44,6 +47,7 @@ data class ShmGeneComparison(
         require(pctIdentity >= 0.0 && pctIdentity <= 100.0)
         require(indelBases >= 0)
         require(clipBases >= 0)
+        require(imgtRefUnaligned >= 0)
     }
 }
 
@@ -137,6 +141,10 @@ fun compareVJRegionToImgt(
     assert(layoutIndex == layoutEnd)
     assert(imgtIndex == imgtAlignEnd)
 
+    // IMGT reference bases beyond the alignment on the extension side (start of IMGT for V, end for J).
+    val imgtRefUnaligned = max(0,
+        if (isV) imgtAlignStart - imgtSeqBounds.start else imgtSeqBounds.endInclusive + 1 - imgtAlignEnd)
+
     return if (comparedBases == 0) null
     else ShmGeneComparison(
         seqLength = lastComparedLayoutIndex - firstComparedLayoutIndex!! + 1,
@@ -147,5 +155,6 @@ fun compareVJRegionToImgt(
         indelBases = indelBases,
         clipBases = max(0,
             if (isV) min(firstAlignedLayoutIndex!! - layoutStart, imgtAlignStart - imgtSeqBounds.start)
-                    else min(layoutEnd - lastAlignedLayoutIndex, imgtSeqBounds.endInclusive + 1 - imgtAlignEnd)))
+                    else min(layoutEnd - lastAlignedLayoutIndex, imgtSeqBounds.endInclusive + 1 - imgtAlignEnd)),
+        imgtRefUnaligned = imgtRefUnaligned)
 }

--- a/cider/src/main/java/com/hartwig/hmftools/cider/VDJSequenceTsvWriter.kt
+++ b/cider/src/main/java/com/hartwig/hmftools/cider/VDJSequenceTsvWriter.kt
@@ -49,6 +49,7 @@ object VDJSequenceTsvWriter
         vPIdentLen,
         vPIdentIndelBases,
         vPIdentClipBases,
+        vImgtRefUnaligned,
         SHMStatus,
         vAlignStart,
         vAlignEnd,
@@ -62,6 +63,7 @@ object VDJSequenceTsvWriter
         jPIdentLen,
         jPIdentIndelBases,
         jPIdentClipBases,
+        jImgtRefUnaligned,
         jAlignStart,
         jAlignEnd,
         vPrimerMatches,
@@ -145,6 +147,7 @@ object VDJSequenceTsvWriter
                 Column.vPIdentLen -> csvPrinter.print(alignmentAnnotation?.vGene?.comparison?.seqLength)
                 Column.vPIdentIndelBases -> csvPrinter.print(alignmentAnnotation?.vGene?.comparison?.indelBases)
                 Column.vPIdentClipBases -> csvPrinter.print(alignmentAnnotation?.vGene?.comparison?.clipBases)
+                Column.vImgtRefUnaligned -> csvPrinter.print(alignmentAnnotation?.vGene?.comparison?.imgtRefUnaligned)
                 Column.SHMStatus -> csvPrinter.print(vdjAnnotation.somaticHypermutationStatus)
                 Column.vAlignStart -> csvPrinter.print(alignmentAnnotation?.vGene?.alignment?.queryRange?.start?.plus(alignmentOffset))
                 Column.vAlignEnd -> csvPrinter.print(alignmentAnnotation?.vGene?.alignment?.queryRange?.endInclusive?.plus(alignmentOffset + 1))
@@ -160,6 +163,7 @@ object VDJSequenceTsvWriter
                 Column.jPIdentLen -> csvPrinter.print(alignmentAnnotation?.jGene?.comparison?.seqLength)
                 Column.jPIdentIndelBases -> csvPrinter.print(alignmentAnnotation?.jGene?.comparison?.indelBases)
                 Column.jPIdentClipBases -> csvPrinter.print(alignmentAnnotation?.jGene?.comparison?.clipBases)
+                Column.jImgtRefUnaligned -> csvPrinter.print(alignmentAnnotation?.jGene?.comparison?.imgtRefUnaligned)
                 Column.jAlignStart -> csvPrinter.print(alignmentAnnotation?.jGene?.alignment?.queryRange?.start?.plus(alignmentOffset))
                 Column.jAlignEnd -> csvPrinter.print(alignmentAnnotation?.jGene?.alignment?.queryRange?.endInclusive?.plus(alignmentOffset + 1))
                 Column.vPrimerMatches -> csvPrinter.print(vdjAnnotation.vPrimerMatchCount)

--- a/cider/src/test/java/com/hartwig/hmftools/cider/SomaticHypermutationTest.kt
+++ b/cider/src/test/java/com/hartwig/hmftools/cider/SomaticHypermutationTest.kt
@@ -234,8 +234,6 @@ class SomaticHypermutationTest {
     @Test
     fun testCompareVJRegionToImgtVAssemblyShort()
     {
-        // FIXME: junk setup, make it better like the other tests
-
         //   sections:       |---V----||-anchor-||--CDR3--||-anchor-||---J----|
         //   query:               |----------------------------------------|
         //   alignment:             |----------------|

--- a/cider/src/test/java/com/hartwig/hmftools/cider/SomaticHypermutationTest.kt
+++ b/cider/src/test/java/com/hartwig/hmftools/cider/SomaticHypermutationTest.kt
@@ -56,7 +56,7 @@ class SomaticHypermutationTest {
             ImgtSequenceFile.Sequence("test", "1", imgtSeq, 5, 7),
             queryRange,
             alignment)
-        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0)
+        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0, 0)
         assertEquals(expected, actual)
     }
 
@@ -91,7 +91,7 @@ class SomaticHypermutationTest {
             ImgtSequenceFile.Sequence("test", "1", imgtSeq, 7, 5),
             queryRange,
             alignment)
-        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0)
+        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0, 0)
         assertEquals(expected, actual)
     }
 
@@ -124,7 +124,7 @@ class SomaticHypermutationTest {
             ImgtSequenceFile.Sequence("test", "1", imgtSeq, 5, 5),
             queryRange,
             alignment)
-        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0)
+        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0, 0)
         assertEquals(expected, actual)
     }
 
@@ -159,7 +159,7 @@ class SomaticHypermutationTest {
             ImgtSequenceFile.Sequence("test", "1", imgtSeq, 5, 5),
             queryRange,
             alignment)
-        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0)
+        val expected = ShmGeneComparison(15, 15, 100.0 * 13 / 15, 0, 0, 0)
         assertEquals(expected, actual)
     }
 
@@ -193,7 +193,7 @@ class SomaticHypermutationTest {
             ImgtSequenceFile.Sequence("test", "1", imgtSeq, 5, 5),
             queryRange,
             alignment)
-        val expected = ShmGeneComparison(13, 13, 100.0, 0, 2)
+        val expected = ShmGeneComparison(13, 13, 100.0, 0, 2, 2)
         assertEquals(expected, actual)
     }
 
@@ -227,7 +227,44 @@ class SomaticHypermutationTest {
             ImgtSequenceFile.Sequence("test", "1", imgtSeq, 5, 5),
             queryRange,
             alignment)
-        val expected = ShmGeneComparison(12, 12, 100.0, 0, 3)
+        val expected = ShmGeneComparison(12, 12, 100.0, 0, 3, 3)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testCompareVJRegionToImgtVAssemblyShort()
+    {
+        // FIXME: junk setup, make it better like the other tests
+
+        //   sections:       |---V----||-anchor-||--CDR3--||-anchor-||---J----|
+        //   query:               |----------------------------------------|
+        //   alignment:             |----------------|
+        val layoutSeq =     "TTTTTTTGGGAAAAAAAAAACCCCCCCCCCAAAAAAAAAATTTTTTTTTT"
+        //   IMGT             |-----------------------|
+        //   ref:        -----                         ------
+        //   alignment:             |----------------|
+        val imgtSeq =   "AAAAAGGGGGGGGGAAAAAAAAAACCCCCAAAAA"
+        //   compare:               |-----------|
+        //   clip:                --
+        //   unaligned:        ---
+
+        val anchorBoundary = 20
+        val queryRange = 5 until 47
+        val queryAlignRange = 7 until 25
+        val refAlignRange = 11 until 29
+        val alignment = Alignment(
+            layoutSeq.substring(queryRange), queryAlignRange,
+            "test", refAlignRange, Strand.FORWARD,
+            0, 25, cigarElementsFromStr("2S18M22S"),
+            imgtSeq.length)
+        val actual = compareVJRegionToImgt(
+            layoutSeq,
+            VJ.V,
+            anchorBoundary,
+            ImgtSequenceFile.Sequence("test", "1", imgtSeq, 5, 5),
+            queryRange,
+            alignment)
+        val expected = ShmGeneComparison(13, 13, 100.0, 0, 2, 6)
         assertEquals(expected, actual)
     }
 }


### PR DESCRIPTION
Adds two output columns to the CIDER VDJ TSV: `vImgtRefUnaligned` and `jImgtRefUnaligned`.

- Reports the number of IMGT reference bases on the V/J extension side that the alignment did not reach.
- Purpose: show how far short of the IMGT reference the assembly extended, distinct from clip bases which only capture divergence, not sequence that was never assembled.
- Includes the existing clip bases; subtract `vPIdentClipBases`/`jPIdentClipBases` to isolate bases missing purely due to short assembly.
- Documented as an additional caveat for SHM status interpretation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)